### PR TITLE
Feature/calculate file size #118

### DIFF
--- a/packages/datagateway-table/cypress/integration/dls/datasets.spec.ts
+++ b/packages/datagateway-table/cypress/integration/dls/datasets.spec.ts
@@ -205,6 +205,24 @@ describe('DLS - Datasets Table', () => {
       ).should('be.visible');
     });
 
+    it('and then calculate file size', () => {
+      // need to wait for counts to finish, otherwise cypress might interact with the details panel
+      // too quickly and it rerenders during the test
+      cy.contains('[aria-rowindex="1"] [aria-colindex="4"]', '56').should(
+        'exist'
+      );
+      cy.contains('[aria-rowindex="2"] [aria-colindex="4"]', '55').should(
+        'exist'
+      );
+
+      cy.get('[aria-label="Show details"]')
+        .first()
+        .click();
+
+      cy.contains('Calculate').click();
+      cy.contains('10.72 GB').should('be.visible');
+    });
+
     it('and view the dataset type panel', () => {
       // need to wait for counts to finish, otherwise cypress might interact with the details panel
       // too quickly and it rerenders during the test

--- a/packages/datagateway-table/cypress/integration/dls/datasets.spec.ts
+++ b/packages/datagateway-table/cypress/integration/dls/datasets.spec.ts
@@ -220,7 +220,7 @@ describe('DLS - Datasets Table', () => {
         .click();
 
       cy.contains('Calculate').click();
-      cy.contains('10.72 GB').should('be.visible');
+      cy.contains('5.51 GB').should('be.visible');
     });
 
     it('and view the dataset type panel', () => {

--- a/packages/datagateway-table/cypress/integration/dls/visits.spec.ts
+++ b/packages/datagateway-table/cypress/integration/dls/visits.spec.ts
@@ -180,6 +180,20 @@ describe('DLS - Visits Table', () => {
       cy.get('[aria-label="Hide details"]').should('exist');
     });
 
+    it('and then calculate file size', () => {
+      // We need to wait for counts to finish, otherwise cypress
+      // might interact with the details panel too quickly and
+      // it re-renders during the test.
+      cy.contains('[aria-rowindex="1"] [aria-colindex="3"]', '2').should(
+        'exist'
+      );
+      cy.get('[aria-label="Show details"]')
+        .first()
+        .click();
+
+      cy.contains('Calculate').click();
+      cy.contains('10.8 GB').should('be.visible');
+    });
     // TODO: Since we only have one investigation, we cannot test
     // showing details when another row is showing details at the moment.
 

--- a/packages/datagateway-table/src/dls/detailsPanels/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-table/src/dls/detailsPanels/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`Dataset details panel component renders calculate size button when size
        
       <WithStyles(ForwardRef(Button))
         color="primary"
+        id="calculate-size-btn"
         onClick={[Function]}
         size="small"
         variant="outlined"
@@ -135,6 +136,7 @@ exports[`Dataset details panel component renders correctly 1`] = `
        
       <WithStyles(ForwardRef(Button))
         color="primary"
+        id="calculate-size-btn"
         onClick={[Function]}
         size="small"
         variant="outlined"
@@ -214,6 +216,7 @@ exports[`Dataset details panel component renders type tab when present in the da
        
       <WithStyles(ForwardRef(Button))
         color="primary"
+        id="calculate-size-btn"
         onClick={[Function]}
         size="small"
         variant="outlined"

--- a/packages/datagateway-table/src/dls/detailsPanels/__snapshots__/visitDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-table/src/dls/detailsPanels/__snapshots__/visitDetailsPanel.component.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`Visit details panel component renders calculate size button when size h
        
       <WithStyles(ForwardRef(Button))
         color="primary"
+        id="calculate-size-btn"
         onClick={[Function]}
         size="small"
         variant="outlined"

--- a/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
-import DatasetsDetailsPanel from './datasetDetailsPanel.component';
+import DatasetDetailsPanel from './datasetDetailsPanel.component';
 import { Dataset } from 'datagateway-common';
 
 describe('Dataset details panel component', () => {
@@ -9,6 +9,7 @@ describe('Dataset details panel component', () => {
   let rowData: Dataset;
   const detailsPanelResize = jest.fn();
   const fetchDetails = jest.fn();
+  const fetchSize = jest.fn();
 
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'div' });
@@ -30,10 +31,11 @@ describe('Dataset details panel component', () => {
 
   it('renders correctly', () => {
     const wrapper = shallow(
-      <DatasetsDetailsPanel
+      <DatasetDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -47,10 +49,11 @@ describe('Dataset details panel component', () => {
     };
 
     const wrapper = shallow(
-      <DatasetsDetailsPanel
+      <DatasetDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -60,10 +63,11 @@ describe('Dataset details panel component', () => {
     const { SIZE, ...rowDataWithoutSize } = rowData;
 
     const wrapper = shallow(
-      <DatasetsDetailsPanel
+      <DatasetDetailsPanel
         rowData={rowDataWithoutSize}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -73,10 +77,11 @@ describe('Dataset details panel component', () => {
     const { SIZE, ...rowDataWithoutSize } = rowData;
 
     const wrapper = mount(
-      <DatasetsDetailsPanel
+      <DatasetDetailsPanel
         rowData={rowDataWithoutSize}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 
@@ -94,10 +99,11 @@ describe('Dataset details panel component', () => {
     };
 
     const wrapper = mount(
-      <DatasetsDetailsPanel
+      <DatasetDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 
@@ -113,10 +119,11 @@ describe('Dataset details panel component', () => {
 
   it('calls fetchDetails on load', () => {
     mount(
-      <DatasetsDetailsPanel
+      <DatasetDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 

--- a/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.test.tsx
@@ -87,8 +87,8 @@ describe('Dataset details panel component', () => {
 
     wrapper.find('#dataset-details-panel button').simulate('click');
 
-    // TODO: test this calls some action that requests to getSize
-    expect(true);
+    expect(fetchSize).toHaveBeenCalled();
+    expect(fetchSize).toHaveBeenCalledWith(1);
   });
 
   it('calls detailsPanelResize on load and when tabs are switched between', () => {

--- a/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
@@ -21,12 +21,7 @@ interface DatasetDetailsPanelDispatchProps {
   fetchSize: (datasetId: number) => Promise<void>;
 }
 
-interface DatasetDetailsPanelStoreProps {
-  data: Entity[];
-}
-
 type VisitDetailsPanelCombinedProps = DatasetDetailsPanelProps &
-  DatasetDetailsPanelStoreProps &
   DatasetDetailsPanelDispatchProps;
 
 const DatasetDetailsPanel = (
@@ -132,13 +127,4 @@ const mapDispatchToProps = (
     dispatch(fetchDatasetSize(investigationId)),
 });
 
-const mapStateToProps = (state: StateType): DatasetDetailsPanelStoreProps => {
-  return {
-    data: state.dgcommon.data,
-  };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(DatasetDetailsPanel);
+export default connect(null, mapDispatchToProps)(DatasetDetailsPanel);

--- a/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
@@ -12,7 +12,7 @@ interface DatasetDetailsPanelProps {
 const DatasetDetailsPanel = (
   props: DatasetDetailsPanelProps
 ): React.ReactElement => {
-  const { rowData, detailsPanelResize, fetchDetails } = props;
+  const { rowData, detailsPanelResize, fetchDetails, fetchSize } = props;
   const [value, setValue] = React.useState<'details' | 'type'>('details');
 
   const datasetData = rowData as Dataset;
@@ -74,7 +74,6 @@ const DatasetDetailsPanel = (
           ) : (
             <Button
               onClick={() => {
-                const { fetchSize } = props;
                 fetchSize(datasetData.ID);
               }}
               variant="outlined"

--- a/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { Entity, Dataset, formatBytes } from 'datagateway-common';
+import {
+  Entity,
+  Dataset,
+  formatBytes,
+  fetchDatasetSize,
+} from 'datagateway-common';
 import { Typography, Tabs, Tab, Button } from '@material-ui/core';
+import { ThunkDispatch } from 'redux-thunk';
+import { connect } from 'react-redux';
+import { StateType } from '../../state/app.types';
+import { AnyAction } from 'redux';
 
 interface DatasetDetailsPanelProps {
   rowData: Entity;
@@ -8,8 +17,20 @@ interface DatasetDetailsPanelProps {
   fetchDetails: (datasetId: number) => Promise<void>;
 }
 
+interface DatasetDetailsPanelDispatchProps {
+  fetchSize: (datasetId: number) => Promise<void>;
+}
+
+interface DatasetDetailsPanelStoreProps {
+  data: Entity[];
+}
+
+type VisitDetailsPanelCombinedProps = DatasetDetailsPanelProps &
+  DatasetDetailsPanelStoreProps &
+  DatasetDetailsPanelDispatchProps;
+
 const DatasetDetailsPanel = (
-  props: DatasetDetailsPanelProps
+  props: VisitDetailsPanelCombinedProps
 ): React.ReactElement => {
   const { rowData, detailsPanelResize, fetchDetails } = props;
   const [value, setValue] = React.useState<'details' | 'type'>('details');
@@ -73,7 +94,8 @@ const DatasetDetailsPanel = (
           ) : (
             <Button
               onClick={() => {
-                // TODO
+                const { fetchSize } = props;
+                fetchSize(datasetData.ID);
               }}
               variant="outlined"
               color="primary"
@@ -103,4 +125,20 @@ const DatasetDetailsPanel = (
   );
 };
 
-export default DatasetDetailsPanel;
+const mapDispatchToProps = (
+  dispatch: ThunkDispatch<StateType, null, AnyAction>
+): DatasetDetailsPanelDispatchProps => ({
+  fetchSize: (investigationId: number) =>
+    dispatch(fetchDatasetSize(investigationId)),
+});
+
+const mapStateToProps = (state: StateType): DatasetDetailsPanelStoreProps => {
+  return {
+    data: state.dgcommon.data,
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DatasetDetailsPanel);

--- a/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
@@ -1,31 +1,16 @@
 import React from 'react';
-import {
-  Entity,
-  Dataset,
-  formatBytes,
-  fetchDatasetSize,
-} from 'datagateway-common';
+import { Entity, Dataset, formatBytes } from 'datagateway-common';
 import { Typography, Tabs, Tab, Button } from '@material-ui/core';
-import { ThunkDispatch } from 'redux-thunk';
-import { connect } from 'react-redux';
-import { StateType } from '../../state/app.types';
-import { AnyAction } from 'redux';
 
 interface DatasetDetailsPanelProps {
   rowData: Entity;
   detailsPanelResize: () => void;
   fetchDetails: (datasetId: number) => Promise<void>;
-}
-
-interface DatasetDetailsPanelDispatchProps {
   fetchSize: (datasetId: number) => Promise<void>;
 }
 
-type VisitDetailsPanelCombinedProps = DatasetDetailsPanelProps &
-  DatasetDetailsPanelDispatchProps;
-
 const DatasetDetailsPanel = (
-  props: VisitDetailsPanelCombinedProps
+  props: DatasetDetailsPanelProps
 ): React.ReactElement => {
   const { rowData, detailsPanelResize, fetchDetails } = props;
   const [value, setValue] = React.useState<'details' | 'type'>('details');
@@ -120,11 +105,4 @@ const DatasetDetailsPanel = (
   );
 };
 
-const mapDispatchToProps = (
-  dispatch: ThunkDispatch<StateType, null, AnyAction>
-): DatasetDetailsPanelDispatchProps => ({
-  fetchSize: (investigationId: number) =>
-    dispatch(fetchDatasetSize(investigationId)),
-});
-
-export default connect(null, mapDispatchToProps)(DatasetDetailsPanel);
+export default DatasetDetailsPanel;

--- a/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/datasetDetailsPanel.component.tsx
@@ -80,6 +80,7 @@ const DatasetDetailsPanel = (
               variant="outlined"
               color="primary"
               size="small"
+              id="calculate-size-btn"
             >
               Calculate
             </Button>

--- a/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.test.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.test.tsx
@@ -136,8 +136,8 @@ describe('Visit details panel component', () => {
 
     wrapper.find('#visit-details-panel button').simulate('click');
 
-    // TODO: test this calls some action that requests to getSize
-    expect(true);
+    expect(fetchSize).toHaveBeenCalled();
+    expect(fetchSize).toHaveBeenCalledWith(1);
   });
 
   it('calls detailsPanelResize on load and when tabs are switched between', () => {

--- a/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.test.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
-import VisitsDetailsPanel from './visitDetailsPanel.component';
+import VisitDetailsPanel from './visitDetailsPanel.component';
 import { Investigation } from 'datagateway-common';
 
 describe('Visit details panel component', () => {
@@ -9,6 +9,7 @@ describe('Visit details panel component', () => {
   let rowData: Investigation;
   const detailsPanelResize = jest.fn();
   const fetchDetails = jest.fn();
+  const fetchSize = jest.fn();
 
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'div' });
@@ -46,10 +47,11 @@ describe('Visit details panel component', () => {
 
   it('renders correctly', () => {
     const wrapper = shallow(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -96,10 +98,11 @@ describe('Visit details panel component', () => {
     ];
 
     const wrapper = shallow(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -109,10 +112,11 @@ describe('Visit details panel component', () => {
     const { SIZE, ...rowDataWithoutSize } = rowData;
 
     const wrapper = shallow(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowDataWithoutSize}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -122,10 +126,11 @@ describe('Visit details panel component', () => {
     const { SIZE, ...rowDataWithoutSize } = rowData;
 
     const wrapper = mount(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowDataWithoutSize}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 
@@ -144,10 +149,11 @@ describe('Visit details panel component', () => {
     ];
 
     const wrapper = mount(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 
@@ -163,10 +169,11 @@ describe('Visit details panel component', () => {
 
   it('calls fetchDetails on load if INVESTIGATIONUSER, SAMPLE or PUBLICATIONS are missing', () => {
     mount(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 
@@ -176,10 +183,11 @@ describe('Visit details panel component', () => {
 
     rowData.INVESTIGATIONUSER = [];
     mount(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 
@@ -189,10 +197,11 @@ describe('Visit details panel component', () => {
 
     rowData.SAMPLE = [];
     mount(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
 
@@ -202,10 +211,11 @@ describe('Visit details panel component', () => {
 
     rowData.PUBLICATION = [];
     mount(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(fetchDetails).not.toHaveBeenCalled();
@@ -222,10 +232,11 @@ describe('Visit details panel component', () => {
     ];
 
     const wrapper = shallow(
-      <VisitsDetailsPanel
+      <VisitDetailsPanel
         rowData={rowData}
         detailsPanelResize={detailsPanelResize}
         fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
       />
     );
     expect(wrapper).toMatchSnapshot();

--- a/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
@@ -21,12 +21,7 @@ interface VisitDetailsPanelDispatchProps {
   fetchSize: (datasetId: number) => Promise<void>;
 }
 
-interface VisitDetailsPanelStoreProps {
-  data: Entity[];
-}
-
 type VisitDetailsPanelCombinedProps = VisitDetailsPanelProps &
-  VisitDetailsPanelStoreProps &
   VisitDetailsPanelDispatchProps;
 
 const VisitDetailsPanel = (
@@ -205,10 +200,4 @@ const mapDispatchToProps = (
     dispatch(fetchInvestigationSize(investigationId)),
 });
 
-const mapStateToProps = (state: StateType): VisitDetailsPanelStoreProps => {
-  return {
-    data: state.dgcommon.data,
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(VisitDetailsPanel);
+export default connect(null, mapDispatchToProps)(VisitDetailsPanel);

--- a/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { Entity, Investigation, formatBytes } from 'datagateway-common';
+import {
+  Entity,
+  Investigation,
+  formatBytes,
+  fetchInvestigationSize,
+} from 'datagateway-common';
 import { Typography, Tabs, Tab, Button } from '@material-ui/core';
+import { ThunkDispatch } from 'redux-thunk';
+import { connect } from 'react-redux';
+import { StateType } from '../../state/app.types';
+import { AnyAction } from 'redux';
 
 interface VisitDetailsPanelProps {
   rowData: Entity;
@@ -8,8 +17,20 @@ interface VisitDetailsPanelProps {
   fetchDetails: (investigationId: number) => Promise<void>;
 }
 
+interface VisitDetailsPanelDispatchProps {
+  fetchSize: (datasetId: number) => Promise<void>;
+}
+
+interface VisitDetailsPanelStoreProps {
+  data: Entity[];
+}
+
+type VisitDetailsPanelCombinedProps = VisitDetailsPanelProps &
+  VisitDetailsPanelStoreProps &
+  VisitDetailsPanelDispatchProps;
+
 const VisitDetailsPanel = (
-  props: VisitDetailsPanelProps
+  props: VisitDetailsPanelCombinedProps
 ): React.ReactElement => {
   const { rowData, detailsPanelResize, fetchDetails } = props;
   const [value, setValue] = React.useState<
@@ -107,7 +128,8 @@ const VisitDetailsPanel = (
           ) : (
             <Button
               onClick={() => {
-                // TODO
+                const { fetchSize } = props;
+                fetchSize(investigationData.ID);
               }}
               variant="outlined"
               color="primary"
@@ -176,4 +198,17 @@ const VisitDetailsPanel = (
   );
 };
 
-export default VisitDetailsPanel;
+const mapDispatchToProps = (
+  dispatch: ThunkDispatch<StateType, null, AnyAction>
+): VisitDetailsPanelDispatchProps => ({
+  fetchSize: (investigationId: number) =>
+    dispatch(fetchInvestigationSize(investigationId)),
+});
+
+const mapStateToProps = (state: StateType): VisitDetailsPanelStoreProps => {
+  return {
+    data: state.dgcommon.data,
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(VisitDetailsPanel);

--- a/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
@@ -1,33 +1,18 @@
 import React from 'react';
-import {
-  Entity,
-  Investigation,
-  formatBytes,
-  fetchInvestigationSize,
-} from 'datagateway-common';
+import { Entity, Investigation, formatBytes } from 'datagateway-common';
 import { Typography, Tabs, Tab, Button } from '@material-ui/core';
-import { ThunkDispatch } from 'redux-thunk';
-import { connect } from 'react-redux';
-import { StateType } from '../../state/app.types';
-import { AnyAction } from 'redux';
 
 interface VisitDetailsPanelProps {
   rowData: Entity;
   detailsPanelResize: () => void;
   fetchDetails: (investigationId: number) => Promise<void>;
-}
-
-interface VisitDetailsPanelDispatchProps {
   fetchSize: (datasetId: number) => Promise<void>;
 }
 
-type VisitDetailsPanelCombinedProps = VisitDetailsPanelProps &
-  VisitDetailsPanelDispatchProps;
-
 const VisitDetailsPanel = (
-  props: VisitDetailsPanelCombinedProps
+  props: VisitDetailsPanelProps
 ): React.ReactElement => {
-  const { rowData, detailsPanelResize, fetchDetails } = props;
+  const { rowData, detailsPanelResize, fetchDetails, fetchSize } = props;
   const [value, setValue] = React.useState<
     'details' | 'users' | 'samples' | 'publications'
   >('details');
@@ -123,7 +108,6 @@ const VisitDetailsPanel = (
           ) : (
             <Button
               onClick={() => {
-                const { fetchSize } = props;
                 fetchSize(investigationData.ID);
               }}
               variant="outlined"
@@ -193,11 +177,4 @@ const VisitDetailsPanel = (
   );
 };
 
-const mapDispatchToProps = (
-  dispatch: ThunkDispatch<StateType, null, AnyAction>
-): VisitDetailsPanelDispatchProps => ({
-  fetchSize: (investigationId: number) =>
-    dispatch(fetchInvestigationSize(investigationId)),
-});
-
-export default connect(null, mapDispatchToProps)(VisitDetailsPanel);
+export default VisitDetailsPanel;

--- a/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-table/src/dls/detailsPanels/visitDetailsPanel.component.tsx
@@ -113,6 +113,7 @@ const VisitDetailsPanel = (
               variant="outlined"
               color="primary"
               size="small"
+              id="calculate-size-btn"
             >
               Calculate
             </Button>

--- a/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.test.tsx
@@ -312,8 +312,10 @@ describe('DLS Dataset table component', () => {
       .first()
       .simulate('click');
 
-    const button = wrapper.find('#calculate-size-btn').first();
-    button.simulate('click');
+    wrapper
+      .find('#calculate-size-btn')
+      .first()
+      .simulate('click');
 
     expect(testStore.getActions()[2]).toEqual(fetchDatasetSizeRequest());
   });

--- a/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.test.tsx
@@ -10,6 +10,7 @@ import {
   sortTable,
   fetchDatasetDetailsRequest,
   fetchDatasetCountRequest,
+  fetchDatasetSizeRequest,
   removeFromCartRequest,
   addToCartRequest,
   dGCommonInitialState,
@@ -290,6 +291,31 @@ describe('DLS Dataset table component', () => {
     );
 
     expect(testStore.getActions()[1]).toEqual(fetchDatasetDetailsRequest());
+  });
+
+  it('sends off an FetchDatasetSize action when Calculate button is clicked', () => {
+    const { SIZE, ...rowDataWithoutSize } = state.dgcommon.data[0];
+    let newState = state;
+    newState.dgcommon.data[0] = rowDataWithoutSize;
+    const testStore = mockStore(newState);
+
+    let wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DLSDatasetsTable investigationId="1" proposalName="Proposal 1" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('[aria-label="Show details"]')
+      .first()
+      .simulate('click');
+
+    const button = wrapper.find('#calculate-size-btn').first();
+    button.simulate('click');
+
+    expect(testStore.getActions()[2]).toEqual(fetchDatasetSizeRequest());
   });
 
   it('renders Dataset title as a link', () => {

--- a/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.tsx
@@ -13,6 +13,7 @@ import {
   fetchDatasets,
   fetchDatasetDetails,
   fetchDatasetCount,
+  fetchInvestigationSize,
   addToCart,
   removeFromCart,
   fetchAllIds,
@@ -61,6 +62,7 @@ interface DLSDatasetsTableDispatchProps {
   addToCart: (entityIds: number[]) => Promise<void>;
   removeFromCart: (entityIds: number[]) => Promise<void>;
   fetchAllIds: () => Promise<void>;
+  fetchSize: (investigationId: number) => Promise<void>;
 }
 
 type DLSDatasetsTableCombinedProps = DLSDatasetsTableProps &
@@ -146,6 +148,7 @@ const DLSDatasetsTable = (
             rowData={rowData}
             detailsPanelResize={detailsPanelResize}
             fetchDetails={props.fetchDetails}
+            fetchSize={props.fetchSize}
           />
         );
       }}
@@ -214,6 +217,8 @@ const mapDispatchToProps = (
         },
       ])
     ),
+  fetchSize: (investigationId: number) =>
+    dispatch(fetchInvestigationSize(investigationId)),
 });
 
 const mapStateToProps = (state: StateType): DLSDatasetsTableStoreProps => {

--- a/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsDatasetsTable.component.tsx
@@ -13,7 +13,7 @@ import {
   fetchDatasets,
   fetchDatasetDetails,
   fetchDatasetCount,
-  fetchInvestigationSize,
+  fetchDatasetSize,
   addToCart,
   removeFromCart,
   fetchAllIds,
@@ -217,8 +217,7 @@ const mapDispatchToProps = (
         },
       ])
     ),
-  fetchSize: (investigationId: number) =>
-    dispatch(fetchInvestigationSize(investigationId)),
+  fetchSize: (datasetId: number) => dispatch(fetchDatasetSize(datasetId)),
 });
 
 const mapStateToProps = (state: StateType): DLSDatasetsTableStoreProps => {

--- a/packages/datagateway-table/src/dls/tables/dlsMyDataTable.component.test.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsMyDataTable.component.test.tsx
@@ -241,8 +241,10 @@ describe('DLS Visits table component', () => {
       .first()
       .simulate('click');
 
-    const button = wrapper.find('#calculate-size-btn').first();
-    button.simulate('click');
+    wrapper
+      .find('#calculate-size-btn')
+      .first()
+      .simulate('click');
 
     expect(testStore.getActions()[4]).toEqual(fetchInvestigationSizeRequest());
   });

--- a/packages/datagateway-table/src/dls/tables/dlsMyDataTable.component.test.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsMyDataTable.component.test.tsx
@@ -10,6 +10,7 @@ import {
   sortTable,
   fetchInvestigationDetailsRequest,
   fetchInvestigationCountRequest,
+  fetchInvestigationSizeRequest,
   dGCommonInitialState,
   clearTable,
 } from 'datagateway-common';
@@ -219,6 +220,31 @@ describe('DLS Visits table component', () => {
     expect(testStore.getActions()[3]).toEqual(
       fetchInvestigationDetailsRequest()
     );
+  });
+
+  it('sends off an FetchInvestigationSize action when Calculate button is clicked', () => {
+    const { SIZE, ...rowDataWithoutSize } = state.dgcommon.data[0];
+    let newState = state;
+    newState.dgcommon.data[0] = rowDataWithoutSize;
+    const testStore = mockStore(newState);
+
+    let wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DLSMyDataTable />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('[aria-label="Show details"]')
+      .first()
+      .simulate('click');
+
+    const button = wrapper.find('#calculate-size-btn').first();
+    button.simulate('click');
+
+    expect(testStore.getActions()[4]).toEqual(fetchInvestigationSizeRequest());
   });
 
   it('renders title and visit ID as a links', () => {

--- a/packages/datagateway-table/src/dls/tables/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsMyDataTable.component.tsx
@@ -11,6 +11,7 @@ import {
   fetchInvestigations,
   fetchInvestigationDetails,
   fetchInvestigationCount,
+  fetchInvestigationSize,
   sortTable,
   filterTable,
   clearTable,
@@ -44,6 +45,7 @@ interface DLSMyDataTableDispatchProps {
   fetchCount: (username: string) => Promise<void>;
   clearTable: () => Action;
   fetchDetails: (investigationId: number) => Promise<void>;
+  fetchSize: (investigationId: number) => Promise<void>;
 }
 
 type DLSMyDataTableCombinedProps = DLSMyDataTableStoreProps &
@@ -110,6 +112,7 @@ const DLSMyDataTable = (
             rowData={rowData}
             detailsPanelResize={detailsPanelResize}
             fetchDetails={props.fetchDetails}
+            fetchSize={props.fetchSize}
           />
         );
       }}
@@ -224,6 +227,8 @@ const mapDispatchToProps = (
   clearTable: () => dispatch(clearTable()),
   fetchDetails: (investigationId: number) =>
     dispatch(fetchInvestigationDetails(investigationId)),
+  fetchSize: (investigationId: number) =>
+    dispatch(fetchInvestigationSize(investigationId)),
 });
 
 const mapStateToProps = (state: StateType): DLSMyDataTableStoreProps => {

--- a/packages/datagateway-table/src/dls/tables/dlsVisitsTable.component.test.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsVisitsTable.component.test.tsx
@@ -10,6 +10,7 @@ import {
   sortTable,
   fetchInvestigationDetailsRequest,
   fetchInvestigationCountRequest,
+  fetchInvestigationSizeRequest,
   dGCommonInitialState,
   clearTable,
 } from 'datagateway-common';
@@ -215,6 +216,31 @@ describe('DLS Visits table component', () => {
     expect(testStore.getActions()[1]).toEqual(
       fetchInvestigationDetailsRequest()
     );
+  });
+
+  it('sends off an FetchInvestigationSize action when Calculate button is clicked', () => {
+    const { SIZE, ...rowDataWithoutSize } = state.dgcommon.data[0];
+    let newState = state;
+    newState.dgcommon.data[0] = rowDataWithoutSize;
+    const testStore = mockStore(newState);
+
+    let wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DLSVisitsTable proposalName="Test 1" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('[aria-label="Show details"]')
+      .first()
+      .simulate('click');
+
+    const button = wrapper.find('#calculate-size-btn').first();
+    button.simulate('click');
+
+    expect(testStore.getActions()[2]).toEqual(fetchInvestigationSizeRequest());
   });
 
   it('renders visit ID as a links', () => {

--- a/packages/datagateway-table/src/dls/tables/dlsVisitsTable.component.test.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsVisitsTable.component.test.tsx
@@ -237,8 +237,10 @@ describe('DLS Visits table component', () => {
       .first()
       .simulate('click');
 
-    const button = wrapper.find('#calculate-size-btn').first();
-    button.simulate('click');
+    wrapper
+      .find('#calculate-size-btn')
+      .first()
+      .simulate('click');
 
     expect(testStore.getActions()[2]).toEqual(fetchInvestigationSizeRequest());
   });

--- a/packages/datagateway-table/src/dls/tables/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-table/src/dls/tables/dlsVisitsTable.component.tsx
@@ -11,6 +11,7 @@ import {
   fetchInvestigations,
   fetchInvestigationDetails,
   fetchInvestigationCount,
+  fetchInvestigationSize,
   sortTable,
   filterTable,
   clearTable,
@@ -47,6 +48,7 @@ interface DLSVisitsTableDispatchProps {
   fetchCount: (proposalName: string) => Promise<void>;
   clearTable: () => Action;
   fetchDetails: (investigationId: number) => Promise<void>;
+  fetchSize: (investigationId: number) => Promise<void>;
 }
 
 type DLSVisitsTableCombinedProps = DLSVisitsTableProps &
@@ -109,6 +111,7 @@ const DLSVisitsTable = (
             rowData={rowData}
             detailsPanelResize={detailsPanelResize}
             fetchDetails={props.fetchDetails}
+            fetchSize={props.fetchSize}
           />
         );
       }}
@@ -200,6 +203,8 @@ const mapDispatchToProps = (
   clearTable: () => dispatch(clearTable()),
   fetchDetails: (investigationId: number) =>
     dispatch(fetchInvestigationDetails(investigationId)),
+  fetchSize: (investigationId: number) =>
+    dispatch(fetchInvestigationSize(investigationId)),
 });
 
 const mapStateToProps = (state: StateType): DLSVisitsTableStoreProps => {


### PR DESCRIPTION
## Description
Trigger fetch size functions as a result of clicking the calculate button in the DLSDatasetDetailsPanel & DLSVisitDetailsPanel. The calculate button is then replaced by the size.

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage

## Agile board tracking
resolves #118
