### PR TITLE
Feature/plugin load error #129

### DIFF
--- a/packages/datagateway-dataview/src/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/pageContainer.component.test.tsx
@@ -20,6 +20,7 @@ jest.mock('loglevel');
 describe('PageContainer - Tests', () => {
   let shallow;
   let state: StateType;
+  document.getElementById = jest.fn();
 
   const createWrapper = (state: StateType): ReactWrapper => {
     const mockStore = configureStore([thunk]);
@@ -44,6 +45,10 @@ describe('PageContainer - Tests', () => {
         },
       })
     );
+  });
+
+  afterEach(() => {
+    document.getElementById.mockReset();
   });
 
   it('displays the correct entity count', () => {
@@ -73,8 +78,6 @@ describe('PageContainer - Tests', () => {
     expect(testStore.getActions()[0]).toEqual({
       type: 'datagateway_common:fetch_download_cart_request',
     });
-
-    document.getElementById.mockReset();
   });
 
   it('does not fetch cart on load if no dg-dataview element exists', () => {

--- a/packages/datagateway-dataview/src/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/pageContainer.component.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactWrapper } from 'enzyme';
+import { ReactWrapper, mount } from 'enzyme';
 
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -51,5 +51,41 @@ describe('PageContainer - Tests', () => {
     const wrapper = createWrapper(state);
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('fetches cart on load', () => {
+    // Mock getElementById so that it returns truthy.
+    const testElement = document.createElement('DIV');
+    document.getElementById = jest.fn(() => testElement);
+
+    const mockStore = configureStore([thunk]);
+    const testStore = mockStore(state);
+    mount(
+      <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
+        <PageContainer store={testStore} />
+      </MemoryRouter>
+    );
+
+    expect(document.getElementById.mock.calls[0][0]).toBe(
+      'datagateway-dataview'
+    );
+
+    expect(testStore.getActions()[0]).toEqual({
+      type: 'datagateway_common:fetch_download_cart_request',
+    });
+
+    document.getElementById.mockReset();
+  });
+
+  it('does not fetch cart on load if no dg-dataview element exists', () => {
+    const mockStore = configureStore([thunk]);
+    const testStore = mockStore(state);
+    mount(
+      <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
+        <PageContainer store={testStore} />
+      </MemoryRouter>
+    );
+
+    expect(testStore.getActions()).toHaveLength(0);
   });
 });

--- a/packages/datagateway-dataview/src/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/pageContainer.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StateType } from './state/app.types';
 import { connect } from 'react-redux';
 
@@ -9,7 +9,6 @@ import { Route } from 'react-router';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
 import { fetchDownloadCart } from 'datagateway-common';
-import { useDetectElement } from './utils';
 
 interface PageContainerStoreProps {
   entityCount: number;
@@ -27,9 +26,13 @@ const PageContainer = (
 ): React.ReactElement => {
   const { entityCount, fetchDownloadCart } = props;
 
-  useDetectElement(() => {
-    fetchDownloadCart();
-  }, []);
+  const dgDataviewElement = document.getElementById('datagateway-dataview');
+
+  useEffect(() => {
+    if (dgDataviewElement) {
+      fetchDownloadCart();
+    }
+  }, [dgDataviewElement, fetchDownloadCart]);
 
   return (
     <Grid container>

--- a/packages/datagateway-dataview/src/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/pageContainer.component.tsx
@@ -6,51 +6,73 @@ import { Grid, Typography, Paper } from '@material-ui/core';
 import PageBreadcrumbs from './breadcrumbs.component';
 import PageTable from './pageTable.component';
 import { Route } from 'react-router';
+import { ThunkDispatch } from 'redux-thunk';
+import { AnyAction } from 'redux';
+import { fetchDownloadCart } from 'datagateway-common';
+import { useDetectElement } from './utils';
 
-class PageContainer extends React.Component<{ entityCount: number }> {
-  public constructor(props: { entityCount: number }) {
-    super(props);
-  }
-
-  public render(): React.ReactElement {
-    return (
-      <Grid container>
-        {/* Hold the breadcrumbs at top left of the page. */}
-        <Grid item xs aria-label="container-breadcrumbs">
-          {/* don't show breadcrumbs on /my-data - only on browse */}
-          <Route path="/browse" component={PageBreadcrumbs} />
-        </Grid>
-
-        {/* The table entity count takes up an xs of 2, where the breadcrumbs 
-           will take the remainder of the space. */}
-        <Grid
-          style={{ textAlign: 'center' }}
-          item
-          xs={2}
-          aria-label="container-table-count"
-        >
-          <Paper square>
-            <Typography variant="h6" component="h3">
-              <b>Results:</b> {this.props.entityCount}
-            </Typography>
-          </Paper>
-        </Grid>
-
-        {/* Hold the table for remainder of the page */}
-        <Grid item xs={12} aria-label="container-table">
-          {/* Place table in Paper component which adjusts for the height
-             of the AppBar (64px) on parent application and the breadcrumbs component (31px). */}
-          <Paper square style={{ height: 'calc(100vh - 95px)', width: '100%' }}>
-            <PageTable />
-          </Paper>
-        </Grid>
-      </Grid>
-    );
-  }
+interface PageContainerStoreProps {
+  entityCount: number;
 }
 
-const mapStateToProps = (state: StateType): { entityCount: number } => ({
+interface PageContainerDispatchProps {
+  fetchDownloadCart: () => Promise<void>;
+}
+
+type PageContainerCombinedProps = PageContainerStoreProps &
+  PageContainerDispatchProps;
+
+const PageContainer = (
+  props: PageContainerCombinedProps
+): React.ReactElement => {
+  const { entityCount, fetchDownloadCart } = props;
+
+  useDetectElement(() => {
+    fetchDownloadCart();
+  }, []);
+
+  return (
+    <Grid container>
+      {/* Hold the breadcrumbs at top left of the page. */}
+      <Grid item xs aria-label="container-breadcrumbs">
+        {/* don't show breadcrumbs on /my-data - only on browse */}
+        <Route path="/browse" component={PageBreadcrumbs} />
+      </Grid>
+
+      {/* The table entity count takes up an xs of 2, where the breadcrumbs
+           will take the remainder of the space. */}
+      <Grid
+        style={{ textAlign: 'center' }}
+        item
+        xs={2}
+        aria-label="container-table-count"
+      >
+        <Paper square>
+          <Typography variant="h6" component="h3">
+            <b>Results:</b> {entityCount}
+          </Typography>
+        </Paper>
+      </Grid>
+
+      {/* Hold the table for remainder of the page */}
+      <Grid item xs={12} aria-label="container-table">
+        {/* Place table in Paper component which adjusts for the height
+             of the AppBar (64px) on parent application and the breadcrumbs component (31px). */}
+        <Paper square style={{ height: 'calc(100vh - 95px)', width: '100%' }}>
+          <PageTable />
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+};
+
+const mapDispatchToProps = (
+  dispatch: ThunkDispatch<StateType, null, AnyAction>
+): PageContainerDispatchProps => ({
+  fetchDownloadCart: () => dispatch(fetchDownloadCart()),
+});
+const mapStateToProps = (state: StateType): PageContainerStoreProps => ({
   entityCount: state.dgcommon.totalDataCount,
 });
 
-export default connect(mapStateToProps)(PageContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(PageContainer);

--- a/packages/datagateway-dataview/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-dataview/src/state/actions/actions.test.tsx
@@ -15,12 +15,7 @@ import {
 import axios from 'axios';
 import * as log from 'loglevel';
 import { actions, resetActions, dispatch, getState } from '../../setupTests';
-import {
-  fetchDownloadCartRequest,
-  fetchDownloadCartSuccess,
-  loadUrls,
-  loadFacilityName,
-} from 'datagateway-common';
+import { loadUrls, loadFacilityName } from 'datagateway-common';
 
 jest.mock('loglevel');
 
@@ -100,7 +95,7 @@ describe('Actions', () => {
     const asyncAction = configureApp();
     await asyncAction(dispatch, getState);
 
-    expect(actions.length).toEqual(8);
+    expect(actions.length).toEqual(6);
     expect(actions).toContainEqual(loadFacilityName('Generic'));
     expect(actions).toContainEqual(loadFeatureSwitches({}));
     expect(actions).toContainEqual(
@@ -120,8 +115,6 @@ describe('Actions', () => {
         },
       })
     );
-    expect(actions).toContainEqual(fetchDownloadCartRequest());
-    expect(actions).toContainEqual(fetchDownloadCartSuccess({}));
     expect(actions).toContainEqual(settingsLoaded());
   });
 
@@ -149,7 +142,7 @@ describe('Actions', () => {
     const asyncAction = configureApp();
     await asyncAction(dispatch, getState);
 
-    expect(actions.length).toEqual(6);
+    expect(actions.length).toEqual(4);
     expect(actions).toContainEqual(loadFacilityName('Generic'));
     expect(actions).toContainEqual(
       configureStrings({ testSection: { test: 'string' } })
@@ -161,8 +154,6 @@ describe('Actions', () => {
         downloadApiUrl: 'download-api',
       })
     );
-    expect(actions).toContainEqual(fetchDownloadCartRequest());
-    expect(actions).toContainEqual(fetchDownloadCartSuccess({}));
     expect(actions).toContainEqual(settingsLoaded());
   });
 

--- a/packages/datagateway-dataview/src/state/actions/index.tsx
+++ b/packages/datagateway-dataview/src/state/actions/index.tsx
@@ -15,7 +15,6 @@ import {
   loadFacilityName,
   MicroFrontendToken,
 } from 'datagateway-common';
-import { fetchDownloadCart } from 'datagateway-common';
 import { Action } from 'redux';
 import axios from 'axios';
 import * as log from 'loglevel';
@@ -35,13 +34,13 @@ export const configureStrings = (
 });
 
 export const loadStrings = (path: string): ThunkResult<Promise<void>> => {
-  return async (dispatch) => {
+  return async dispatch => {
     await axios
       .get(path)
-      .then((res) => {
+      .then(res => {
         dispatch(configureStrings(res.data));
       })
-      .catch((error) =>
+      .catch(error =>
         log.error(`Failed to read strings from ${path}: ${error}`)
       );
   };
@@ -66,10 +65,10 @@ export const loadBreadcrumbSettings = (
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
-  return async (dispatch) => {
+  return async dispatch => {
     await axios
       .get('/datagateway-dataview-settings.json')
-      .then((res) => {
+      .then(res => {
         const settings = res.data;
 
         // invalid settings.json
@@ -131,7 +130,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
                 },
               }
             )
-            .then((response) => {
+            .then(response => {
               axios
                 .get(`${settings['apiUrl']}/sessions`, {
                   headers: {
@@ -153,7 +152,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
 
                   window.localStorage.setItem(MicroFrontendToken, jwt);
                 })
-                .catch((error) => {
+                .catch(error => {
                   log.error(
                     `datagateway-api cannot verify ICAT session id: ${error.message}.
                      This is likely caused if datagateway-api is pointing to a
@@ -161,7 +160,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
                   );
                 });
             })
-            .catch((error) =>
+            .catch(error =>
               log.error(`Can't log in to ICAT: ${error.message}`)
             );
         }
@@ -173,12 +172,9 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
           dispatch(loadStrings(uiStringResourcesPath));
         }
 
-        // fetch initial download cart
-        dispatch(fetchDownloadCart());
-
         dispatch(settingsLoaded());
       })
-      .catch((error) => {
+      .catch(error => {
         log.error(
           `Error loading datagateway-dataview-settings.json: ${error.message}`
         );

--- a/packages/datagateway-dataview/src/state/actions/index.tsx
+++ b/packages/datagateway-dataview/src/state/actions/index.tsx
@@ -34,13 +34,13 @@ export const configureStrings = (
 });
 
 export const loadStrings = (path: string): ThunkResult<Promise<void>> => {
-  return async dispatch => {
+  return async (dispatch) => {
     await axios
       .get(path)
-      .then(res => {
+      .then((res) => {
         dispatch(configureStrings(res.data));
       })
-      .catch(error =>
+      .catch((error) =>
         log.error(`Failed to read strings from ${path}: ${error}`)
       );
   };
@@ -65,10 +65,10 @@ export const loadBreadcrumbSettings = (
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
-  return async dispatch => {
+  return async (dispatch) => {
     await axios
       .get('/datagateway-dataview-settings.json')
-      .then(res => {
+      .then((res) => {
         const settings = res.data;
 
         // invalid settings.json
@@ -130,7 +130,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
                 },
               }
             )
-            .then(response => {
+            .then((response) => {
               axios
                 .get(`${settings['apiUrl']}/sessions`, {
                   headers: {
@@ -152,7 +152,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
 
                   window.localStorage.setItem(MicroFrontendToken, jwt);
                 })
-                .catch(error => {
+                .catch((error) => {
                   log.error(
                     `datagateway-api cannot verify ICAT session id: ${error.message}.
                      This is likely caused if datagateway-api is pointing to a
@@ -160,7 +160,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
                   );
                 });
             })
-            .catch(error =>
+            .catch((error) =>
               log.error(`Can't log in to ICAT: ${error.message}`)
             );
         }
@@ -174,7 +174,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
 
         dispatch(settingsLoaded());
       })
-      .catch(error => {
+      .catch((error) => {
         log.error(
           `Error loading datagateway-dataview-settings.json: ${error.message}`
         );

--- a/packages/datagateway-dataview/src/utils.ts
+++ b/packages/datagateway-dataview/src/utils.ts
@@ -24,7 +24,6 @@ export const useDetectElement = (
 ): void => {
   React.useEffect(() => {
     if (document.getElementById('datagateway-dataview')) {
-      console.log('useDetectElement');
       func();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/datagateway-dataview/src/utils.ts
+++ b/packages/datagateway-dataview/src/utils.ts
@@ -17,17 +17,4 @@ const useAfterMountEffect = (
   }, deps);
 };
 
-export const useDetectElement = (
-  func: () => void,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  deps?: any[]
-): void => {
-  React.useEffect(() => {
-    if (document.getElementById('datagateway-dataview')) {
-      func();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
-};
-
 export default useAfterMountEffect;

--- a/packages/datagateway-dataview/src/utils.ts
+++ b/packages/datagateway-dataview/src/utils.ts
@@ -17,4 +17,18 @@ const useAfterMountEffect = (
   }, deps);
 };
 
+export const useDetectElement = (
+  func: () => void,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deps?: any[]
+): void => {
+  React.useEffect(() => {
+    if (document.getElementById('datagateway-dataview')) {
+      console.log('useDetectElement');
+      func();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};
+
 export default useAfterMountEffect;

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -159,13 +159,9 @@ describe('Download cart table component', () => {
     });
 
     expect(getSize).toHaveBeenCalledTimes(4);
-    expect(
-      wrapper
-        .find('[aria-colindex=3]')
-        .find('p')
-        .first()
-        .text()
-    ).toEqual('1 B');
+    expect(wrapper.find('[aria-colindex=3]').find('p').first().text()).toEqual(
+      '1 B'
+    );
     expect(wrapper.find('p#totalSizeDisplay').text()).toEqual(
       expect.stringContaining('Total size: 4 B')
     );
@@ -323,10 +319,7 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
-    const firstNameCell = wrapper
-      .find('[aria-colindex=1]')
-      .find('p')
-      .first();
+    const firstNameCell = wrapper.find('[aria-colindex=1]').find('p').first();
 
     const typeSortLabel = wrapper
       .find('[role="columnheader"] span[role="button"]')

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -114,9 +114,11 @@ describe('Download cart table component', () => {
 
   it('fetches the download cart on load', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
 
     await act(async () => {
@@ -127,7 +129,7 @@ describe('Download cart table component', () => {
     expect(fetchDownloadCartItems).toHaveBeenCalled();
   });
 
-  it('calculates sizes once cart items have been fetched', async () => {
+  it('does not fetch the download cart on load if no dg-download element exists', async () => {
     const wrapper = mount(
       <DownloadSettingsContext.Provider value={mockedSettings}>
         <DownloadCartTable statusTabRedirect={jest.fn()} />
@@ -139,10 +141,31 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
-    expect(getSize).toHaveBeenCalledTimes(4);
-    expect(wrapper.find('[aria-colindex=3]').find('p').first().text()).toEqual(
-      '1 B'
+    expect(fetchDownloadCartItems).not.toHaveBeenCalled();
+  });
+
+  it('calculates sizes once cart items have been fetched', async () => {
+    const wrapper = mount(
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(getSize).toHaveBeenCalledTimes(4);
+    expect(
+      wrapper
+        .find('[aria-colindex=3]')
+        .find('p')
+        .first()
+        .text()
+    ).toEqual('1 B');
     expect(wrapper.find('p#totalSizeDisplay').text()).toEqual(
       expect.stringContaining('Total size: 4 B')
     );
@@ -150,9 +173,11 @@ describe('Download cart table component', () => {
 
   it('calculates total file count once cart items have been fetched', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
 
     await act(async () => {
@@ -168,9 +193,11 @@ describe('Download cart table component', () => {
 
   it('loads cart confirmation dialog when Download Cart button is clicked', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
 
     expect(wrapper.find('button#downloadCartButton').prop('disabled')).toBe(
@@ -217,9 +244,11 @@ describe('Download cart table component', () => {
 
   it('removes all items from cart when Remove All button is clicked', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
 
     await act(async () => {
@@ -240,9 +269,11 @@ describe('Download cart table component', () => {
 
   it("removes an item when said item's remove button is clicked", async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
 
     await act(async () => {
@@ -280,9 +311,11 @@ describe('Download cart table component', () => {
 
   it('sorts data when headers are clicked', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
 
     await act(async () => {
@@ -290,7 +323,10 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
-    const firstNameCell = wrapper.find('[aria-colindex=1]').find('p').first();
+    const firstNameCell = wrapper
+      .find('[aria-colindex=1]')
+      .find('p')
+      .first();
 
     const typeSortLabel = wrapper
       .find('[role="columnheader"] span[role="button"]')
@@ -323,9 +359,11 @@ describe('Download cart table component', () => {
 
   it('filters data when text fields are typed into', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <div id="datagateway-download">
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </div>
     );
 
     await act(async () => {

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -49,6 +49,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
   const [showConfirmation, setShowConfirmation] = React.useState(false);
   const [isTwoLevel, setIsTwoLevel] = React.useState(false);
 
+  const dgDownloadElement = document.getElementById('datagateway-download');
+
   const totalSize = React.useMemo(() => {
     if (sizesFinished) {
       return data.reduce((accumulator, nextItem) => {
@@ -69,22 +71,31 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
 
     if (settings.idsUrl) checkTwoLevel();
   }, [settings.idsUrl]);
-
   React.useEffect(() => {
-    if (settings.facilityName && settings.apiUrl && settings.downloadApiUrl)
+    if (
+      settings.facilityName &&
+      settings.apiUrl &&
+      settings.downloadApiUrl &&
+      dgDownloadElement
+    )
       fetchDownloadCartItems({
         facilityName: settings.facilityName,
         downloadApiUrl: settings.downloadApiUrl,
-      }).then((cartItems) => {
-        setData(cartItems.map((cartItem) => ({ ...cartItem, size: -1 })));
+      }).then(cartItems => {
+        setData(cartItems.map(cartItem => ({ ...cartItem, size: -1 })));
         setDataLoaded(true);
         setSizesLoaded(false);
         setSizesFinished(false);
         getCartDatafileCount(cartItems, {
           apiUrl: settings.apiUrl,
-        }).then((count) => setFileCount(count));
+        }).then(count => setFileCount(count));
       });
-  }, [settings.facilityName, settings.apiUrl, settings.downloadApiUrl]);
+  }, [
+    settings.facilityName,
+    settings.apiUrl,
+    settings.downloadApiUrl,
+    dgDownloadElement,
+  ]);
 
   React.useEffect(() => {
     if (!sizesLoaded) {
@@ -101,7 +112,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             facilityName: settings.facilityName,
             apiUrl: settings.apiUrl,
             downloadApiUrl: settings.downloadApiUrl,
-          }).then((size) => {
+          }).then(size => {
             updatedData[chunkIndexOffset + index].size = size;
           });
           chunkPromises.push(promise);
@@ -145,7 +156,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
   );
 
   const sortedAndFilteredData = React.useMemo(() => {
-    const filteredData = data.filter((item) => {
+    const filteredData = data.filter(item => {
       for (const [key, value] of Object.entries(filters)) {
         const tableValue = item[key];
         if (
@@ -203,7 +214,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 {
                   label: 'Size',
                   dataKey: 'size',
-                  cellContentRenderer: (props) => {
+                  cellContentRenderer: props => {
                     return formatBytes(props.cellData);
                   },
                 },
@@ -243,7 +254,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                             ).then(() =>
                               setData(
                                 data.filter(
-                                  (item) => item.entityId !== cartItem.entityId
+                                  item => item.entityId !== cartItem.entityId
                                 )
                               )
                             ),

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -81,14 +81,14 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
       fetchDownloadCartItems({
         facilityName: settings.facilityName,
         downloadApiUrl: settings.downloadApiUrl,
-      }).then(cartItems => {
-        setData(cartItems.map(cartItem => ({ ...cartItem, size: -1 })));
+      }).then((cartItems) => {
+        setData(cartItems.map((cartItem) => ({ ...cartItem, size: -1 })));
         setDataLoaded(true);
         setSizesLoaded(false);
         setSizesFinished(false);
         getCartDatafileCount(cartItems, {
           apiUrl: settings.apiUrl,
-        }).then(count => setFileCount(count));
+        }).then((count) => setFileCount(count));
       });
   }, [
     settings.facilityName,
@@ -112,7 +112,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             facilityName: settings.facilityName,
             apiUrl: settings.apiUrl,
             downloadApiUrl: settings.downloadApiUrl,
-          }).then(size => {
+          }).then((size) => {
             updatedData[chunkIndexOffset + index].size = size;
           });
           chunkPromises.push(promise);
@@ -156,7 +156,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
   );
 
   const sortedAndFilteredData = React.useMemo(() => {
-    const filteredData = data.filter(item => {
+    const filteredData = data.filter((item) => {
       for (const [key, value] of Object.entries(filters)) {
         const tableValue = item[key];
         if (
@@ -214,7 +214,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 {
                   label: 'Size',
                   dataKey: 'size',
-                  cellContentRenderer: props => {
+                  cellContentRenderer: (props) => {
                     return formatBytes(props.cellData);
                   },
                 },
@@ -254,7 +254,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                             ).then(() =>
                               setData(
                                 data.filter(
-                                  item => item.entityId !== cartItem.entityId
+                                  (item) => item.entityId !== cartItem.entityId
                                 )
                               )
                             ),

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -19,11 +19,13 @@ const RefreshHOC: React.FC<{ refresh: boolean }> = (props: {
   }, [props.refresh]);
 
   return (
-    <DownloadStatusTable
-      refreshTable={refreshTable}
-      setRefreshTable={setRefreshTable}
-      setLastChecked={jest.fn()}
-    />
+    <div id="datagateway-download">
+      <DownloadStatusTable
+        refreshTable={refreshTable}
+        setRefreshTable={setRefreshTable}
+        setLastChecked={jest.fn()}
+      />
+    </div>
   );
 };
 
@@ -137,11 +139,13 @@ describe('Download Status Table', () => {
 
   it('fetches the download items on load', async () => {
     const wrapper = mount(
-      <DownloadStatusTable
-        refreshTable={false}
-        setRefreshTable={jest.fn()}
-        setLastChecked={jest.fn()}
-      />
+      <div id="datagateway-download">
+        <DownloadStatusTable
+          refreshTable={false}
+          setRefreshTable={jest.fn()}
+          setLastChecked={jest.fn()}
+        />
+      </div>
     );
 
     await act(async () => {
@@ -181,11 +185,13 @@ describe('Download Status Table', () => {
 
   it('should have a link for a download item', async () => {
     const wrapper = mount(
-      <DownloadStatusTable
-        refreshTable={false}
-        setRefreshTable={jest.fn()}
-        setLastChecked={jest.fn()}
-      />
+      <div id="datagateway-download">
+        <DownloadStatusTable
+          refreshTable={false}
+          setRefreshTable={jest.fn()}
+          setLastChecked={jest.fn()}
+        />
+      </div>
     );
 
     await act(async () => {
@@ -209,7 +215,10 @@ describe('Download Status Table', () => {
 
     // Check to see if the href contains the correct call.
     expect(
-      wrapper.find('a[aria-label="Download test-file-3"]').at(0).props().href
+      wrapper
+        .find('a[aria-label="Download test-file-3"]')
+        .at(0)
+        .props().href
     ).toContain('/getData');
 
     wrapper.find('a[aria-label="Download test-file-3"]').simulate('click');
@@ -230,11 +239,13 @@ describe('Download Status Table', () => {
 
   it("removes an item when said item's remove button is clicked", async () => {
     const wrapper = mount(
-      <DownloadStatusTable
-        refreshTable={false}
-        setRefreshTable={jest.fn()}
-        setLastChecked={jest.fn()}
-      />
+      <div id="datagateway-download">
+        <DownloadStatusTable
+          refreshTable={false}
+          setRefreshTable={jest.fn()}
+          setLastChecked={jest.fn()}
+        />
+      </div>
     );
 
     await act(async () => {
@@ -272,11 +283,13 @@ describe('Download Status Table', () => {
 
   it('sorts data when headers are clicked', async () => {
     const wrapper = mount(
-      <DownloadStatusTable
-        refreshTable={false}
-        setRefreshTable={jest.fn()}
-        setLastChecked={jest.fn()}
-      />
+      <div id="datagateway-download">
+        <DownloadStatusTable
+          refreshTable={false}
+          setRefreshTable={jest.fn()}
+          setLastChecked={jest.fn()}
+        />
+      </div>
     );
 
     await act(async () => {
@@ -284,7 +297,10 @@ describe('Download Status Table', () => {
       wrapper.update();
     });
 
-    const firstNameCell = wrapper.find('[aria-colindex=1]').find('p').first();
+    const firstNameCell = wrapper
+      .find('[aria-colindex=1]')
+      .find('p')
+      .first();
 
     // Get the access method sort header.
     const accessMethodSortLabel = wrapper
@@ -319,11 +335,13 @@ describe('Download Status Table', () => {
 
   it('filters data when text fields are typed into', async () => {
     const wrapper = mount(
-      <DownloadStatusTable
-        refreshTable={false}
-        setRefreshTable={jest.fn()}
-        setLastChecked={jest.fn()}
-      />
+      <div id="datagateway-download">
+        <DownloadStatusTable
+          refreshTable={false}
+          setRefreshTable={jest.fn()}
+          setLastChecked={jest.fn()}
+        />
+      </div>
     );
 
     await act(async () => {
@@ -383,11 +401,13 @@ describe('Download Status Table', () => {
 
   it('filters data when date filter is altered', async () => {
     const wrapper = mount(
-      <DownloadStatusTable
-        refreshTable={false}
-        setRefreshTable={jest.fn()}
-        setLastChecked={jest.fn()}
-      />
+      <div id="datagateway-download">
+        <DownloadStatusTable
+          refreshTable={false}
+          setRefreshTable={jest.fn()}
+          setLastChecked={jest.fn()}
+        />
+      </div>
     );
 
     await act(async () => {

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -215,10 +215,7 @@ describe('Download Status Table', () => {
 
     // Check to see if the href contains the correct call.
     expect(
-      wrapper
-        .find('a[aria-label="Download test-file-3"]')
-        .at(0)
-        .props().href
+      wrapper.find('a[aria-label="Download test-file-3"]').at(0).props().href
     ).toContain('/getData');
 
     wrapper.find('a[aria-label="Download test-file-3"]').simulate('click');
@@ -297,10 +294,7 @@ describe('Download Status Table', () => {
       wrapper.update();
     });
 
-    const firstNameCell = wrapper
-      .find('[aria-colindex=1]')
-      .find('p')
-      .first();
+    const firstNameCell = wrapper.find('[aria-colindex=1]').find('p').first();
 
     // Get the access method sort header.
     const accessMethodSortLabel = wrapper

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -37,6 +37,8 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
 
   const { refreshTable, setRefreshTable, setLastChecked } = props;
 
+  const dgDownloadElement = document.getElementById('datagateway-download');
+
   React.useEffect(() => {
     if (!dataLoaded || refreshTable) {
       // Clear the current contents, this will make sure
@@ -49,11 +51,11 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
         setRefreshTable(false);
       }
 
-      if (!dataLoaded) {
+      if (!dataLoaded && dgDownloadElement) {
         fetchDownloads({
           facilityName: settings.facilityName,
           downloadApiUrl: settings.downloadApiUrl,
-        }).then((downloads) => {
+        }).then(downloads => {
           setData([...downloads].reverse());
           setDataLoaded(true);
 
@@ -69,6 +71,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
     setLastChecked,
     settings.facilityName,
     settings.downloadApiUrl,
+    dgDownloadElement,
   ]);
 
   const textFilter = (label: string, dataKey: string): React.ReactElement => (
@@ -119,7 +122,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
 
   // Handle filtering for both text and date filters.
   const sortedAndFilteredData = React.useMemo(() => {
-    const filteredData = data.filter((item) => {
+    const filteredData = data.filter(item => {
       for (const [key, value] of Object.entries(filters)) {
         const tableValue = item[key];
         if (tableValue !== undefined && typeof tableValue === 'string') {
@@ -316,7 +319,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                             downloadApiUrl: settings.downloadApiUrl,
                           }).then(() =>
                             setData(
-                              data.filter((item) => item.id !== downloadItem.id)
+                              data.filter(item => item.id !== downloadItem.id)
                             )
                           ),
                         100

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -55,7 +55,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
         fetchDownloads({
           facilityName: settings.facilityName,
           downloadApiUrl: settings.downloadApiUrl,
-        }).then(downloads => {
+        }).then((downloads) => {
           setData([...downloads].reverse());
           setDataLoaded(true);
 
@@ -122,7 +122,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
 
   // Handle filtering for both text and date filters.
   const sortedAndFilteredData = React.useMemo(() => {
-    const filteredData = data.filter(item => {
+    const filteredData = data.filter((item) => {
       for (const [key, value] of Object.entries(filters)) {
         const tableValue = item[key];
         if (tableValue !== undefined && typeof tableValue === 'string') {
@@ -319,7 +319,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                             downloadApiUrl: settings.downloadApiUrl,
                           }).then(() =>
                             setData(
-                              data.filter(item => item.id !== downloadItem.id)
+                              data.filter((item) => item.id !== downloadItem.id)
                             )
                           ),
                         100


### PR DESCRIPTION
## Description
Fixes errors occuring when dataview and download plugins are configured in SciGateway and a user loads the page whist not logged in.

These errors were being caused by fetching the cart before logging in, as there was no check that the plugin was actually visible within the plugin div.

## Testing instructions
Check that the plugins still work as expected and that fetch cart errors don't appear before opening the plugins.

- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage

## Agile board tracking
Resolves #129
