### PR TITLE
Fix npm test by separating from lerna (#82)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1256,12 +1256,6 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
-    "@types/sizzle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
-      "dev": true
-    },
     "@zkochan/cmd-shim": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
@@ -2298,14 +2292,13 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.6.1.tgz",
-      "integrity": "sha512-6n0oqENdz/oQ7EJ6IgESNb2M7Bo/70qX9jSJsAziJTC3kICfEMmJUlrAnP9bn+ut24MlXQST5nRXhUP5nRIx6A==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.1.tgz",
+      "integrity": "sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
         "@cypress/xvfb": "1.2.4",
-        "@types/sizzle": "2.3.2",
         "arch": "2.1.1",
         "bluebird": "3.5.0",
         "cachedir": "1.3.0",
@@ -2332,7 +2325,6 @@
         "request-progress": "3.0.0",
         "supports-color": "5.5.0",
         "tmp": "0.1.0",
-        "untildify": "3.0.3",
         "url": "0.11.0",
         "yauzl": "2.10.0"
       },
@@ -7498,12 +7490,6 @@
           "dev": true
         }
       }
-    },
-    "untildify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
-      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "devDependencies": {
-    "cypress": "^3.4.1",
+    "cypress": "3.4.1",
     "cypress-failed-log": "^2.5.1",
     "husky": "^3.0.2",
     "lerna": "^3.16.4",
@@ -15,7 +15,8 @@
     "tsc": "lerna run tsc",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "lerna run test --stream",
-    "test:e2e": "lerna run e2e --stream --concurrency 1",
+    "test:e2e": "cd packages/datagateway-table && npm run e2e && cd ../datagateway-download && npm run e2e && ../datagateway-search && npm run e2e",
+    "test:e2e:lerna": "lerna run e2e --stream --concurrency 1",
     "datagateway-table": "cd packages/datagateway-table && npm start"
   },
   "husky": {

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "cross-env": "^5.2.0",
-    "cypress": "^3.4.1",
+    "cypress": "3.4.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.3.5",

--- a/packages/datagateway-search/package.json
+++ b/packages/datagateway-search/package.json
@@ -97,7 +97,7 @@
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "cross-env": "^5.2.0",
-    "cypress": "^3.4.1",
+    "cypress": "3.4.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.3.5",

--- a/packages/datagateway-table/package.json
+++ b/packages/datagateway-table/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "cross-env": "^5.2.0",
-    "cypress": "^3.4.1",
+    "cypress": "3.4.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.3.5",


### PR DESCRIPTION
## Description
A temporary fix for npm test until [headless issue](https://github.com/cypress-io/cypress/issues/5475) is fixed by Cypress. As mentioned in the issue for this PR, we downgrade to Cypress 3.4.1 and separate lerna to npm run test:lerna and npm test will change directory into each repository and run them individually.

For now, if a test fails for a repository then you may not know if it has impacted any other tests in the other repository. As a result, it would be best to test out all datagateway repositories (table, download and search) locally as well.

## Testing instructions

- [ ] Review code
- [ ] Check Travis build
- [ ] Run npm test and ensure all passes

## Agile board tracking
Closes #82 
