### PR TITLE
Feature/daaas renaming #95

### DIFF
--- a/packages/datagateway-common/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-common/src/state/actions/actions.types.tsx
@@ -1,10 +1,14 @@
 import { Filter, Order, Entity, DownloadCart } from '../../app.types';
 
 // parent app actions
-export const RegisterRouteType = 'scigateway:api:register_route';
-export const RequestPluginRerenderType = 'scigateway:api:plugin_rerender';
+export const MicroFrontendMessageId = 'scigateway';
+export const CustomFrontendMessageType = `${MicroFrontendMessageId}:api:`;
+export const RegisterRouteType = `${MicroFrontendMessageId}:api:register_route`;
+export const RequestPluginRerenderType = `${MicroFrontendMessageId}:api:plugin_rerender`;
 
 // internal actions
+// export const CommonCustomMessageType = 'datagateway_common:api:';
+
 export const SortTableType = 'datagateway_common:sort_table';
 export const FilterTableType = 'datagateway_common:filter_table';
 export const ClearTableType = 'datagateway_common:clear_table';

--- a/packages/datagateway-common/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-common/src/state/actions/actions.types.tsx
@@ -7,8 +7,6 @@ export const RegisterRouteType = `${MicroFrontendMessageId}:api:register_route`;
 export const RequestPluginRerenderType = `${MicroFrontendMessageId}:api:plugin_rerender`;
 
 // internal actions
-// export const CommonCustomMessageType = 'datagateway_common:api:';
-
 export const SortTableType = 'datagateway_common:sort_table';
 export const FilterTableType = 'datagateway_common:filter_table';
 export const ClearTableType = 'datagateway_common:clear_table';

--- a/packages/datagateway-common/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-common/src/state/actions/actions.types.tsx
@@ -1,8 +1,8 @@
 import { Filter, Order, Entity, DownloadCart } from '../../app.types';
 
 // parent app actions
-export const RegisterRouteType = 'daaas:api:register_route';
-export const RequestPluginRerenderType = 'daaas:api:plugin_rerender';
+export const RegisterRouteType = 'scigateway:api:register_route';
+export const RequestPluginRerenderType = 'scigateway:api:plugin_rerender';
 
 // internal actions
 export const SortTableType = 'datagateway_common:sort_table';

--- a/packages/datagateway-common/src/state/middleware/dgcommon.middleware.tsx
+++ b/packages/datagateway-common/src/state/middleware/dgcommon.middleware.tsx
@@ -3,30 +3,32 @@ import log from 'loglevel';
 import {
   RegisterRouteType,
   RequestPluginRerenderType,
+  MicroFrontendMessageId,
+  CustomFrontendMessageType,
 } from '../actions/actions.types';
 import axios from 'axios';
 
 const CancelToken = axios.CancelToken;
 export let source = CancelToken.source();
 
