### PR TITLE
Use & parse scigateway:token

### DIFF
--- a/packages/datagateway-common/package.json
+++ b/packages/datagateway-common/package.json
@@ -17,7 +17,7 @@
     "lodash.debounce": "^4.0.8",
     "loglevel": "^1.6.3",
     "react-draggable": "^4.0.3",
-    "react-redux": "^7.1.3",
+    "react-redux": "^7.1.0",
     "react-virtualized": "^9.21.1",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",

--- a/packages/datagateway-common/package.json
+++ b/packages/datagateway-common/package.json
@@ -69,7 +69,7 @@
     "test": "react-scripts test --env=jsdom --coverage --watchAll=false",
     "prepare": "yarn tsc",
     "test:watch": "react-scripts test --env=jsdom --watch",
-    "lint:js": "eslint --ext=tsx --ext=js --ext=jsx --fix ./src",
+    "lint:js": "eslint --ext=tsx --ext=ts --ext=js --ext=jsx --fix ./src",
     "tsc": "tsc -p tsconfig.lib.json",
     "eject": "react-scripts eject",
     "pre-commit": "lint-staged"
@@ -103,7 +103,7 @@
       "enzyme-to-json/serializer"
     ],
     "collectCoverageFrom": [
-      "src/**/*.{tsx,js,jsx}",
+      "src/**/*.{tsx,ts,js,jsx}",
       "!src/index.tsx",
       "!src/serviceWorker.ts",
       "!src/setupTests.js"

--- a/packages/datagateway-common/src/handleICATError.test.ts
+++ b/packages/datagateway-common/src/handleICATError.test.ts
@@ -1,0 +1,92 @@
+import { AxiosError } from 'axios';
+import * as log from 'loglevel';
+import handleICATError from './handleICATError';
+import { AnyAction } from 'redux';
+
+jest.mock('loglevel');
+
+describe('handleICATError', () => {
+  let error: AxiosError;
+  let events: CustomEvent<AnyAction>[] = [];
+
+  beforeEach(() => {
+    events = [];
+
+    document.dispatchEvent = (e: Event) => {
+      events.push(e as CustomEvent<AnyAction>);
+      return true;
+    };
+
+    error = {
+      isAxiosError: true,
+      config: {},
+      response: {
+        data: {},
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {},
+      },
+      name: 'Test error name',
+      message: 'Test error message',
+    };
+  });
+
+  it('logs an error and sends a notification to SciGateway', () => {
+    handleICATError(error);
+
+    expect(log.error).toHaveBeenCalledWith('Test error message');
+    expect(events.length).toBe(1);
+    expect(events[0].detail).toEqual({
+      type: 'scigateway:api:notification',
+      payload: { severity: 'error', message: 'Test error message' },
+    });
+  });
+
+  it('just logs an error if broadcast is false', () => {
+    handleICATError(error, false);
+
+    expect(log.error).toHaveBeenCalledWith('Test error message');
+    expect(events.length).toBe(0);
+  });
+
+  it('sends an invalidate token message to SciGateway on 403 response', () => {
+    if (error.response) error.response.status = 403;
+    handleICATError(error);
+
+    expect(log.error).toHaveBeenCalledWith('Test error message');
+    expect(events.length).toBe(2);
+    expect(events[1].detail).toEqual({
+      type: 'scigateway:api:invalidate_token',
+    });
+  });
+
+  it('sends an invalidate token message to SciGateway on TopCAT authentication error', () => {
+    if (error.response)
+      error.response.data = {
+        message: 'Unable to find user by sessionid: null',
+      };
+    handleICATError(error);
+
+    expect(log.error).toHaveBeenCalledWith('Test error message');
+    expect(events.length).toBe(2);
+    expect(events[1].detail).toEqual({
+      type: 'scigateway:api:invalidate_token',
+    });
+
+    (log.error as jest.Mock).mockClear();
+    events = [];
+
+    if (error.response)
+      error.response.data = {
+        message: 'Session id:null has expired',
+      };
+    handleICATError(error);
+
+    expect(log.error).toHaveBeenCalledWith('Test error message');
+    expect(events.length).toBe(2);
+    expect(events[1].detail).toEqual({
+      type: 'scigateway:api:invalidate_token',
+    });
+  });
+});

--- a/packages/datagateway-common/src/handleICATError.ts
+++ b/packages/datagateway-common/src/handleICATError.ts
@@ -1,0 +1,40 @@
+import { AxiosError } from 'axios';
+import * as log from 'loglevel';
+
+const handleICATError = (
+  error: AxiosError,
+  broadcast: boolean = true
+): void => {
+  log.error(error.message);
+  if (broadcast) {
+    document.dispatchEvent(
+      new CustomEvent('scigateway', {
+        detail: {
+          type: 'scigateway:api:notification',
+          payload: {
+            severity: 'error',
+            message: error.message,
+          },
+        },
+      })
+    );
+  }
+  if (
+    error.response &&
+    error.response.status &&
+    (error.response.status === 403 ||
+      // TopCAT doesn't set 403 for session ID failure, so detect by looking at the message
+      (error.response.data.message &&
+        error.response.data.message.toUpperCase().includes('SESSION')))
+  ) {
+    document.dispatchEvent(
+      new CustomEvent('scigateway', {
+        detail: {
+          type: 'scigateway:api:invalidate_token',
+        },
+      })
+    );
+  }
+};
+
+export default handleICATError;

--- a/packages/datagateway-common/src/index.tsx
+++ b/packages/datagateway-common/src/index.tsx
@@ -31,5 +31,6 @@ export { default as dGCommonReducer } from './state/reducers/dgcommon.reducer';
 export type DGCommonState = StateType;
 
 export * from './parseTokens';
+export { default as handleICATError } from './handleICATError';
 
 // ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/datagateway-common/src/index.tsx
+++ b/packages/datagateway-common/src/index.tsx
@@ -31,6 +31,5 @@ export { default as dGCommonReducer } from './state/reducers/dgcommon.reducer';
 export type DGCommonState = StateType;
 
 export * from './parseTokens';
-export * from './handleICATError';
 
 // ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/datagateway-common/src/index.tsx
+++ b/packages/datagateway-common/src/index.tsx
@@ -30,4 +30,7 @@ export { default as dGCommonReducer } from './state/reducers/dgcommon.reducer';
 
 export type DGCommonState = StateType;
 
+export * from './parseTokens';
+export * from './handleICATError';
+
 // ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/datagateway-common/src/parseTokens.test.ts
+++ b/packages/datagateway-common/src/parseTokens.test.ts
@@ -1,0 +1,32 @@
+import { readSciGatewayToken } from './parseTokens';
+
+describe('readSciGatewayToken', () => {
+  const localStorageGetItemMock = jest.spyOn(
+    window.localStorage.__proto__,
+    'getItem'
+  );
+
+  it('should read token from localstorage and parse the JWT', () => {
+    localStorageGetItemMock.mockImplementationOnce(
+      () =>
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uSWQiOiJ0ZXN0IiwidXNlcm5hbWUiOiLFgcO0w7zDrXPDqCJ9.nvE928aMiDdQk-G20Md7p2K6dEQ7JY2m2o6EMdz3wnw'
+    );
+    const result = readSciGatewayToken();
+    expect(result).toEqual({ sessionId: 'test', username: 'Łôüísè' });
+  });
+
+  it("should return nulls if token doesn't contain session id or username fields", () => {
+    localStorageGetItemMock.mockImplementationOnce(
+      () =>
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZXN0IjoidGVzdCJ9.YMHLrDnDXLh13W2VajRFRY8bUwHjr8dzHzVeA-Cek8Y'
+    );
+    const result = readSciGatewayToken();
+    expect(result).toEqual({ sessionId: null, username: null });
+  });
+
+  it("should return nulls if token doesn't exist", () => {
+    localStorageGetItemMock.mockImplementationOnce(() => null);
+    const result = readSciGatewayToken();
+    expect(result).toEqual({ sessionId: null, username: null });
+  });
+});

--- a/packages/datagateway-common/src/parseTokens.ts
+++ b/packages/datagateway-common/src/parseTokens.ts
@@ -1,0 +1,38 @@
+// we return the payload as a string rather than JSON.parse-ing it
+// so that callers can inform TypeScript the type of their payload
+// when they JSON.parse the result of this function
+const parseJwt = (token: string): string => {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const payload = decodeURIComponent(
+    atob(base64).replace(/(.)/g, function(m, p) {
+      var code = p
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase();
+      return '%' + ('00' + code).slice(-2);
+    })
+  );
+  return payload;
+};
+
+export interface SciGatewayToken {
+  sessionId: string | null;
+  username: string | null;
+}
+
+export const readSciGatewayToken = (): SciGatewayToken => {
+  const token = localStorage.getItem('scigateway:token');
+  let sessionId = null;
+  let username = null;
+  if (token) {
+    const parsedToken = JSON.parse(parseJwt(token));
+    if (parsedToken.sessionId) sessionId = parsedToken.sessionId;
+    if (parsedToken.username) username = parsedToken.username;
+  }
+
+  return {
+    sessionId,
+    username,
+  };
+};

--- a/packages/datagateway-common/src/state/actions/cart.test.tsx
+++ b/packages/datagateway-common/src/state/actions/cart.test.tsx
@@ -14,7 +14,6 @@ import {
 } from '.';
 import axios from 'axios';
 import { actions, dispatch, getState, resetActions } from '../../setupTests';
-import * as log from 'loglevel';
 import { DownloadCart } from '../../app.types';
 import {
   fetchAllIds,
@@ -25,8 +24,9 @@ import {
 } from './cart';
 import { initialState } from '../reducers/dgcommon.reducer';
 import { StateType } from '../app.types';
+import handleICATError from '../../handleICATError';
 
-jest.mock('loglevel');
+jest.mock('../../handleICATError');
 
 describe('Cart actions', () => {
   Date.now = jest.fn().mockImplementation(() => 1);
@@ -52,6 +52,7 @@ describe('Cart actions', () => {
     (axios.get as jest.Mock).mockClear();
     (axios.post as jest.Mock).mockClear();
     (axios.delete as jest.Mock).mockClear();
+    (handleICATError as jest.Mock).mockClear();
     resetActions();
   });
 
@@ -93,9 +94,10 @@ describe('Cart actions', () => {
         fetchDownloadCartFailure('Test error message')
       );
 
-      expect(log.error).toHaveBeenCalled();
-      const mockLog = (log.error as jest.Mock).mock;
-      expect(mockLog.calls[0][0]).toEqual('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -135,9 +137,10 @@ describe('Cart actions', () => {
       expect(actions[0]).toEqual(addToCartRequest());
       expect(actions[1]).toEqual(addToCartFailure('Test error message'));
 
-      expect(log.error).toHaveBeenCalled();
-      const mockLog = (log.error as jest.Mock).mock;
-      expect(mockLog.calls[0][0]).toEqual('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -178,9 +181,10 @@ describe('Cart actions', () => {
       expect(actions[0]).toEqual(removeFromCartRequest());
       expect(actions[1]).toEqual(removeFromCartFailure('Test error message'));
 
-      expect(log.error).toHaveBeenCalled();
-      const mockLog = (log.error as jest.Mock).mock;
-      expect(mockLog.calls[0][0]).toEqual('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -296,9 +300,10 @@ describe('Cart actions', () => {
       expect(actions[0]).toEqual(fetchAllIdsRequest(1));
       expect(actions[1]).toEqual(fetchAllIdsFailure('Test error message'));
 
-      expect(log.error).toHaveBeenCalled();
-      const mockLog = (log.error as jest.Mock).mock;
-      expect(mockLog.calls[0][0]).toEqual('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -379,9 +384,10 @@ describe('Cart actions', () => {
       expect(actions[0]).toEqual(fetchAllIdsRequest(1));
       expect(actions[1]).toEqual(fetchAllIdsFailure('Test error message'));
 
-      expect(log.error).toHaveBeenCalled();
-      const mockLog = (log.error as jest.Mock).mock;
-      expect(mockLog.calls[0][0]).toEqual('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 });

--- a/packages/datagateway-common/src/state/actions/cart.tsx
+++ b/packages/datagateway-common/src/state/actions/cart.tsx
@@ -19,10 +19,10 @@ import {
 import { ActionType, ThunkResult } from '../app.types';
 import { Action } from 'redux';
 import axios from 'axios';
-import * as log from 'loglevel';
 import { DownloadCart, Investigation } from '../../app.types';
 import { getApiFilter } from '.';
 import { readSciGatewayToken } from '../../parseTokens';
+import handleICATError from '../../handleICATError';
 
 export const fetchDownloadCartSuccess = (
   downloadCart: DownloadCart
@@ -63,7 +63,7 @@ export const fetchDownloadCart = (): ThunkResult<Promise<void>> => {
         dispatch(fetchDownloadCartSuccess(response.data));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchDownloadCartFailure(error.message));
       });
   };
@@ -114,7 +114,7 @@ export const addToCart = (
         dispatch(addToCartSuccess(response.data));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(addToCartFailure(error.message));
       });
   };
@@ -163,7 +163,7 @@ export const removeFromCart = (
         dispatch(removeFromCartSuccess(response.data));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(removeFromCartFailure(error.message));
       });
   };
@@ -248,7 +248,7 @@ export const fetchAllIds = (
         );
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchAllIdsFailure(error.message));
       });
   };
@@ -289,7 +289,7 @@ export const fetchAllISISInvestigationIds = (
         );
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchAllIdsFailure(error.message));
       });
   };

