### PR TITLE
 Fix URLSearchParams tests

### DIFF
--- a/packages/datagateway-table/src/state/actions/cart.test.tsx
+++ b/packages/datagateway-table/src/state/actions/cart.test.tsx
@@ -118,7 +118,10 @@ describe('Cart actions', () => {
       expect(actions[1]).toEqual(addToCartSuccess(mockData));
       expect(axios.post).toHaveBeenCalledWith(
         '/user/cart/LILS/cartItems',
-        expect.objectContaining(params)
+        params
+      );
+      expect((axios.post as jest.Mock).mock.calls[0][1]).toHaveSameSearchParams(
+        params
       );
     });
 
@@ -209,6 +212,9 @@ describe('Cart actions', () => {
           params,
         })
       );
+      expect(
+        (axios.get as jest.Mock).mock.calls[0][1].params
+      ).toHaveSameSearchParams(params);
     });
 
     it('applies additional filters as well as sort and filter state to the request params', async () => {
@@ -253,6 +259,9 @@ describe('Cart actions', () => {
           params,
         })
       );
+      expect(
+        (axios.get as jest.Mock).mock.calls[0][1].params
+      ).toHaveSameSearchParams(params);
     });
 
     it('can handle array distinct filters and add them to request params', async () => {
@@ -283,6 +292,9 @@ describe('Cart actions', () => {
           params,
         })
       );
+      expect(
+        (axios.get as jest.Mock).mock.calls[0][1].params
+      ).toHaveSameSearchParams(params);
     });
 
     it('dispatches fetchAllIdsRequest and fetchAllIdsFailure actions upon unsuccessful fetchAllIds action', async () => {
@@ -328,6 +340,9 @@ describe('Cart actions', () => {
           params,
         })
       );
+      expect(
+        (axios.get as jest.Mock).mock.calls[0][1].params
+      ).toHaveSameSearchParams(params);
     });
 
     it('applies filter state to the request params', async () => {
@@ -362,6 +377,9 @@ describe('Cart actions', () => {
           params,
         })
       );
+      expect(
+        (axios.get as jest.Mock).mock.calls[0][1].params
+      ).toHaveSameSearchParams(params);
     });
 
     it('dispatches fetchAllIdsRequest and fetchAllIdsFailure actions upon unsuccessful fetchAllISISInvestigationIds action', async () => {

--- a/packages/datagateway-table/src/state/actions/cart.test.tsx
+++ b/packages/datagateway-table/src/state/actions/cart.test.tsx
@@ -120,9 +120,6 @@ describe('Cart actions', () => {
         '/user/cart/LILS/cartItems',
         params
       );
-      expect((axios.post as jest.Mock).mock.calls[0][1]).toHaveSameSearchParams(
-        params
-      );
     });
 
     it('dispatches addToCartRequest and addToCartFailure actions upon unsuccessful addToCart action', async () => {
@@ -204,17 +201,13 @@ describe('Cart actions', () => {
       expect(actions[1]).toEqual(fetchAllIdsSuccess([1, 2, 3], 1));
 
       const params = new URLSearchParams();
+      params.append('order', JSON.stringify('ID asc'));
       params.append('distinct', JSON.stringify('ID'));
 
-      expect(axios.get).toHaveBeenCalledWith(
-        '/investigations',
-        expect.objectContaining({
-          params,
-        })
-      );
-      expect(
-        (axios.get as jest.Mock).mock.calls[0][1].params
-      ).toHaveSameSearchParams(params);
+      expect(axios.get).toHaveBeenCalledWith('/investigations', {
+        headers: { Authorization: 'Bearer null' },
+        params,
+      });
     });
 
     it('applies additional filters as well as sort and filter state to the request params', async () => {
@@ -249,19 +242,16 @@ describe('Cart actions', () => {
 
       const params = new URLSearchParams();
       params.append('order', JSON.stringify('column1 desc'));
+      params.append('order', JSON.stringify('ID asc'));
       params.append('where', JSON.stringify({ column1: { like: '1' } }));
       params.append('where', JSON.stringify({ column2: { like: '2' } }));
+      params.append('where', JSON.stringify({ DATASET_ID: { eq: 1 } }));
       params.append('distinct', JSON.stringify(['NAME', 'ID']));
 
-      expect(axios.get).toHaveBeenCalledWith(
-        '/datasets',
-        expect.objectContaining({
-          params,
-        })
-      );
-      expect(
-        (axios.get as jest.Mock).mock.calls[0][1].params
-      ).toHaveSameSearchParams(params);
+      expect(axios.get).toHaveBeenCalledWith('/datasets', {
+        headers: { Authorization: 'Bearer null' },
+        params,
+      });
     });
 
     it('can handle array distinct filters and add them to request params', async () => {
@@ -284,17 +274,13 @@ describe('Cart actions', () => {
       expect(actions[1]).toEqual(fetchAllIdsSuccess([1, 2, 3], 1));
 
       const params = new URLSearchParams();
+      params.append('order', JSON.stringify('ID asc'));
       params.append('distinct', JSON.stringify(['NAME', 'TITLE', 'ID']));
 
-      expect(axios.get).toHaveBeenCalledWith(
-        '/datafiles',
-        expect.objectContaining({
-          params,
-        })
-      );
-      expect(
-        (axios.get as jest.Mock).mock.calls[0][1].params
-      ).toHaveSameSearchParams(params);
+      expect(axios.get).toHaveBeenCalledWith('/datafiles', {
+        headers: { Authorization: 'Bearer null' },
+        params,
+      });
     });
 
     it('dispatches fetchAllIdsRequest and fetchAllIdsFailure actions upon unsuccessful fetchAllIds action', async () => {
@@ -333,16 +319,15 @@ describe('Cart actions', () => {
       expect(actions[1]).toEqual(fetchAllIdsSuccess([1, 2, 3], 1));
 
       const params = new URLSearchParams();
+      params.append('order', JSON.stringify('ID asc'));
 
       expect(axios.get).toHaveBeenCalledWith(
         '/instruments/1/facilitycycles/2/investigations',
-        expect.objectContaining({
+        {
+          headers: { Authorization: 'Bearer null' },
           params,
-        })
+        }
       );
-      expect(
-        (axios.get as jest.Mock).mock.calls[0][1].params
-      ).toHaveSameSearchParams(params);
     });
 
     it('applies filter state to the request params', async () => {
@@ -368,18 +353,17 @@ describe('Cart actions', () => {
 
       const params = new URLSearchParams();
       params.append('order', JSON.stringify('column1 desc'));
+      params.append('order', JSON.stringify('ID asc'));
       params.append('where', JSON.stringify({ column1: { like: '1' } }));
       params.append('where', JSON.stringify({ column2: { like: '2' } }));
 
       expect(axios.get).toHaveBeenCalledWith(
         '/instruments/1/facilitycycles/2/investigations',
-        expect.objectContaining({
+        {
+          headers: { Authorization: 'Bearer null' },
           params,
-        })
+        }
       );
-      expect(
-        (axios.get as jest.Mock).mock.calls[0][1].params
-      ).toHaveSameSearchParams(params);
     });
 
     it('dispatches fetchAllIdsRequest and fetchAllIdsFailure actions upon unsuccessful fetchAllISISInvestigationIds action', async () => {

--- a/packages/datagateway-table/src/state/actions/datafiles.test.tsx
+++ b/packages/datagateway-table/src/state/actions/datafiles.test.tsx
@@ -76,14 +76,13 @@ describe('Datafile actions', () => {
     expect(actions[1]).toEqual(fetchDatafilesSuccess(mockData, 1));
 
     const params = new URLSearchParams();
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ DATASET_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datafiles',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datafiles', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('fetchDatafiles action applies filters and sort state to request params', async () => {
@@ -109,15 +108,15 @@ describe('Datafile actions', () => {
 
     const params = new URLSearchParams();
     params.append('order', JSON.stringify('column1 desc'));
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ column1: { like: '1' } }));
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
+    params.append('where', JSON.stringify({ DATASET_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datafiles',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datafiles', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchDatafilesRequest and fetchDatafilesFailure actions upon unsuccessful fetchDatafiles action', async () => {
@@ -154,12 +153,10 @@ describe('Datafile actions', () => {
     const params = new URLSearchParams();
     params.append('where', JSON.stringify({ DATASET_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datafiles/count',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datafiles/count', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('fetchDatafileCount action applies filters to request params', async () => {
@@ -187,12 +184,10 @@ describe('Datafile actions', () => {
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
     params.append('where', JSON.stringify({ DATASET_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datafiles/count',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datafiles/count', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchDatafileCountRequest and fetchDatafileCountFailure actions upon unsuccessful fetchDatafileCount action', async () => {
@@ -329,10 +324,10 @@ describe('Datafile actions', () => {
       JSON.stringify({ DATAFILEPARAMETER: 'PARAMETERTYPE' })
     );
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datafiles',
-      expect.objectContaining({ params })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datafiles', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchDatafileDetailsRequest and fetchDatafileDetailsFailure actions upon unsuccessful fetchDatafileDetails action', async () => {

--- a/packages/datagateway-table/src/state/actions/datasets.test.tsx
+++ b/packages/datagateway-table/src/state/actions/datasets.test.tsx
@@ -89,14 +89,13 @@ describe('Dataset actions', () => {
     expect(actions[1]).toEqual(fetchDatasetsSuccess(mockData, 1));
 
     const params = new URLSearchParams();
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ INVESTIGATION_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datasets',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datasets', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('fetchDatasets action applies filters and sort state to request params', async () => {
@@ -115,17 +114,16 @@ describe('Dataset actions', () => {
     expect(actions[1]).toEqual(fetchDatasetsSuccess(mockData, 1));
 
     const params = new URLSearchParams();
-    params.append('where', JSON.stringify({ INVESTIGATION_ID: { eq: 1 } }));
     params.append('order', JSON.stringify('column1 desc'));
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ column1: { like: '1' } }));
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
+    params.append('where', JSON.stringify({ INVESTIGATION_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datasets',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datasets', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('fetchDatasets action sends fetchDatafileCount actions when specified via optional parameters', async () => {
@@ -250,12 +248,10 @@ describe('Dataset actions', () => {
     const params = new URLSearchParams();
     params.append('where', JSON.stringify({ INVESTIGATION_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datasets/count',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datasets/count', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('fetchDatasetCount action applies filters to request params', async () => {
@@ -283,12 +279,10 @@ describe('Dataset actions', () => {
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
     params.append('where', JSON.stringify({ INVESTIGATION_ID: { eq: 1 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datasets/count',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datasets/count', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchDatasetCountRequest and fetchDatasetCountFailure actions upon unsuccessful fetchDatasetCount action', async () => {
@@ -340,10 +334,10 @@ describe('Dataset actions', () => {
     params.append('where', JSON.stringify({ ID: { eq: 1 } }));
     params.append('include', JSON.stringify('DATASETTYPE'));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/datasets',
-      expect.objectContaining({ params })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/datasets', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchDatasetDetailsRequest and fetchDatasetDetailsFailure actions upon unsuccessful fetchDatasetDetails action', async () => {

--- a/packages/datagateway-table/src/state/actions/facilityCycles.test.tsx
+++ b/packages/datagateway-table/src/state/actions/facilityCycles.test.tsx
@@ -79,15 +79,14 @@ describe('FacilityCycle actions', () => {
 
     const params = new URLSearchParams();
     params.append('order', JSON.stringify('column1 desc'));
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ column1: { like: '1' } }));
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/instruments/1/facilitycycles',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/instruments/1/facilitycycles', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchFacilityCyclesRequest and fetchFacilityCyclesFailure actions upon unsuccessful fetchFacilityCycles action', async () => {
@@ -150,9 +149,10 @@ describe('FacilityCycle actions', () => {
 
     expect(axios.get).toHaveBeenCalledWith(
       '/instruments/1/facilitycycles/count',
-      expect.objectContaining({
+      {
+        headers: { Authorization: 'Bearer null' },
         params,
-      })
+      }
     );
   });
 

--- a/packages/datagateway-table/src/state/actions/instruments.test.tsx
+++ b/packages/datagateway-table/src/state/actions/instruments.test.tsx
@@ -77,15 +77,14 @@ describe('Instrument actions', () => {
 
     const params = new URLSearchParams();
     params.append('order', JSON.stringify('column1 desc'));
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ column1: { like: '1' } }));
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/instruments',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/instruments', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchInstrumentsRequest and fetchInstrumentsFailure actions upon unsuccessful fetchInstruments action', async () => {
@@ -144,12 +143,10 @@ describe('Instrument actions', () => {
     params.append('where', JSON.stringify({ column1: { like: '1' } }));
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/instruments/count',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/instruments/count', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchInstrumentCountRequest and fetchInstrumentCountFailure actions upon unsuccessful fetchInstrumentCount action', async () => {
@@ -205,12 +202,12 @@ describe('Instrument actions', () => {
 
     const params = new URLSearchParams();
     params.append('where', JSON.stringify({ ID: { eq: 1 } }));
-    params.append('include', JSON.stringify({ INSTRUMENTUSER: 'USER_' }));
+    params.append('include', JSON.stringify({ INSTRUMENTSCIENTIST: 'USER_' }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/instruments',
-      expect.objectContaining({ params })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/instruments', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchInstrumentDetailsRequest and fetchInstrumentDetailsFailure actions upon unsuccessful fetchInstrumentDetails action', async () => {

--- a/packages/datagateway-table/src/state/actions/investigations.test.tsx
+++ b/packages/datagateway-table/src/state/actions/investigations.test.tsx
@@ -132,16 +132,15 @@ describe('Investigation actions', () => {
 
     const params = new URLSearchParams();
     params.append('order', JSON.stringify('column1 desc'));
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ column1: { like: '1' } }));
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
     params.append('where', JSON.stringify({ column3: { eq: 3 } }));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/investigations',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/investigations', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('fetchInvestigations action sends fetchDatasetCount actions when specified via optional parameters', async () => {
@@ -287,14 +286,23 @@ describe('Investigation actions', () => {
     expect(actions[1]).toEqual(fetchInvestigationsSuccess(mockData, 1));
     const params = new URLSearchParams();
     params.append('order', JSON.stringify('column1 desc'));
+    params.append('order', JSON.stringify('ID asc'));
     params.append('where', JSON.stringify({ column1: { like: '1' } }));
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
+    params.append(
+      'include',
+      JSON.stringify([
+        { INVESTIGATIONINSTRUMENT: 'INSTRUMENT' },
+        { STUDYINVESTIGATION: 'STUDY' },
+      ])
+    );
 
     expect(axios.get).toHaveBeenCalledWith(
       '/instruments/1/facilitycycles/2/investigations',
-      expect.objectContaining({
+      {
+        headers: { Authorization: 'Bearer null' },
         params,
-      })
+      }
     );
   });
 
@@ -369,10 +377,10 @@ describe('Investigation actions', () => {
       JSON.stringify([{ INVESTIGATIONUSER: 'USER_' }, 'SAMPLE', 'PUBLICATION'])
     );
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/investigations',
-      expect.objectContaining({ params })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/investigations', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchInvestigationDetailsRequest and fetchInvestigationDetailsFailure actions upon unsuccessful fetchInvestigationDetails action', async () => {
@@ -440,12 +448,10 @@ describe('Investigation actions', () => {
     params.append('where', JSON.stringify({ column2: { like: '2' } }));
     params.append('distinct', JSON.stringify(['NAME']));
 
-    expect(axios.get).toHaveBeenCalledWith(
-      '/investigations/count',
-      expect.objectContaining({
-        params,
-      })
-    );
+    expect(axios.get).toHaveBeenCalledWith('/investigations/count', {
+      headers: { Authorization: 'Bearer null' },
+      params,
+    });
   });
 
   it('dispatches fetchInvestigationCountRequest and fetchInvestigationCountFailure actions upon unsuccessful fetchInvestigationCount action', async () => {
@@ -509,9 +515,10 @@ describe('Investigation actions', () => {
 
     expect(axios.get).toHaveBeenCalledWith(
       '/instruments/1/facilitycycles/2/investigations/count',
-      expect.objectContaining({
+      {
+        headers: { Authorization: 'Bearer null' },
         params,
-      })
+      }
     );
   });
 

--- a/packages/datagateway-table/src/state/actions/investigations.tsx
+++ b/packages/datagateway-table/src/state/actions/investigations.tsx
@@ -203,18 +203,7 @@ export const fetchISISInvestigations = ({
     const timestamp = Date.now();
     dispatch(fetchInvestigationsRequest(timestamp));
 
-    // TODO: replace this with getApiFilters again when API filter change merges in
-    const sort = getState().dgtable.sort;
-    const filter = getState().dgtable.filters;
-
-    let params = new URLSearchParams();
-    for (let [key, value] of Object.entries(sort)) {
-      params.append('order', JSON.stringify(`${key} ${value}`));
-    }
-
-    for (let [key, value] of Object.entries(filter)) {
-      params.append('where', JSON.stringify({ [key]: { like: value } }));
-    }
+    let params = getApiFilter(getState);
 
     params.append(
       'include',
@@ -361,6 +350,13 @@ export const fetchInvestigationCount = (
     dispatch(fetchInvestigationCountRequest(timestamp));
 
     let params = getApiFilter(getState);
+
+    if (additionalFilters) {
+      additionalFilters.forEach(filter => {
+        params.append(filter.filterType, filter.filterValue);
+      });
+    }
+
     params.delete('order');
 
     const { apiUrl } = getState().dgtable.urls;


### PR DESCRIPTION
##  Description
Tests now actually check the key/value pairs in URLSearchParams.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage

## Agile board tracking
Closes #105 