-const microFrontendMessageId = 'scigateway';
+// const microFrontendMessageId = 'scigateway';
 
 const broadcastMessage = (action: AnyAction): void => {
   document.dispatchEvent(
-    new CustomEvent(microFrontendMessageId, { detail: action })
+    new CustomEvent(MicroFrontendMessageId, { detail: action })
   );
 };
 
 type microFrontendMessageType = CustomEvent<AnyAction>;
 
 export const listenToMessages = (dispatch: Dispatch): void => {
-  document.addEventListener(microFrontendMessageId, event => {
+  document.addEventListener(MicroFrontendMessageId, event => {
     const pluginMessage = event as microFrontendMessageType;
 
     if (
       pluginMessage.detail &&
       pluginMessage.detail.type &&
-      (pluginMessage.detail.type.startsWith('scigateway:api:') ||
+      (pluginMessage.detail.type.startsWith(CustomFrontendMessageType) ||
         pluginMessage.detail.type.startsWith('datagateway_common:api:'))
     ) {
       // this is a valid message, so process it

--- a/packages/datagateway-common/src/state/middleware/dgcommon.middleware.tsx
+++ b/packages/datagateway-common/src/state/middleware/dgcommon.middleware.tsx
@@ -11,8 +11,6 @@ import axios from 'axios';
 const CancelToken = axios.CancelToken;
 export let source = CancelToken.source();
 
-// const microFrontendMessageId = 'scigateway';
-
 const broadcastMessage = (action: AnyAction): void => {
   document.dispatchEvent(
     new CustomEvent(MicroFrontendMessageId, { detail: action })

--- a/packages/datagateway-common/src/state/middleware/dgcommon.middleware.tsx
+++ b/packages/datagateway-common/src/state/middleware/dgcommon.middleware.tsx
@@ -9,7 +9,7 @@ import axios from 'axios';
 const CancelToken = axios.CancelToken;
 export let source = CancelToken.source();
 
-const microFrontendMessageId = 'daaas-frontend';
+const microFrontendMessageId = 'scigateway';
 
 const broadcastMessage = (action: AnyAction): void => {
   document.dispatchEvent(
@@ -26,7 +26,7 @@ export const listenToMessages = (dispatch: Dispatch): void => {
     if (
       pluginMessage.detail &&
       pluginMessage.detail.type &&
-      (pluginMessage.detail.type.startsWith('daaas:api:') ||
+      (pluginMessage.detail.type.startsWith('scigateway:api:') ||
         pluginMessage.detail.type.startsWith('datagateway_common:api:'))
     ) {
       // this is a valid message, so process it

--- a/packages/datagateway-download/src/index.tsx
+++ b/packages/datagateway-download/src/index.tsx
@@ -4,8 +4,13 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import axios from 'axios';
-
 import singleSpaReact from 'single-spa-react';
+
+import {
+  MicroFrontendMessageId,
+  RequestPluginRerenderType,
+  RegisterRouteType,
+} from 'datagateway-common';
 
 function domElementGetter(): HTMLElement {
   // Make sure there is a div for us to render into
@@ -36,10 +41,10 @@ window.addEventListener('single-spa:routing-event', () => {
   render();
 });
 
-document.addEventListener('scigateway', e => {
+document.addEventListener(MicroFrontendMessageId, e => {
   // attempt to re-render the plugin if the corresponding div is present
   const action = (e as CustomEvent).detail;
-  if (action.type === 'scigateway:api:plugin_rerender') {
+  if (action.type === RequestPluginRerenderType) {
     render();
   }
 });
@@ -95,9 +100,9 @@ if (
 serviceWorker.unregister();
 
 document.dispatchEvent(
-  new CustomEvent('scigateway', {
+  new CustomEvent(MicroFrontendMessageId, {
     detail: {
-      type: 'scigateway:api:register_route',
+      type: RegisterRouteType,
       payload: {
         section: 'Test',
         link: '/download',

--- a/packages/datagateway-download/src/index.tsx
+++ b/packages/datagateway-download/src/index.tsx
@@ -36,10 +36,10 @@ window.addEventListener('single-spa:routing-event', () => {
   render();
 });
 
-document.addEventListener('daaas-frontend', e => {
+document.addEventListener('scigateway', e => {
   // attempt to re-render the plugin if the corresponding div is present
   const action = (e as CustomEvent).detail;
-  if (action.type === 'daaas:api:plugin_rerender') {
+  if (action.type === 'scigateway:api:plugin_rerender') {
     render();
   }
 });
@@ -95,9 +95,9 @@ if (
 serviceWorker.unregister();
 
 document.dispatchEvent(
-  new CustomEvent('daaas-frontend', {
+  new CustomEvent('scigateway', {
     detail: {
-      type: 'daaas:api:register_route',
+      type: 'scigateway:api:register_route',
       payload: {
         section: 'Test',
         link: '/download',

--- a/packages/datagateway-table/src/App.tsx
+++ b/packages/datagateway-table/src/App.tsx
@@ -72,7 +72,7 @@ const registerRouteAction = {
 };
 
 document.dispatchEvent(
-  new CustomEvent('daaas-frontend', { detail: registerRouteAction })
+  new CustomEvent('scigateway', { detail: registerRouteAction })
 );
 
 function mapPreloaderStateToProps(state: StateType): { loading: boolean } {

--- a/packages/datagateway-table/src/App.tsx
+++ b/packages/datagateway-table/src/App.tsx
@@ -14,6 +14,7 @@ import {
   DGCommonMiddleware,
   listenToMessages,
   RegisterRouteType,
+  MicroFrontendMessageId,
 } from 'datagateway-common';
 import { configureApp } from './state/actions';
 import { StateType } from './state/app.types';
@@ -72,7 +73,7 @@ const registerRouteAction = {
 };
 
 document.dispatchEvent(
-  new CustomEvent('scigateway', { detail: registerRouteAction })
+  new CustomEvent(MicroFrontendMessageId, { detail: registerRouteAction })
 );
 
 function mapPreloaderStateToProps(state: StateType): { loading: boolean } {

--- a/packages/datagateway-table/src/index.tsx
+++ b/packages/datagateway-table/src/index.tsx
@@ -8,7 +8,11 @@ import './index.css';
 import App from './App';
 import singleSpaReact from 'single-spa-react';
 import * as log from 'loglevel';
-import { RequestPluginRerenderType } from './state/actions/actions.types';
+
+import {
+  MicroFrontendMessageId,
+  RequestPluginRerenderType,
+} from 'datagateway-common';
 
 const pluginName = 'datagateway-table';
 
@@ -39,7 +43,7 @@ window.addEventListener('single-spa:routing-event', () => {
   render();
 });
 
-document.addEventListener('scigateway', e => {
+document.addEventListener(MicroFrontendMessageId, e => {
   const action = (e as CustomEvent).detail;
   if (action.type === RequestPluginRerenderType) {
     render();

--- a/packages/datagateway-table/src/index.tsx
+++ b/packages/datagateway-table/src/index.tsx
@@ -39,7 +39,7 @@ window.addEventListener('single-spa:routing-event', () => {
   render();
 });
 
-document.addEventListener('daaas-frontend', e => {
+document.addEventListener('scigateway', e => {
   const action = (e as CustomEvent).detail;
   if (action.type === RequestPluginRerenderType) {
     render();

--- a/packages/datagateway-table/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-table/src/state/actions/actions.types.tsx
@@ -1,8 +1,8 @@
 import { ApplicationStrings } from '../app.types';
 
 // // parent app actions
-export const RegisterRouteType = 'daaas:api:register_route';
-export const RequestPluginRerenderType = 'daaas:api:plugin_rerender';
+export const RegisterRouteType = 'scigateway:api:register_route';
+export const RequestPluginRerenderType = 'scigateway:api:plugin_rerender';
 
 // // internal actions
 export const ConfigureStringsType = 'datagateway_table:configure_strings';

--- a/packages/datagateway-table/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-table/src/state/actions/actions.types.tsx
@@ -1,10 +1,10 @@
 import { ApplicationStrings } from '../app.types';
 
-// // parent app actions
-export const RegisterRouteType = 'scigateway:api:register_route';
-export const RequestPluginRerenderType = 'scigateway:api:plugin_rerender';
+// parent app actions
+// export const RegisterRouteType = 'scigateway:api:register_route';
+// export const RequestPluginRerenderType = 'scigateway:api:plugin_rerender';
 
-// // internal actions
+// internal actions
 export const ConfigureStringsType = 'datagateway_table:configure_strings';
 export const ConfigureFeatureSwitchesType =
   'datagateway_table:configure_feature_switches';

--- a/packages/datagateway-table/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-table/src/state/actions/actions.types.tsx
@@ -1,9 +1,5 @@
 import { ApplicationStrings } from '../app.types';
 
-// parent app actions
-// export const RegisterRouteType = 'scigateway:api:register_route';
-// export const RequestPluginRerenderType = 'scigateway:api:plugin_rerender';
-
 // internal actions
 export const ConfigureStringsType = 'datagateway_table:configure_strings';
 export const ConfigureFeatureSwitchesType =


### PR DESCRIPTION
## Description
Re-named instances of `daaas`/`daaas-frontend` in the datagateway packages to `scigateway`. In addition, the types have now been imported from `datagateway-common` in order to make it easier to change in the future.

## Testing instructions

- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #95 
