### PR TITLE
Fix datagateway-common compile error due to DGThemeProvider (#323)

### DIFF
--- a/packages/datagateway-common/src/dgThemeProvider.component.tsx
+++ b/packages/datagateway-common/src/dgThemeProvider.component.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
-import { Theme } from '@material-ui/core/styles/createMuiTheme';
-import { MuiThemeProvider } from '@material-ui/core';
+import {
+  MuiThemeProvider,
+  Theme,
+  createMuiTheme,
+} from '@material-ui/core/styles';
 import { MicroFrontendId } from './app.types';
 import { SendThemeOptionsType } from './state/actions/actions.types';
 
 // Store the parent theme options when received.
-let parentThemeOptions: Theme | null = null;
+// Otherwise, set to an empty theme.
+let parentThemeOptions: Theme = createMuiTheme({});
 
 // Handle theme options sent from the parent app.
 document.addEventListener(MicroFrontendId, (e) => {


### PR DESCRIPTION
## Description
Fixes the error that occurs when compiling `datagateway-common` since `null` is passed as a prop to the `ThemeProvider` in the DGThemeProvider component.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [x] Ensure `datagateway-common` compiles.

## Agile board tracking
Closes #323 