--- a/packages/datagateway-common/src/state/actions/cart.tsx
+++ b/packages/datagateway-common/src/state/actions/cart.tsx
@@ -22,6 +22,7 @@ import axios from 'axios';
 import * as log from 'loglevel';
 import { DownloadCart, Investigation } from '../../app.types';
 import { getApiFilter } from '.';
+import { readSciGatewayToken } from '../../parseTokens';
 
 export const fetchDownloadCartSuccess = (
   downloadCart: DownloadCart
@@ -55,8 +56,7 @@ export const fetchDownloadCart = (): ThunkResult<Promise<void>> => {
     await axios
       .get(`${downloadApiUrl}/user/cart/LILS`, {
         params: {
-          // TODO: get session ID from somewhere else (extract from JWT)
-          sessionId: window.localStorage.getItem('icat:token'),
+          sessionId: readSciGatewayToken().sessionId,
         },
       })
       .then(response => {
@@ -101,8 +101,7 @@ export const addToCart = (
     const { downloadApiUrl } = getState().dgcommon.urls;
 
     const params = new URLSearchParams();
-    // TODO: get session ID from somewhere else (extract from JWT)
-    params.append('sessionId', window.localStorage.getItem('icat:token') || '');
+    params.append('sessionId', readSciGatewayToken().sessionId || '');
     params.append(
       'items',
       `${entityType} ${entityIds.join(`, ${entityType} `)}`
@@ -156,8 +155,7 @@ export const removeFromCart = (
     await axios
       .delete(`${downloadApiUrl}/user/cart/LILS/cartItems`, {
         params: {
-          // TODO: get session ID from somewhere else (extract from JWT)
-          sessionId: window.localStorage.getItem('icat:token'),
+          sessionId: readSciGatewayToken().sessionId,
           items: `${entityType} ${entityIds.join(`, ${entityType} `)}`,
         },
       })
@@ -238,7 +236,7 @@ export const fetchAllIds = (
       .get<{ ID: number }[]>(`${apiUrl}/${entityType}s`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -278,9 +276,7 @@ export const fetchAllISISInvestigationIds = (
         {
           params,
           headers: {
-            Authorization: `Bearer ${window.localStorage.getItem(
-              'daaas:token'
-            )}`,
+            Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
           },
         }
       )

--- a/packages/datagateway-common/src/state/actions/datafiles.test.tsx
+++ b/packages/datagateway-common/src/state/actions/datafiles.test.tsx
@@ -22,10 +22,10 @@ import axios from 'axios';
 import { StateType, EntityCache } from '../app.types';
 import { initialState } from '../reducers/dgcommon.reducer';
 import { actions, resetActions, dispatch, getState } from '../../setupTests';
-import * as log from 'loglevel';
 import { Datafile } from '../../app.types';
+import handleICATError from '../../handleICATError';
 
-jest.mock('loglevel');
+jest.mock('../../handleICATError');
 
 describe('Datafile actions', () => {
   Date.now = jest.fn().mockImplementation(() => 1);
@@ -60,6 +60,7 @@ describe('Datafile actions', () => {
 
   afterEach(() => {
     (axios.get as jest.Mock).mockClear();
+    (handleICATError as jest.Mock).mockClear();
     resetActions();
   });
 
@@ -133,9 +134,10 @@ describe('Datafile actions', () => {
     expect(actions[0]).toEqual(fetchDatafilesRequest(1));
     expect(actions[1]).toEqual(fetchDatafilesFailure('Test error message'));
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchDatafileCountRequest and fetchDatafileCountSuccess actions upon successful fetchDatafileCount action', async () => {
@@ -206,9 +208,10 @@ describe('Datafile actions', () => {
       fetchDatafileCountFailure('Test error message', 1)
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchDatasetDatafilesCountRequest and fetchDatasetDatafilesCountSuccess actions upon successful fetchDatasetDatafilesCount action', async () => {
@@ -271,9 +274,11 @@ describe('Datafile actions', () => {
       fetchDatasetDatafilesCountFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith(
+      { message: 'Test error message' },
+      false
+    );
   });
 
   it('dispatches downloadDatafileRequest and clicks on IDS link upon downloadDatafile action', async () => {
@@ -346,9 +351,10 @@ describe('Datafile actions', () => {
       fetchDatafileDetailsFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('fetchDatafiles applies skip and limit when specified via optional parameters', async () => {

--- a/packages/datagateway-common/src/state/actions/datafiles.tsx
+++ b/packages/datagateway-common/src/state/actions/datafiles.tsx
@@ -26,10 +26,10 @@ import { Action } from 'redux';
 import axios from 'axios';
 import { getApiFilter } from '.';
 import { source } from '../middleware/dgcommon.middleware';
-import * as log from 'loglevel';
 import { Datafile } from '../../app.types';
 import { IndexRange } from 'react-virtualized';
 import { readSciGatewayToken } from '../../parseTokens';
+import handleICATError from '../../handleICATError';
 
 export const fetchDatafilesSuccess = (
   datafiles: Datafile[],
@@ -91,7 +91,7 @@ export const fetchDatafiles = (
         dispatch(fetchDatafilesSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchDatafilesFailure(error.message));
       });
   };
@@ -149,7 +149,7 @@ export const fetchDatafileCount = (
         dispatch(fetchDatafileCountSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchDatafileCountFailure(error.message));
       });
   };
@@ -231,7 +231,7 @@ export const fetchDatasetDatafilesCount = (
           );
         })
         .catch(error => {
-          log.error(error.message);
+          handleICATError(error, false);
           dispatch(fetchDatasetDatafilesCountFailure(error.message));
         });
     }
@@ -286,7 +286,7 @@ export const fetchDatafileDetails = (
         dispatch(fetchDatafileDetailsSuccess(response.data));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchDatafileDetailsFailure(error.message));
       });
   };

--- a/packages/datagateway-common/src/state/actions/datafiles.tsx
+++ b/packages/datagateway-common/src/state/actions/datafiles.tsx
@@ -29,6 +29,7 @@ import { source } from '../middleware/dgcommon.middleware';
 import * as log from 'loglevel';
 import { Datafile } from '../../app.types';
 import { IndexRange } from 'react-virtualized';
+import { readSciGatewayToken } from '../../parseTokens';
 
 export const fetchDatafilesSuccess = (
   datafiles: Datafile[],
@@ -83,7 +84,7 @@ export const fetchDatafiles = (
       .get(`${apiUrl}/datafiles`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -141,7 +142,7 @@ export const fetchDatafileCount = (
       .get(`${apiUrl}/datafiles/count`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -216,9 +217,7 @@ export const fetchDatasetDatafilesCount = (
         .get(`${apiUrl}/datafiles/count`, {
           params,
           headers: {
-            Authorization: `Bearer ${window.localStorage.getItem(
-              'daaas:token'
-            )}`,
+            Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
           },
           cancelToken: source.token,
         })
@@ -280,7 +279,7 @@ export const fetchDatafileDetails = (
       .get(`${apiUrl}/datafiles`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -325,9 +324,8 @@ export const downloadDatafile = (
 
     const { idsUrl } = getState().dgcommon.urls;
 
-    // TODO: get ICAT session id properly when auth is sorted
     const params = {
-      sessionId: window.localStorage.getItem('icat:token'),
+      sessionId: readSciGatewayToken().sessionId,
       datafileIds: datafileId,
       compress: false,
       outname: filename,

--- a/packages/datagateway-common/src/state/actions/datasets.test.tsx
+++ b/packages/datagateway-common/src/state/actions/datasets.test.tsx
@@ -26,12 +26,11 @@ import { StateType, EntityCache } from '../app.types';
 import { initialState } from '../reducers/dgcommon.reducer';
 import axios from 'axios';
 import { actions, dispatch, getState, resetActions } from '../../setupTests';
-import * as log from 'loglevel';
 import { Dataset } from '../../app.types';
-
 import { fetchDatasetDatafilesCountRequest } from './datafiles';
+import handleICATError from '../../handleICATError';
 
-jest.mock('loglevel');
+jest.mock('../../handleICATError');
 
 describe('Dataset actions', () => {
   Date.now = jest.fn().mockImplementation(() => 1);
@@ -77,6 +76,7 @@ describe('Dataset actions', () => {
 
   afterEach(() => {
     (axios.get as jest.Mock).mockClear();
+    (handleICATError as jest.Mock).mockClear();
     resetActions();
   });
 
@@ -151,9 +151,10 @@ describe('Dataset actions', () => {
     expect(actions[0]).toEqual(fetchDatasetsRequest(1));
     expect(actions[1]).toEqual(fetchDatasetsFailure('Test error message'));
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('fetchDataset action sends fetchDatasetSize actions when specified via optional parameters', async () => {
@@ -226,9 +227,11 @@ describe('Dataset actions', () => {
     expect(actions[0]).toEqual(fetchDatasetSizeRequest());
     expect(actions[1]).toEqual(fetchDatasetSizeFailure('Test error message'));
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith(
+      { message: 'Test error message' },
+      false
+    );
   });
 
   it('dispatches fetchDatasetCountRequest and fetchDatasetCountSuccess actions upon successful fetchDatasetCount action', async () => {
@@ -297,9 +300,10 @@ describe('Dataset actions', () => {
     expect(actions[0]).toEqual(fetchDatasetCountRequest(1));
     expect(actions[1]).toEqual(fetchDatasetCountFailure('Test error message'));
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('fetchDatasets applies skip and limit when specified via optional parameters', async () => {
@@ -379,9 +383,10 @@ describe('Dataset actions', () => {
       fetchDatasetDetailsFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchInvestigationDatasetsCountRequest and fetchInvestigationDatasetsCountSuccess actions upon successful fetchInvestigationDatasetsCount action', async () => {
@@ -444,9 +449,11 @@ describe('Dataset actions', () => {
       fetchInvestigationDatasetsCountFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith(
+      { message: 'Test error message' },
+      false
+    );
   });
 
   it('dispatches downloadDatasetRequest and clicks on IDS link upon downloadDataset action', async () => {

--- a/packages/datagateway-common/src/state/actions/datasets.tsx
+++ b/packages/datagateway-common/src/state/actions/datasets.tsx
@@ -32,10 +32,10 @@ import { batch } from 'react-redux';
 import axios from 'axios';
 import { getApiFilter } from '.';
 import { fetchDatasetDatafilesCount } from './datafiles';
-import * as log from 'loglevel';
 import { IndexRange } from 'react-virtualized';
 import { Dataset } from '../../app.types';
 import { readSciGatewayToken } from '../../parseTokens';
+import handleICATError from '../../handleICATError';
 
 export const fetchDatasetsSuccess = (
   datasets: Dataset[],
@@ -119,7 +119,7 @@ export const fetchDatasetSize = (
           dispatch(fetchDatasetSizeSuccess(datasetId, response.data));
         })
         .catch(error => {
-          log.error(error.message);
+          handleICATError(error, false);
           dispatch(fetchDatasetSizeFailure(error.message));
         });
     }
@@ -188,7 +188,7 @@ export const fetchDatasets = ({
         }
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchDatasetsFailure(error.message));
       });
   };
@@ -249,7 +249,7 @@ export const fetchDatasetCount = (
         dispatch(fetchDatasetCountSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchDatasetCountFailure(error.message));
       });
   };
@@ -386,7 +386,7 @@ export const fetchInvestigationDatasetsCount = (
           );
         })
         .catch(error => {
-          log.error(error.message);
+          handleICATError(error, false);
           dispatch(fetchInvestigationDatasetsCountFailure(error.message));
         });
     }
@@ -439,7 +439,7 @@ export const fetchDatasetDetails = (
         dispatch(fetchDatasetDetailsSuccess(response.data));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchDatasetDetailsFailure(error.message));
       });
   };

--- a/packages/datagateway-common/src/state/actions/datasets.tsx
+++ b/packages/datagateway-common/src/state/actions/datasets.tsx
@@ -35,6 +35,7 @@ import { fetchDatasetDatafilesCount } from './datafiles';
 import * as log from 'loglevel';
 import { IndexRange } from 'react-virtualized';
 import { Dataset } from '../../app.types';
+import { readSciGatewayToken } from '../../parseTokens';
 
 export const fetchDatasetsSuccess = (
   datasets: Dataset[],
@@ -108,8 +109,7 @@ export const fetchDatasetSize = (
       await axios
         .get(`${downloadApiUrl}/user/getSize`, {
           params: {
-            // TODO: Get session ID from somewhere else (extract from JWT)
-            sessionId: window.localStorage.getItem('icat:token'),
+            sessionId: readSciGatewayToken().sessionId,
             facilityName: 'LILS',
             entityType: 'dataset',
             entityId: datasetId,
@@ -162,7 +162,7 @@ export const fetchDatasets = ({
       .get(`${apiUrl}/datasets`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -242,7 +242,7 @@ export const fetchDatasetCount = (
       .get(`${apiUrl}/datasets/count`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -287,9 +287,8 @@ export const downloadDataset = (
 
     const { idsUrl } = getState().dgcommon.urls;
 
-    // TODO: get ICAT session id properly when auth is sorted
     const params = {
-      sessionId: window.localStorage.getItem('icat:token'),
+      sessionId: readSciGatewayToken().sessionId,
       datasetIds: datasetId,
       compress: false,
       zip: true,
@@ -373,9 +372,7 @@ export const fetchInvestigationDatasetsCount = (
         .get(`${apiUrl}/datasets/count`, {
           params,
           headers: {
-            Authorization: `Bearer ${window.localStorage.getItem(
-              'daaas:token'
-            )}`,
+            Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
           },
           cancelToken: source.token,
         })
@@ -435,7 +432,7 @@ export const fetchDatasetDetails = (
       .get(`${apiUrl}/datasets`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {

--- a/packages/datagateway-common/src/state/actions/facilityCycles.test.tsx
+++ b/packages/datagateway-common/src/state/actions/facilityCycles.test.tsx
@@ -12,16 +12,17 @@ import { StateType } from '../app.types';
 import { initialState } from '../reducers/dgcommon.reducer';
 import axios from 'axios';
 import { actions, dispatch, getState, resetActions } from '../../setupTests';
-import * as log from 'loglevel';
 import { FacilityCycle } from '../../app.types';
+import handleICATError from '../../handleICATError';
 
-jest.mock('loglevel');
+jest.mock('../../handleICATError');
 
 describe('FacilityCycle actions', () => {
   Date.now = jest.fn().mockImplementation(() => 1);
 
   afterEach(() => {
     (axios.get as jest.Mock).mockClear();
+    (handleICATError as jest.Mock).mockClear();
     resetActions();
   });
 
@@ -104,9 +105,10 @@ describe('FacilityCycle actions', () => {
       fetchFacilityCyclesFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchFacilityCycleCountRequest and fetchFacilityCycleCountSuccess actions upon successful fetchFacilityCycleCount action', async () => {
@@ -171,9 +173,10 @@ describe('FacilityCycle actions', () => {
       fetchFacilityCycleCountFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('fetchFacilityCycles applies skip and limit when specified via optional parameters', async () => {

--- a/packages/datagateway-common/src/state/actions/facilityCycles.tsx
+++ b/packages/datagateway-common/src/state/actions/facilityCycles.tsx
@@ -13,10 +13,10 @@ import {
 import { ActionType, ThunkResult } from '../app.types';
 import axios from 'axios';
 import { getApiFilter } from '.';
-import * as log from 'loglevel';
 import { FacilityCycle } from '../../app.types';
 import { IndexRange } from 'react-virtualized';
 import { readSciGatewayToken } from '../../parseTokens';
+import handleICATError from '../../handleICATError';
 
 export const fetchFacilityCyclesSuccess = (
   facilityCycles: FacilityCycle[],
@@ -77,7 +77,7 @@ export const fetchFacilityCycles = (
         dispatch(fetchFacilityCyclesSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchFacilityCyclesFailure(error.message));
       });
   };
@@ -134,7 +134,7 @@ export const fetchFacilityCycleCount = (
         dispatch(fetchFacilityCycleCountSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchFacilityCycleCountFailure(error.message));
       });
   };

--- a/packages/datagateway-common/src/state/actions/facilityCycles.tsx
+++ b/packages/datagateway-common/src/state/actions/facilityCycles.tsx
@@ -16,6 +16,7 @@ import { getApiFilter } from '.';
 import * as log from 'loglevel';
 import { FacilityCycle } from '../../app.types';
 import { IndexRange } from 'react-virtualized';
+import { readSciGatewayToken } from '../../parseTokens';
 
 export const fetchFacilityCyclesSuccess = (
   facilityCycles: FacilityCycle[],
@@ -69,7 +70,7 @@ export const fetchFacilityCycles = (
       .get(`${apiUrl}/instruments/${instrumentId}/facilitycycles`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -126,7 +127,7 @@ export const fetchFacilityCycleCount = (
       .get(`${apiUrl}/instruments/${instrumentId}/facilitycycles/count`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {

--- a/packages/datagateway-common/src/state/actions/instruments.test.tsx
+++ b/packages/datagateway-common/src/state/actions/instruments.test.tsx
@@ -16,16 +16,17 @@ import { StateType } from '../app.types';
 import { initialState } from '../reducers/dgcommon.reducer';
 import axios from 'axios';
 import { actions, dispatch, getState, resetActions } from '../../setupTests';
-import * as log from 'loglevel';
 import { Instrument } from '../../app.types';
+import handleICATError from '../../handleICATError';
 
-jest.mock('loglevel');
+jest.mock('../../handleICATError');
 
 describe('Instrument actions', () => {
   Date.now = jest.fn().mockImplementation(() => 1);
 
   afterEach(() => {
     (axios.get as jest.Mock).mockClear();
+    (handleICATError as jest.Mock).mockClear();
     resetActions();
   });
 
@@ -100,9 +101,10 @@ describe('Instrument actions', () => {
     expect(actions[0]).toEqual(fetchInstrumentsRequest(1));
     expect(actions[1]).toEqual(fetchInstrumentsFailure('Test error message'));
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('fetchInstruments applies skip and limit when specified via optional parameters', async () => {
@@ -185,9 +187,10 @@ describe('Instrument actions', () => {
       fetchInstrumentCountFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchInstrumentDetailsRequest and fetchInstrumentDetailsSuccess actions upon successful fetchInstrumentDetails action', async () => {
@@ -246,8 +249,9 @@ describe('Instrument actions', () => {
       fetchInstrumentDetailsFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 });

--- a/packages/datagateway-common/src/state/actions/instruments.tsx
+++ b/packages/datagateway-common/src/state/actions/instruments.tsx
@@ -21,6 +21,7 @@ import * as log from 'loglevel';
 import { Instrument } from '../../app.types';
 import { Action } from 'redux';
 import { IndexRange } from 'react-virtualized';
+import { readSciGatewayToken } from '../../parseTokens';
 
 export const fetchInstrumentsSuccess = (
   instruments: Instrument[],
@@ -73,7 +74,7 @@ export const fetchInstruments = (
       .get(`${apiUrl}/instruments`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -128,7 +129,7 @@ export const fetchInstrumentCount = (): ThunkResult<Promise<void>> => {
       .get(`${apiUrl}/instruments/count`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -180,7 +181,7 @@ export const fetchInstrumentDetails = (
       .get(`${apiUrl}/instruments`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {

--- a/packages/datagateway-common/src/state/actions/instruments.tsx
+++ b/packages/datagateway-common/src/state/actions/instruments.tsx
@@ -17,11 +17,11 @@ import {
 import { ActionType, ThunkResult } from '../app.types';
 import axios from 'axios';
 import { getApiFilter } from '.';
-import * as log from 'loglevel';
 import { Instrument } from '../../app.types';
 import { Action } from 'redux';
 import { IndexRange } from 'react-virtualized';
 import { readSciGatewayToken } from '../../parseTokens';
+import handleICATError from '../../handleICATError';
 
 export const fetchInstrumentsSuccess = (
   instruments: Instrument[],
@@ -81,7 +81,7 @@ export const fetchInstruments = (
         dispatch(fetchInstrumentsSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInstrumentsFailure(error.message));
       });
   };
@@ -136,7 +136,7 @@ export const fetchInstrumentCount = (): ThunkResult<Promise<void>> => {
         dispatch(fetchInstrumentCountSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInstrumentCountFailure(error.message));
       });
   };
@@ -188,7 +188,7 @@ export const fetchInstrumentDetails = (
         dispatch(fetchInstrumentDetailsSuccess(response.data));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInstrumentDetailsFailure(error.message));
       });
   };

--- a/packages/datagateway-common/src/state/actions/investigations.test.tsx
+++ b/packages/datagateway-common/src/state/actions/investigations.test.tsx
@@ -22,11 +22,11 @@ import { StateType, EntityCache } from '../app.types';
 import { initialState } from '../reducers/dgcommon.reducer';
 import axios from 'axios';
 import { actions, dispatch, getState, resetActions } from '../../setupTests';
-import * as log from 'loglevel';
 import { Investigation } from '../../app.types';
 import { fetchInvestigationDatasetsCountRequest } from './datasets';
+import handleICATError from '../../handleICATError';
 
-jest.mock('loglevel');
+jest.mock('../../handleICATError');
 
 describe('Investigation actions', () => {
   Date.now = jest.fn().mockImplementation(() => 1);
@@ -95,6 +95,7 @@ describe('Investigation actions', () => {
 
   afterEach(() => {
     (axios.get as jest.Mock).mockClear();
+    (handleICATError as jest.Mock).mockClear();
     resetActions();
   });
 
@@ -226,9 +227,10 @@ describe('Investigation actions', () => {
       fetchInvestigationsFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchInvestigationsRequest and fetchInvestigationsSuccess actions upon successful fetchISISInvestigations action', async () => {
@@ -319,9 +321,11 @@ describe('Investigation actions', () => {
       fetchInvestigationSizeFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith(
+      { message: 'Test error message' },
+      false
+    );
   });
 
   it('fetchISISInvestigations action applies filters and sort state to request params', async () => {
@@ -381,9 +385,10 @@ describe('Investigation actions', () => {
       fetchInvestigationsFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchInvestigationDetailsRequest and fetchInvestigationDetailsSuccess actions upon successful fetchInvestigationDetails action', async () => {
@@ -455,9 +460,10 @@ describe('Investigation actions', () => {
       fetchInvestigationDetailsFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchInvestigationCountRequest and fetchInvestigationCountSuccess actions upon successful fetchInvestigationCount action', async () => {
@@ -526,9 +532,10 @@ describe('Investigation actions', () => {
       fetchInvestigationCountFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 
   it('dispatches fetchInvestigationCountRequest and fetchInvestigationCountSuccess actions upon successful fetchISISInvestigationCount action', async () => {
@@ -594,8 +601,9 @@ describe('Investigation actions', () => {
       fetchInvestigationCountFailure('Test error message')
     );
 
-    expect(log.error).toHaveBeenCalled();
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual('Test error message');
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
   });
 });

--- a/packages/datagateway-common/src/state/actions/investigations.tsx
+++ b/packages/datagateway-common/src/state/actions/investigations.tsx
@@ -27,6 +27,7 @@ import { fetchInvestigationDatasetsCount } from './datasets';
 import * as log from 'loglevel';
 import { Investigation } from '../../app.types';
 import { IndexRange } from 'react-virtualized';
+import { readSciGatewayToken } from '../../parseTokens';
 
 export const fetchInvestigationsSuccess = (
   investigations: Investigation[],
@@ -106,8 +107,7 @@ export const fetchInvestigationSize = (
       await axios
         .get(`${downloadApiUrl}/user/getSize`, {
           params: {
-            // TODO: Get session ID from somewhere else (extract from JWT)
-            sessionId: window.localStorage.getItem('icat:token'),
+            sessionId: readSciGatewayToken().sessionId,
             facilityName: 'LILS',
             entityType: 'investigation',
             entityId: investigationId,
@@ -170,7 +170,7 @@ export const fetchInvestigations = (
       .get(`${apiUrl}/investigations`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -231,9 +231,7 @@ export const fetchISISInvestigations = ({
         {
           params,
           headers: {
-            Authorization: `Bearer ${window.localStorage.getItem(
-              'daaas:token'
-            )}`,
+            Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
           },
         }
       )
@@ -319,7 +317,7 @@ export const fetchInvestigationDetails = (
       .get(`${apiUrl}/investigations`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -367,7 +365,7 @@ export const fetchInvestigationCount = (
       .get(`${apiUrl}/investigations/count`, {
         params,
         headers: {
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -399,9 +397,7 @@ export const fetchISISInvestigationCount = (
         {
           params,
           headers: {
-            Authorization: `Bearer ${window.localStorage.getItem(
-              'daaas:token'
-            )}`,
+            Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
           },
         }
       )

--- a/packages/datagateway-common/src/state/actions/investigations.tsx
+++ b/packages/datagateway-common/src/state/actions/investigations.tsx
@@ -24,10 +24,10 @@ import { batch } from 'react-redux';
 import axios from 'axios';
 import { getApiFilter } from '.';
 import { fetchInvestigationDatasetsCount } from './datasets';
-import * as log from 'loglevel';
 import { Investigation } from '../../app.types';
 import { IndexRange } from 'react-virtualized';
 import { readSciGatewayToken } from '../../parseTokens';
+import handleICATError from '../../handleICATError';
 
 export const fetchInvestigationsSuccess = (
   investigations: Investigation[],
@@ -119,7 +119,7 @@ export const fetchInvestigationSize = (
           );
         })
         .catch(error => {
-          log.error(error.message);
+          handleICATError(error, false);
           dispatch(fetchInvestigationSizeFailure(error.message));
         });
     }
@@ -184,7 +184,7 @@ export const fetchInvestigations = (
         }
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInvestigationsFailure(error.message));
       });
   };
@@ -249,7 +249,7 @@ export const fetchISISInvestigations = ({
         }
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInvestigationsFailure(error.message));
       });
   };
@@ -324,7 +324,7 @@ export const fetchInvestigationDetails = (
         dispatch(fetchInvestigationDetailsSuccess(response.data));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInvestigationDetailsFailure(error.message));
       });
   };
@@ -372,7 +372,7 @@ export const fetchInvestigationCount = (
         dispatch(fetchInvestigationCountSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInvestigationCountFailure(error.message));
       });
   };
@@ -405,7 +405,7 @@ export const fetchISISInvestigationCount = (
         dispatch(fetchInvestigationCountSuccess(response.data, timestamp));
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error);
         dispatch(fetchInvestigationCountFailure(error.message));
       });
   };

--- a/packages/datagateway-download/cypress/support/commands.js
+++ b/packages/datagateway-download/cypress/support/commands.js
@@ -1,3 +1,5 @@
+import { readSciGatewayToken } from 'datagateway-common';
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -56,7 +58,7 @@ Cypress.Commands.add('clearDownloadCart', () => {
     url:
       'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat/user/cart/LILS/cartItems',
     qs: {
-      sessionId: window.localStorage.getItem('icat:token'),
+      sessionId: readSciGatewayToken().sessionId,
       items: '*',
     },
   });
@@ -77,7 +79,7 @@ Cypress.Commands.add('seedDownloadCart', () => {
     url:
       'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat/user/cart/LILS/cartItems',
     body: {
-      sessionId: window.localStorage.getItem('icat:token'),
+      sessionId: readSciGatewayToken().sessionId,
       items,
     },
     form: true,
@@ -93,7 +95,7 @@ Cypress.Commands.add('addCartItem', cartItem => {
     url:
       'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat/user/cart/LILS/cartItems',
     body: {
-      sessionId: window.localStorage.getItem('icat:token'),
+      sessionId: readSciGatewayToken().sessionId,
       items: cartItem,
     },
     form: true,

--- a/packages/datagateway-download/cypress/support/commands.js
+++ b/packages/datagateway-download/cypress/support/commands.js
@@ -1,5 +1,3 @@
-import { readSciGatewayToken } from 'datagateway-common';
-
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -26,27 +24,52 @@ import { readSciGatewayToken } from 'datagateway-common';
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+import jsrsasign from 'jsrsasign';
+
+const parseJwt = token => {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const payload = decodeURIComponent(
+    atob(base64).replace(/(.)/g, function(m, p) {
+      var code = p
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase();
+      return '%' + ('00' + code).slice(-2);
+    })
+  );
+  return payload;
+};
+
+export const readSciGatewayToken = () => {
+  const token = window.localStorage.getItem('scigateway:token');
+  let sessionId = null;
+  let username = null;
+  if (token) {
+    const parsedToken = JSON.parse(parseJwt(token));
+    if (parsedToken.sessionId) sessionId = parsedToken.sessionId;
+    if (parsedToken.username) username = parsedToken.username;
+  }
+
+  return {
+    sessionId,
+    username,
+  };
+};
+
 Cypress.Commands.add('login', (username, password) => {
   cy.request('POST', `http://scigateway-preprod.esc.rl.ac.uk:5000/sessions`, {
     username: username,
     password: password,
   }).then(response => {
-    window.localStorage.setItem('daaas:token', response.body.sessionID);
-  });
+    const jwtHeader = { alg: 'HS256', typ: 'JWT' };
+    const payload = {
+      sessionId: response.body.sessionID,
+      username: 'test',
+    };
+    const jwt = jsrsasign.KJUR.jws.JWS.sign('HS256', jwtHeader, payload, 'shh');
 
-  // TODO: replace with getting from daaas:token when supported
-  cy.request({
-    method: 'POST',
-    url: 'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/session',
-    body: {
-      json: JSON.stringify({
-        plugin: 'simple',
-        credentials: [{ username: 'root' }, { password: 'pw' }],
-      }),
-    },
-    form: true,
-  }).then(response => {
-    window.localStorage.setItem('icat:token', response.body.sessionId);
+    window.localStorage.setItem('scigateway:token', jwt);
   });
 });
 

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@craco/craco": "^5.5.0",
+    "@types/jsrsasign": "^8.0.2",
     "@types/lodash.chunk": "^4.2.6",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
@@ -43,6 +44,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.5.0",
+    "jsrsasign": "^8.0.12",
     "lint-staged": "^9.2.1",
     "prettier": "^1.18.2",
     "serve": "^11.1.0",

--- a/packages/datagateway-download/src/downloadCart/downloadCartApi.test.ts
+++ b/packages/datagateway-download/src/downloadCart/downloadCartApi.test.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import axios from 'axios';
 import {
   fetchDownloadCartItems,
@@ -13,12 +12,23 @@ import {
   getDownload,
   downloadPreparedCart,
 } from './downloadCartApi';
-import * as log from 'loglevel';
-import { DownloadCartItem } from 'datagateway-common';
+import { DownloadCartItem, handleICATError } from 'datagateway-common';
 
-jest.mock('loglevel');
+jest.mock('datagateway-common', () => {
+  const originalModule = jest.requireActual('datagateway-common');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    handleICATError: jest.fn(),
+  };
+});
 
 describe('Download Cart API functions test', () => {
+  afterEach(() => {
+    (handleICATError as jest.Mock).mockClear();
+  });
+
   describe('fetchDownloadCartItems', () => {
     it('returns cartItems upon successful response', async () => {
       const downloadCartMockData = {
@@ -80,8 +90,10 @@ describe('Download Cart API functions test', () => {
         'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat/user/cart/LILS',
         { params: { sessionId: null } }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -122,8 +134,10 @@ describe('Download Cart API functions test', () => {
         'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat/user/cart/LILS/cartItems',
         { params: { sessionId: null, items: '*' } }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -164,8 +178,10 @@ describe('Download Cart API functions test', () => {
         'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat/user/cart/LILS/cartItems',
         { params: { sessionId: null, items: 'investigation 1' } }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -200,8 +216,13 @@ describe('Download Cart API functions test', () => {
       expect(axios.get).toHaveBeenCalledWith(
         'https://scigateway-preprod.esc.rl.ac.uk:8181/ids/isTwoLevel'
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith(
+        {
+          message: 'Test error message',
+        },
+        false
+      );
     });
   });
 
@@ -267,8 +288,10 @@ describe('Download Cart API functions test', () => {
         'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat/user/cart/LILS/submit',
         params
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -341,8 +364,10 @@ describe('Download Cart API functions test', () => {
           },
         }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith({
+        message: 'Test error message',
+      });
     });
   });
 
@@ -406,8 +431,13 @@ describe('Download Cart API functions test', () => {
           headers: { Authorization: 'Bearer null' },
         }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith(
+        {
+          message: 'Test error message',
+        },
+        false
+      );
     });
 
     it('returns a number upon successful response for non-datafile entityType', async () => {
@@ -456,8 +486,13 @@ describe('Download Cart API functions test', () => {
           },
         }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith(
+        {
+          message: 'Test error message',
+        },
+        false
+      );
     });
   });
 
@@ -518,8 +553,13 @@ describe('Download Cart API functions test', () => {
           headers: { Authorization: 'Bearer null' },
         }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith(
+        {
+          message: 'Test error message',
+        },
+        false
+      );
     });
 
     it('returns a number upon successful response for investigation entityType', async () => {
@@ -574,8 +614,13 @@ describe('Download Cart API functions test', () => {
           headers: { Authorization: 'Bearer null' },
         }
       );
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('Test error message');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith(
+        {
+          message: 'Test error message',
+        },
+        false
+      );
     });
   });
 
@@ -629,8 +674,13 @@ describe('Download Cart API functions test', () => {
 
       expect(returnData).toBe(3);
       expect(axios.get).toHaveBeenCalledTimes(3);
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('simulating a failed response');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith(
+        {
+          message: 'simulating a failed response',
+        },
+        false
+      );
     });
   });
 
@@ -694,8 +744,13 @@ describe('Download Cart API functions test', () => {
 
       expect(returnData).toBe(3);
       expect(axios.get).toHaveBeenCalledTimes(4);
-      expect(log.error).toHaveBeenCalled();
-      expect(log.error).toHaveBeenCalledWith('simulating a failed response');
+      expect(handleICATError).toHaveBeenCalled();
+      expect(handleICATError).toHaveBeenCalledWith(
+        {
+          message: 'simulating a failed response',
+        },
+        false
+      );
     });
   });
 });

--- a/packages/datagateway-download/src/downloadCart/downloadCartApi.ts
+++ b/packages/datagateway-download/src/downloadCart/downloadCartApi.ts
@@ -7,6 +7,7 @@ import {
   Datafile,
   Download,
   readSciGatewayToken,
+  handleICATError,
 } from 'datagateway-common';
 
 // TODO: get URLs from settings or something...
@@ -25,7 +26,7 @@ export const fetchDownloadCartItems: () => Promise<DownloadCartItem[]> = () => {
       return response.data.cartItems;
     })
     .catch(error => {
-      log.error(error.message);
+      handleICATError(error);
       return [];
     });
 };
@@ -39,9 +40,7 @@ export const removeAllDownloadCartItems: () => Promise<void> = () => {
       },
     })
     .then(() => {})
-    .catch(error => {
-      log.error(error.message);
-    });
+    .catch(handleICATError);
 };
 
 export const removeDownloadCartItem: (
@@ -56,9 +55,7 @@ export const removeDownloadCartItem: (
       },
     })
     .then(() => {})
-    .catch(error => {
-      log.error(error.message);
-    });
+    .catch(handleICATError);
 };
 
 export const getIsTwoLevel: () => Promise<boolean> = () => {
@@ -68,7 +65,7 @@ export const getIsTwoLevel: () => Promise<boolean> = () => {
       return response.data;
     })
     .catch(error => {
-      log.error(error.message);
+      handleICATError(error, false);
       return false;
     });
 };
@@ -105,7 +102,7 @@ export const submitCart: (
       return downloadId;
     })
     .catch(error => {
-      log.error(error.message);
+      handleICATError(error);
       return -1;
     });
 };
@@ -127,7 +124,7 @@ export const getDownload: (
       return download;
     })
     .catch(error => {
-      log.error(error.message);
+      handleICATError(error);
       return null;
     });
 };
@@ -174,7 +171,7 @@ export const getSize: (
         return size;
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error, false);
         return -1;
       });
   } else {
@@ -191,7 +188,7 @@ export const getSize: (
         return response.data;
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error, false);
         return -1;
       });
   }
@@ -221,7 +218,7 @@ export const getDatafileCount: (
         return response.data;
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error, false);
         return -1;
       });
   } else {
@@ -243,7 +240,7 @@ export const getDatafileCount: (
         return response.data;
       })
       .catch(error => {
-        log.error(error.message);
+        handleICATError(error, false);
         return -1;
       });
   }

--- a/packages/datagateway-download/src/downloadCart/downloadCartApi.ts
+++ b/packages/datagateway-download/src/downloadCart/downloadCartApi.ts
@@ -6,6 +6,7 @@ import {
   DownloadCartItem,
   Datafile,
   Download,
+  readSciGatewayToken,
 } from 'datagateway-common';
 
 // TODO: get URLs from settings or something...
@@ -17,8 +18,7 @@ export const fetchDownloadCartItems: () => Promise<DownloadCartItem[]> = () => {
   return axios
     .get<DownloadCart>(`${topcatUrl}/user/cart/LILS`, {
       params: {
-        // TODO: get session ID from somewhere else (extract from JWT)
-        sessionId: window.localStorage.getItem('icat:token'),
+        sessionId: readSciGatewayToken().sessionId,
       },
     })
     .then(response => {
@@ -34,8 +34,7 @@ export const removeAllDownloadCartItems: () => Promise<void> = () => {
   return axios
     .delete(`${topcatUrl}/user/cart/LILS/cartItems`, {
       params: {
-        // TODO: get session ID from somewhere else (extract from JWT)
-        sessionId: window.localStorage.getItem('icat:token'),
+        sessionId: readSciGatewayToken().sessionId,
         items: '*',
       },
     })
@@ -52,8 +51,7 @@ export const removeDownloadCartItem: (
   return axios
     .delete(`${topcatUrl}/user/cart/LILS/cartItems`, {
       params: {
-        // TODO: get session ID from somewhere else (extract from JWT)
-        sessionId: window.localStorage.getItem('icat:token'),
+        sessionId: readSciGatewayToken().sessionId,
         items: `${entityType} ${entityId}`,
       },
     })
@@ -88,9 +86,8 @@ export const submitCart: (
 ) => {
   const params = new URLSearchParams();
 
-  // TODO: get session ID from somewhere else (extract from JWT)
   // Construct the form parameters.
-  params.append('sessionId', window.localStorage.getItem('icat:token') || '');
+  params.append('sessionId', readSciGatewayToken().sessionId || '');
   params.append('transport', transport);
   params.append('email', emailAddress);
   params.append('fileName', fileName);
@@ -120,8 +117,7 @@ export const getDownload: (
   return axios
     .get<Download[]>(`${topcatUrl}/user/downloads`, {
       params: {
-        // TODO: get session ID from somewhere else (extract from JWT)
-        sessionId: window.localStorage.getItem('icat:token'),
+        sessionId: readSciGatewayToken().sessionId,
         facilityName: facilityName,
         queryOffset: `where download.id = ${downloadId}`,
       },
@@ -143,7 +139,7 @@ export const downloadPreparedCart: (
   // We need to set the preparedId and outname query parameters
   // for the IDS download.
   const params = {
-    sessionId: window.localStorage.getItem('icat:token'),
+    sessionId: readSciGatewayToken().sessionId,
     preparedId: preparedId,
     outname: fileName,
   };
@@ -170,8 +166,7 @@ export const getSize: (
     return axios
       .get<Datafile>(`${apiUrl}/datafiles/${entityId}`, {
         headers: {
-          // TODO: get session ID from somewhere else (extract from JWT)
-          Authorization: `Bearer ${window.localStorage.getItem('icat:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -186,8 +181,7 @@ export const getSize: (
     return axios
       .get<number>(`${topcatUrl}/user/getSize`, {
         params: {
-          // TODO: get session ID from somewhere else (extract from JWT)
-          sessionId: window.localStorage.getItem('icat:token'),
+          sessionId: readSciGatewayToken().sessionId,
           facilityName: 'LILS',
           entityType: entityType,
           entityId: entityId,
@@ -220,8 +214,7 @@ export const getDatafileCount: (
           },
         },
         headers: {
-          // TODO: get session ID from somewhere else (extract from JWT)
-          Authorization: `Bearer ${window.localStorage.getItem('icat:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {
@@ -243,8 +236,7 @@ export const getDatafileCount: (
           },
         },
         headers: {
-          // TODO: get session ID from somewhere else (extract from JWT)
-          Authorization: `Bearer ${window.localStorage.getItem('icat:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {

--- a/packages/datagateway-download/src/index.tsx
+++ b/packages/datagateway-download/src/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import axios from 'axios';
+import jsrsasign from 'jsrsasign';
 
 import singleSpaReact from 'single-spa-react';
 
@@ -67,7 +68,7 @@ if (
   render();
 
   if (process.env.NODE_ENV === `development`) {
-    // TODO: replace with getting from daaas:token when supported
+    // TODO: get url from settings file
     const icatUrl = `https://scigateway-preprod.esc.rl.ac.uk:8181/icat`;
     axios
       .post(
@@ -83,9 +84,21 @@ if (
         }
       )
       .then(response => {
-        window.localStorage.setItem('icat:token', response.data.sessionId);
+        const jwtHeader = { alg: 'HS256', typ: 'JWT' };
+        const payload = {
+          sessionId: response.data.sessionId,
+          username: 'dev',
+        };
+        const jwt = jsrsasign.KJUR.jws.JWS.sign(
+          'HS256',
+          jwtHeader,
+          payload,
+          'shh'
+        );
+
+        window.localStorage.setItem('scigateway:token', jwt);
       })
-      .catch(error => console.error("Can't log in to ICAT"));
+      .catch(error => console.error(`Can't log in to ICAT: ${error.message}`));
   }
 }
 

--- a/packages/datagateway-search/cypress/support/commands.js
+++ b/packages/datagateway-search/cypress/support/commands.js
@@ -24,6 +24,39 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+import jsrsasign from 'jsrsasign';
+
+const parseJwt = token => {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const payload = decodeURIComponent(
+    atob(base64).replace(/(.)/g, function(m, p) {
+      var code = p
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase();
+      return '%' + ('00' + code).slice(-2);
+    })
+  );
+  return payload;
+};
+
+export const readSciGatewayToken = () => {
+  const token = window.localStorage.getItem('scigateway:token');
+  let sessionId = null;
+  let username = null;
+  if (token) {
+    const parsedToken = JSON.parse(parseJwt(token));
+    if (parsedToken.sessionId) sessionId = parsedToken.sessionId;
+    if (parsedToken.username) username = parsedToken.username;
+  }
+
+  return {
+    sessionId,
+    username,
+  };
+};
+
 Cypress.Commands.add('login', (username, password) => {
   return cy
     .request('POST', 'http://scigateway-preprod.esc.rl.ac.uk:5000', {
@@ -31,6 +64,18 @@ Cypress.Commands.add('login', (username, password) => {
       password: password,
     })
     .then(response => {
-      window.localStorage.setItem('daaas:token', response.body.sessionID);
+      const jwtHeader = { alg: 'HS256', typ: 'JWT' };
+      const payload = {
+        sessionId: response.body.sessionID,
+        username: 'test',
+      };
+      const jwt = jsrsasign.KJUR.jws.JWS.sign(
+        'HS256',
+        jwtHeader,
+        payload,
+        'shh'
+      );
+
+      window.localStorage.setItem('scigateway:token', jwt);
     });
 });

--- a/packages/datagateway-search/package.json
+++ b/packages/datagateway-search/package.json
@@ -5,7 +5,6 @@
   "proxy": "http://scigateway-preprod.esc.rl.ac.uk:5000/",
   "dependencies": {
     "@date-io/date-fns": "^1.3.11",
-    "date-fns": "^2.2.1",
     "@material-ui/core": "^4.6.0",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/pickers": "^3.2.7",
@@ -17,6 +16,7 @@
     "connected-react-router": "^6.5.2",
     "custom-event-polyfill": "^1.0.7",
     "datagateway-common": "0.1.0",
+    "date-fns": "^2.2.1",
     "loglevel": "^1.6.3",
     "react": "^16.11.0",
     "react-app-polyfill": "^1.0.1",
@@ -86,6 +86,7 @@
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.3",
+    "@types/jsrsasign": "^8.0.2",
     "@types/loglevel": "^1.6.3",
     "@types/react-redux": "^7.1.1",
     "@types/react-router": "^5.0.3",
@@ -114,6 +115,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.5.0",
     "express": "^4.17.1",
+    "jsrsasign": "^8.0.12",
     "lint-staged": "^9.2.1",
     "prettier": "^1.18.2",
     "react-scripts-rewired": "3.0.1--latest1",

--- a/packages/datagateway-search/src/search/searchButton.component.tsx
+++ b/packages/datagateway-search/src/search/searchButton.component.tsx
@@ -5,6 +5,7 @@ import Button from '@material-ui/core/Button';
 import axios from 'axios';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import { format } from 'date-fns';
+import { readSciGatewayToken } from 'datagateway-common';
 
 interface SearchButtonStoreProps {
   searchText: string;
@@ -81,7 +82,7 @@ class SearchButton extends React.Component<SearchButtonCombinedProps> {
     }
 
     const queryParams = {
-      sessionId: window.localStorage.getItem('icat:token'),
+      sessionId: readSciGatewayToken().sessionId,
       query,
       maxCount: 300,
     };

--- a/packages/datagateway-table/cypress/support/commands.js
+++ b/packages/datagateway-table/cypress/support/commands.js
@@ -24,7 +24,38 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-import { readSciGatewayToken } from 'datagateway-common';
+import jsrsasign from 'jsrsasign';
+
+const parseJwt = token => {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const payload = decodeURIComponent(
+    atob(base64).replace(/(.)/g, function(m, p) {
+      var code = p
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase();
+      return '%' + ('00' + code).slice(-2);
+    })
+  );
+  return payload;
+};
+
+export const readSciGatewayToken = () => {
+  const token = window.localStorage.getItem('scigateway:token');
+  let sessionId = null;
+  let username = null;
+  if (token) {
+    const parsedToken = JSON.parse(parseJwt(token));
+    if (parsedToken.sessionId) sessionId = parsedToken.sessionId;
+    if (parsedToken.username) username = parsedToken.username;
+  }
+
+  return {
+    sessionId,
+    username,
+  };
+};
 
 Cypress.Commands.add('login', (username, password) => {
   return cy.readFile('server/e2e-settings.json').then(settings => {
@@ -32,24 +63,19 @@ Cypress.Commands.add('login', (username, password) => {
       username: username,
       password: password,
     }).then(response => {
-      window.localStorage.setItem('daaas:token', response.body.sessionID);
-    });
+      const jwtHeader = { alg: 'HS256', typ: 'JWT' };
+      const payload = {
+        sessionId: response.body.sessionID,
+        username: 'test',
+      };
+      const jwt = jsrsasign.KJUR.jws.JWS.sign(
+        'HS256',
+        jwtHeader,
+        payload,
+        'shh'
+      );
 
-    // TODO: replace with getting from daaas:token when supported
-    const splitUrl = settings.downloadApiUrl.split('/');
-    const icatUrl = `${splitUrl.slice(0, splitUrl.length - 1).join('/')}/icat`;
-    cy.request({
-      method: 'POST',
-      url: `${icatUrl}/session`,
-      body: {
-        json: JSON.stringify({
-          plugin: 'simple',
-          credentials: [{ username: 'root' }, { password: 'pw' }],
-        }),
-      },
-      form: true,
-    }).then(response => {
-      window.localStorage.setItem('icat:token', response.body.sessionId);
+      window.localStorage.setItem('scigateway:token', jwt);
     });
   });
 });

--- a/packages/datagateway-table/cypress/support/commands.js
+++ b/packages/datagateway-table/cypress/support/commands.js
@@ -24,6 +24,8 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+import { readSciGatewayToken } from 'datagateway-common';
+
 Cypress.Commands.add('login', (username, password) => {
   return cy.readFile('server/e2e-settings.json').then(settings => {
     cy.request('POST', `${settings.apiUrl}/sessions`, {
@@ -59,7 +61,7 @@ Cypress.Commands.add('clearDownloadCart', () => {
       method: 'DELETE',
       url: `${settings.downloadApiUrl}/user/cart/LILS/cartItems`,
       qs: {
-        sessionId: window.localStorage.getItem('icat:token'),
+        sessionId: readSciGatewayToken().sessionId,
         items: '*',
       },
     });

--- a/packages/datagateway-table/package.json
+++ b/packages/datagateway-table/package.json
@@ -86,6 +86,7 @@
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.3",
+    "@types/jsrsasign": "^8.0.2",
     "@types/loglevel": "^1.6.3",
     "@types/react-redux": "^7.1.1",
     "@types/react-router": "^5.0.3",
@@ -115,6 +116,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.5.0",
     "express": "^4.17.1",
+    "jsrsasign": "^8.0.12",
     "lint-staged": "^9.2.1",
     "prettier": "^1.18.2",
     "react-scripts-rewired": "3.0.1--latest1",

--- a/packages/datagateway-table/src/breadcrumbs.component.tsx
+++ b/packages/datagateway-table/src/breadcrumbs.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StateType } from './state/app.types';
-import { EntityTypes } from 'datagateway-common';
+import { EntityTypes, readSciGatewayToken } from 'datagateway-common';
 import { connect } from 'react-redux';
 
 import axios from 'axios';
@@ -416,10 +416,7 @@ class PageBreadcrumbs extends React.Component<
     entityName = await axios
       .get(requestUrl, {
         headers: {
-          // NOTE: Authorisation is specified as daaas token, however if this
-          //       is subject to change, it might be worth referencing the token
-          //       name which is stored elsewhere.
-          Authorization: `Bearer ${window.localStorage.getItem('daaas:token')}`,
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
         },
       })
       .then(response => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11732,7 +11732,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@^7.1.0, react-redux@^7.1.3:
+react-redux@^7.1.0:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.3.tgz#717a3d7bbe3a1b2d535c94885ce04cdc5a33fc79"
   integrity sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,6 +2317,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/jsrsasign@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jsrsasign/-/jsrsasign-8.0.2.tgz#39f19045f33a7e2bd09a195556c1450d2e82f4c9"
+  integrity sha512-H9E1AhOgouH0Zi7O1TAfntNXzMgFZWncB0MY/bfVs4v4gUBVsEM/ZCjBqPmw3QfsL2ZdcBb7YunXykMLpqNBhQ==
+
 "@types/lodash.chunk@^4.2.6":
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.chunk/-/lodash.chunk-4.2.6.tgz#9d35f05360b0298715d7f3d9efb34dd4f77e5d2a"
@@ -8510,6 +8515,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsrsasign@^8.0.12:
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-8.0.12.tgz#22abb9656d34a30b9530436720835e89c2e5c316"
+  integrity sha1-Iqu5ZW00owuVMENnIINeicLlwxY=
+
 jss-plugin-camel-case@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0.tgz#d601bae2e8e2041cc526add289dcd7062db0a248"
@@ -11722,7 +11732,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@^7.1.0:
+react-redux@^7.1.0, react-redux@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.3.tgz#717a3d7bbe3a1b2d535c94885ce04cdc5a33fc79"
   integrity sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==


### PR DESCRIPTION
## Description
Add utility functions that handle the parsing of `scigateway:token` and also a utility function that handles error handling so that we can invalidate tokens on authentication error responses.

## Testing instructions
- [ ] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [ ] Set up `scigateway` with `scigateway-auth` and verify everything works fine in "prod" mode - note this is best to be done over HTTP (otherwise the plugins need to be ran over HTTPs, and thus `datagateway-api`...), which will require ral-facilities/scigateway-auth#43

## Agile board tracking
Closes #111 
