### PR TITLE
Removed assigning id and appending child to body (#38)

### DIFF
--- a/packages/datagateway-table/src/index.tsx
+++ b/packages/datagateway-table/src/index.tsx
@@ -30,11 +30,7 @@ if (process.env.NODE_ENV === `development`) {
 function domElementGetter(): HTMLElement {
   // Make sure there is a div for us to render into
   let el = document.getElementById(pluginName);
-  if (!el) {
-    el = document.createElement('div');
-    el.id = pluginName;
-    document.body.appendChild(el);
-  }
+  if (!el) el = document.createElement('div');
 
   return el;
 }


### PR DESCRIPTION
## Description
The datagateway-table plugin creates a div and assigns it's id and appends to the body. We remove the assigning of the id and appending to the body to remove the plugin creating the div. As a result we not see a duplicate AppBar at the bottom of the page when the datagateway-table has loaded.

## Testing instructions

- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage
- [ ] Load datagateway-table into parent app and ensure the table is correct visually

## Agile board tracking
Closes #38 