### PR TITLE
Fix datagateway-download e2e test that fails on 1st of month

### DIFF
--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -8,7 +8,7 @@ describe('Download Status', () => {
   });
 
   beforeEach(() => {
-    Cypress.currentTest.retries(2);
+    // Cypress.currentTest.retries(2);
     cy.server();
     cy.route('GET', '**/topcat/user/downloads**').as('fetchDownloads');
     cy.login('download-e2e-tests', 'pw');
@@ -137,9 +137,20 @@ describe('Download Status', () => {
         '2020-01-31'
       );
 
+      let date = new Date();
+      const month = date.toLocaleString('default', { month: 'long' });
+      const year = date.getFullYear();
+
       cy.get('[aria-label="Requested Date date filter to"]')
         .parent()
         .find('button')
+        .click();
+
+      cy.contains(`${month} ${year}`)
+        .parent()
+        .parent()
+        .find('button')
+        .first()
         .click();
 
       cy.get('.MuiPickersDay-day[tabindex="0"]')
@@ -148,15 +159,15 @@ describe('Download Status', () => {
 
       cy.contains('OK').click();
 
-      let date = new Date();
       date.setDate(1);
+      date.setMonth(date.getMonth() - 1);
 
       cy.get('[aria-label="Requested Date date filter to"]').should(
         'have.value',
         date.toISOString().slice(0, 10)
       );
 
-      // There should be results for this time period.
+      // There should not be results for this time period.
       cy.get('[aria-rowcount="0"]').should('exist');
 
       let currDate = new Date();

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -8,7 +8,7 @@ describe('Download Status', () => {
   });
 
   beforeEach(() => {
-    // Cypress.currentTest.retries(2);
+    Cypress.currentTest.retries(2);
     cy.server();
     cy.route('GET', '**/topcat/user/downloads**').as('fetchDownloads');
     cy.login('download-e2e-tests', 'pw');


### PR DESCRIPTION
## Description
Fix by selecting first of previous month instead, which will always filter out the downloads created on the current date

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
