### PR TITLE
Fix table column headers and improve resizing

### DIFF
--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -8,52 +8,53 @@ exports[`Data column header component renders correctly with filter but no sort 
   <div
     style={
       Object {
-        "display": "flex",
+        "flex": 1,
+        "overflow": "hidden",
       }
     }
   >
     Test
-    <Draggable
-      allowAnyClick={false}
-      axis="none"
-      bounds={false}
-      cancel={null}
-      defaultClassName="react-draggable"
-      defaultClassNameDragged="react-draggable-dragged"
-      defaultClassNameDragging="react-draggable-dragging"
-      defaultPosition={
+    <TextColumnFilter
+      label="test"
+      onChange={[MockFunction]}
+    />
+  </div>
+  <Draggable
+    allowAnyClick={false}
+    axis="none"
+    bounds={false}
+    cancel={null}
+    defaultClassName="react-draggable"
+    defaultClassNameDragged="react-draggable-dragged"
+    defaultClassNameDragging="react-draggable-dragging"
+    defaultPosition={
+      Object {
+        "x": 0,
+        "y": 0,
+      }
+    }
+    disabled={false}
+    enableUserSelectHack={true}
+    grid={null}
+    handle={null}
+    offsetParent={null}
+    onDrag={[Function]}
+    onMouseDown={[Function]}
+    onStart={[Function]}
+    onStop={[Function]}
+    position={null}
+    scale={1}
+    transform={null}
+  >
+    <DragIndicatorIcon
+      fontSize="small"
+      style={
         Object {
-          "x": 0,
-          "y": 0,
+          "cursor": "col-resize",
         }
       }
-      disabled={false}
-      enableUserSelectHack={true}
-      grid={null}
-      handle={null}
-      offsetParent={null}
-      onDrag={[Function]}
-      onMouseDown={[Function]}
-      onStart={[Function]}
-      onStop={[Function]}
-      position={null}
-      scale={1}
-      transform={null}
-    >
-      <DragIndicatorIcon
-        fontSize="small"
-        style={
-          Object {
-            "cursor": "col-resize",
-          }
-        }
-      />
-    </Draggable>
-  </div>
-  <TextColumnFilter
-    label="test"
-    onChange={[MockFunction]}
-  />
+    />
+  </Draggable>
 </div>
 `;
 
@@ -65,62 +66,58 @@ exports[`Data column header component renders correctly with sort and filter 1`]
   <div
     style={
       Object {
-        "display": "flex",
+        "flex": 1,
+        "overflow": "hidden",
       }
     }
   >
     <WithStyles(ForwardRef(TableSortLabel))
       active={false}
       onClick={[Function]}
-      style={
-        Object {
-          "flex": "auto",
-        }
-      }
     >
       Test
     </WithStyles(ForwardRef(TableSortLabel))>
-    <Draggable
-      allowAnyClick={false}
-      axis="none"
-      bounds={false}
-      cancel={null}
-      defaultClassName="react-draggable"
-      defaultClassNameDragged="react-draggable-dragged"
-      defaultClassNameDragging="react-draggable-dragging"
-      defaultPosition={
+    <TextColumnFilter
+      label="test"
+      onChange={[MockFunction]}
+    />
+  </div>
+  <Draggable
+    allowAnyClick={false}
+    axis="none"
+    bounds={false}
+    cancel={null}
+    defaultClassName="react-draggable"
+    defaultClassNameDragged="react-draggable-dragged"
+    defaultClassNameDragging="react-draggable-dragging"
+    defaultPosition={
+      Object {
+        "x": 0,
+        "y": 0,
+      }
+    }
+    disabled={false}
+    enableUserSelectHack={true}
+    grid={null}
+    handle={null}
+    offsetParent={null}
+    onDrag={[Function]}
+    onMouseDown={[Function]}
+    onStart={[Function]}
+    onStop={[Function]}
+    position={null}
+    scale={1}
+    transform={null}
+  >
+    <DragIndicatorIcon
+      fontSize="small"
+      style={
         Object {
-          "x": 0,
-          "y": 0,
+          "cursor": "col-resize",
         }
       }
-      disabled={false}
-      enableUserSelectHack={true}
-      grid={null}
-      handle={null}
-      offsetParent={null}
-      onDrag={[Function]}
-      onMouseDown={[Function]}
-      onStart={[Function]}
-      onStop={[Function]}
-      position={null}
-      scale={1}
-      transform={null}
-    >
-      <DragIndicatorIcon
-        fontSize="small"
-        style={
-          Object {
-            "cursor": "col-resize",
-          }
-        }
-      />
-    </Draggable>
-  </div>
-  <TextColumnFilter
-    label="test"
-    onChange={[MockFunction]}
-  />
+    />
+  </Draggable>
 </div>
 `;
 
@@ -132,58 +129,54 @@ exports[`Data column header component renders correctly with sort but no filter 
   <div
     style={
       Object {
-        "display": "flex",
+        "flex": 1,
+        "overflow": "hidden",
       }
     }
   >
     <WithStyles(ForwardRef(TableSortLabel))
       active={false}
       onClick={[Function]}
-      style={
-        Object {
-          "flex": "auto",
-        }
-      }
     >
       Test
     </WithStyles(ForwardRef(TableSortLabel))>
-    <Draggable
-      allowAnyClick={false}
-      axis="none"
-      bounds={false}
-      cancel={null}
-      defaultClassName="react-draggable"
-      defaultClassNameDragged="react-draggable-dragged"
-      defaultClassNameDragging="react-draggable-dragging"
-      defaultPosition={
+  </div>
+  <Draggable
+    allowAnyClick={false}
+    axis="none"
+    bounds={false}
+    cancel={null}
+    defaultClassName="react-draggable"
+    defaultClassNameDragged="react-draggable-dragged"
+    defaultClassNameDragging="react-draggable-dragging"
+    defaultPosition={
+      Object {
+        "x": 0,
+        "y": 0,
+      }
+    }
+    disabled={false}
+    enableUserSelectHack={true}
+    grid={null}
+    handle={null}
+    offsetParent={null}
+    onDrag={[Function]}
+    onMouseDown={[Function]}
+    onStart={[Function]}
+    onStop={[Function]}
+    position={null}
+    scale={1}
+    transform={null}
+  >
+    <DragIndicatorIcon
+      fontSize="small"
+      style={
         Object {
-          "x": 0,
-          "y": 0,
+          "cursor": "col-resize",
         }
       }
-      disabled={false}
-      enableUserSelectHack={true}
-      grid={null}
-      handle={null}
-      offsetParent={null}
-      onDrag={[Function]}
-      onMouseDown={[Function]}
-      onStart={[Function]}
-      onStop={[Function]}
-      position={null}
-      scale={1}
-      transform={null}
-    >
-      <DragIndicatorIcon
-        fontSize="small"
-        style={
-          Object {
-            "cursor": "col-resize",
-          }
-        }
-      />
-    </Draggable>
-  </div>
+    />
+  </Draggable>
 </div>
 `;
 
@@ -195,47 +188,48 @@ exports[`Data column header component renders correctly without sort or filter 1
   <div
     style={
       Object {
-        "display": "flex",
+        "flex": 1,
+        "overflow": "hidden",
       }
     }
   >
     Test
-    <Draggable
-      allowAnyClick={false}
-      axis="none"
-      bounds={false}
-      cancel={null}
-      defaultClassName="react-draggable"
-      defaultClassNameDragged="react-draggable-dragged"
-      defaultClassNameDragging="react-draggable-dragging"
-      defaultPosition={
+  </div>
+  <Draggable
+    allowAnyClick={false}
+    axis="none"
+    bounds={false}
+    cancel={null}
+    defaultClassName="react-draggable"
+    defaultClassNameDragged="react-draggable-dragged"
+    defaultClassNameDragging="react-draggable-dragging"
+    defaultPosition={
+      Object {
+        "x": 0,
+        "y": 0,
+      }
+    }
+    disabled={false}
+    enableUserSelectHack={true}
+    grid={null}
+    handle={null}
+    offsetParent={null}
+    onDrag={[Function]}
+    onMouseDown={[Function]}
+    onStart={[Function]}
+    onStop={[Function]}
+    position={null}
+    scale={1}
+    transform={null}
+  >
+    <DragIndicatorIcon
+      fontSize="small"
+      style={
         Object {
-          "x": 0,
-          "y": 0,
+          "cursor": "col-resize",
         }
       }
-      disabled={false}
-      enableUserSelectHack={true}
-      grid={null}
-      handle={null}
-      offsetParent={null}
-      onDrag={[Function]}
-      onMouseDown={[Function]}
-      onStart={[Function]}
-      onStop={[Function]}
-      position={null}
-      scale={1}
-      transform={null}
-    >
-      <DragIndicatorIcon
-        fontSize="small"
-        style={
-          Object {
-            "cursor": "col-resize",
-          }
-        }
-      />
-    </Draggable>
-  </div>
+    />
+  </Draggable>
 </div>
 `;

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -43,7 +43,6 @@ const DataHeader = (
       active={dataKey in sort}
       direction={currSortDirection}
       onClick={() => onSort(dataKey, nextSortDirection)}
-      style={{ flex: '0 1 auto', flexDirection: 'row' }}
     >
       {label}
     </TableSortLabel>
@@ -62,6 +61,7 @@ const DataHeader = (
       <div
         style={{
           overflow: 'hidden',
+          flex: 1,
         }}
       >
         {inner}

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -43,7 +43,7 @@ const DataHeader = (
       active={dataKey in sort}
       direction={currSortDirection}
       onClick={() => onSort(dataKey, nextSortDirection)}
-      style={{ flex: 'auto' }}
+      style={{ flex: '0 1 auto', flexDirection: 'row' }}
     >
       {label}
     </TableSortLabel>
@@ -61,23 +61,23 @@ const DataHeader = (
     >
       <div
         style={{
-          display: 'flex',
+          overflow: 'hidden',
         }}
       >
         {inner}
-        <Draggable
-          axis="none"
-          onDrag={(event, { deltaX }) => resizeColumn(deltaX)}
-        >
-          <DragIndicator
-            fontSize="small"
-            style={{
-              cursor: 'col-resize',
-            }}
-          />
-        </Draggable>
+        {filterComponent}
       </div>
-      {filterComponent}
+      <Draggable
+        axis="none"
+        onDrag={(event, { deltaX }) => resizeColumn(deltaX)}
+      >
+        <DragIndicator
+          fontSize="small"
+          style={{
+            cursor: 'col-resize',
+          }}
+        />
+      </Draggable>
     </TableCell>
   );
 };

--- a/packages/datagateway-common/src/table/table.component.test.tsx
+++ b/packages/datagateway-common/src/table/table.component.test.tsx
@@ -131,20 +131,14 @@ describe('Table component', () => {
     ]);
   });
 
-  it('resizes all data columns correctly when a column is resized', () => {
+  it('resizes data columns correctly when a column is resized', () => {
     const wrapper = mount(<Table {...tableProps} />);
 
     wrapper.update();
 
     expect(wrapper.find('[role="columnheader"]').at(0).prop('style')).toEqual(
       expect.objectContaining({
-        flex: expect.stringContaining('400px'),
-      })
-    );
-
-    expect(wrapper.find('[role="columnheader"]').at(1).prop('style')).toEqual(
-      expect.objectContaining({
-        flex: expect.stringContaining('400px'),
+        flex: expect.stringContaining('1 1 512px'),
       })
     );
 
@@ -156,13 +150,7 @@ describe('Table component', () => {
 
     expect(wrapper.find('[role="columnheader"]').at(0).prop('style')).toEqual(
       expect.objectContaining({
-        flex: expect.stringContaining('450px'),
-      })
-    );
-
-    expect(wrapper.find('[role="columnheader"]').at(1).prop('style')).toEqual(
-      expect.objectContaining({
-        flex: expect.stringContaining('350px'),
+        flex: expect.stringContaining('0 0 562px'),
       })
     );
   });
@@ -185,13 +173,7 @@ describe('Table component', () => {
 
     expect(wrapper.find('[role="columnheader"]').at(2).prop('style')).toEqual(
       expect.objectContaining({
-        flex: expect.stringContaining('325px'),
-      })
-    );
-
-    expect(wrapper.find('[role="columnheader"]').at(3).prop('style')).toEqual(
-      expect.objectContaining({
-        flex: expect.stringContaining('325px'),
+        flex: expect.stringContaining('1 1 512px'),
       })
     );
 
@@ -203,13 +185,7 @@ describe('Table component', () => {
 
     expect(wrapper.find('[role="columnheader"]').at(2).prop('style')).toEqual(
       expect.objectContaining({
-        flex: expect.stringContaining('365px'),
-      })
-    );
-
-    expect(wrapper.find('[role="columnheader"]').at(3).prop('style')).toEqual(
-      expect.objectContaining({
-        flex: expect.stringContaining('285px'),
+        flex: expect.stringContaining('0 0 552px'),
       })
     );
   });

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -27,7 +27,7 @@ import SelectCell from './cellRenderers/selectCell.component';
 import SelectHeader from './headerRenderers/selectHeader.component';
 
 const rowHeight = 30;
-const headerHeight = 120;
+const headerHeight = 70;
 const selectColumnWidth = 40;
 const detailsColumnWidth = 40;
 const actionsColumnDefaultWidth = 70;
@@ -44,10 +44,10 @@ const styles = (theme: Theme): StyleRules =>
     },
     headerFlexContainer: {
       display: 'flex',
-      flexDirection: 'column',
+      flexDirection: 'row',
       alignItems: 'left',
       boxSizing: 'border-box',
-      justifyContent: 'flex-end',
+      overflow: 'hidden',
     },
     tableRow: {},
     tableRowHover: {
@@ -63,6 +63,9 @@ const styles = (theme: Theme): StyleRules =>
     headerTableCell: {
       flex: 1,
       height: headerHeight,
+    },
+    header: {
+      overflow: 'hidden',
     },
   });
 
@@ -312,6 +315,10 @@ const VirtualizedTable = (
                         dataKey={dataKey}
                         label={label}
                         disableSort={disableSort}
+                        headerClassName={clsx(
+                          classes.flexContainer,
+                          classes.header
+                        )}
                         headerRenderer={(headerProps) => (
                           <DataHeader
                             {...headerProps}

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -397,6 +397,7 @@ const VirtualizedTable = (
                     key="Actions"
                     dataKey="actions"
                     className={classes.flexContainer}
+                    headerClassName={classes.headerFlexContainer}
                     headerRenderer={(headerProps) => (
                       <TableCell
                         size="small"

--- a/packages/datagateway-dataview/cypress/integration/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/datafiles.spec.ts
@@ -20,25 +20,21 @@ describe('Datafiles Table', () => {
     let columnWidth = 0;
 
     cy.window()
-      .then(window => {
+      .then((window) => {
         const windowWidth = window.innerWidth;
         columnWidth = (windowWidth - 40 - 40 - 70) / 4;
       })
       .then(() => expect(columnWidth).to.not.equal(0));
 
-    cy.get('[role="columnheader"]')
-      .eq(2)
-      .as('nameColumn');
-    cy.get('[role="columnheader"]')
-      .eq(3)
-      .as('locationColumn');
+    cy.get('[role="columnheader"]').eq(2).as('nameColumn');
+    cy.get('[role="columnheader"]').eq(3).as('locationColumn');
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
 
-    cy.get('@locationColumn').should($column => {
+    cy.get('@locationColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
@@ -49,14 +45,33 @@ describe('Datafiles Table', () => {
       .trigger('mousemove', { clientX: 400 })
       .trigger('mouseup');
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.greaterThan(columnWidth);
     });
 
-    cy.get('@locationColumn').should($column => {
+    cy.get('@locationColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
+    });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@locationColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
     });
   });
 
@@ -121,9 +136,7 @@ describe('Datafiles Table', () => {
 
   describe('should be able to filter by', () => {
     it('text', () => {
-      cy.get('[aria-label="Filter by Location"]')
-        .find('input')
-        .type('ok');
+      cy.get('[aria-label="Filter by Location"]').find('input').type('ok');
 
       cy.get('[aria-rowcount="1"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
@@ -141,13 +154,11 @@ describe('Datafiles Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-day[tabindex="0"]')
-        .first()
-        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
 
       cy.contains('OK').click();
 
-      let date = new Date();
+      const date = new Date();
       date.setDate(1);
 
       cy.get('[aria-label="Modified Time date filter to"]').should(
@@ -165,13 +176,9 @@ describe('Datafiles Table', () => {
     });
 
     it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Name"]')
-        .find('input')
-        .type('5');
+      cy.get('[aria-label="Filter by Name"]').find('input').type('5');
 
-      cy.get('[aria-label="Filter by Location"]')
-        .find('input')
-        .type('.png');
+      cy.get('[aria-label="Filter by Location"]').find('input').type('.png');
 
       cy.get('[aria-rowcount="1"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
@@ -182,22 +189,16 @@ describe('Datafiles Table', () => {
 
   describe('should be able to view details', () => {
     it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains('Name: Datafile 24').should('be.visible');
       cy.get('[aria-label="Hide details"]').should('exist');
     });
 
     it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .eq(1)
-        .click();
+      cy.get('[aria-label="Show details"]').eq(1).click();
 
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains('Name: Datafile 24').should('be.visible');
       cy.contains('Name: Datafile 3377').should('not.be.visible');
@@ -205,13 +206,9 @@ describe('Datafiles Table', () => {
     });
 
     it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-label="Hide details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Hide details"]').first().click();
 
       cy.contains('Name: Datafile 24').should('not.be.visible');
       cy.get('[aria-label="Hide details"]').should('not.exist');

--- a/packages/datagateway-dataview/cypress/integration/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/datasets.spec.ts
@@ -10,9 +10,7 @@ describe('Datasets Table', () => {
   });
 
   it('should be able to click a dataset to see its datafiles', () => {
-    cy.get('[role="gridcell"] a')
-      .first()
-      .click({ force: true });
+    cy.get('[role="gridcell"] a').first().click({ force: true });
     cy.location('pathname').should(
       'eq',
       '/browse/investigation/1/dataset/25/datafile'
@@ -23,25 +21,21 @@ describe('Datasets Table', () => {
     let columnWidth = 0;
 
     cy.window()
-      .then(window => {
+      .then((window) => {
         const windowWidth = window.innerWidth;
         columnWidth = (windowWidth - 40 - 40) / 4;
       })
       .then(() => expect(columnWidth).to.not.equal(0));
 
-    cy.get('[role="columnheader"]')
-      .eq(2)
-      .as('nameColumn');
-    cy.get('[role="columnheader"]')
-      .eq(3)
-      .as('sizeColumn');
+    cy.get('[role="columnheader"]').eq(2).as('nameColumn');
+    cy.get('[role="columnheader"]').eq(3).as('sizeColumn');
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
 
-    cy.get('@sizeColumn').should($column => {
+    cy.get('@sizeColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
@@ -52,14 +46,33 @@ describe('Datasets Table', () => {
       .trigger('mousemove', { clientX: 400 })
       .trigger('mouseup');
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.greaterThan(columnWidth);
     });
 
-    cy.get('@sizeColumn').should($column => {
+    cy.get('@sizeColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
+    });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@sizeColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
     });
   });
 
@@ -120,9 +133,7 @@ describe('Datasets Table', () => {
 
   describe('should be able to filter by', () => {
     it('text', () => {
-      cy.get('[aria-label="Filter by Name"]')
-        .find('input')
-        .type('DATASET 1');
+      cy.get('[aria-label="Filter by Name"]').find('input').type('DATASET 1');
 
       cy.get('[aria-rowcount="1"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="5"]').contains(
@@ -138,13 +149,11 @@ describe('Datasets Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-day[tabindex="0"]')
-        .first()
-        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
 
       cy.contains('OK').click();
 
-      let date = new Date();
+      const date = new Date();
       date.setDate(1);
 
       cy.get('[aria-label="Create Time date filter to"]').should(
@@ -157,9 +166,7 @@ describe('Datasets Table', () => {
     });
 
     it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Name"]')
-        .find('input')
-        .type('1');
+      cy.get('[aria-label="Filter by Name"]').find('input').type('1');
 
       cy.get('[aria-label="Create Time date filter to"]').type('2002-01-01');
 
@@ -170,22 +177,16 @@ describe('Datasets Table', () => {
 
   describe('should be able to view details', () => {
     it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains('Name: DATASET 1').should('be.visible');
       cy.get('[aria-label="Hide details"]').should('exist');
     });
 
     it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .eq(1)
-        .click();
+      cy.get('[aria-label="Show details"]').eq(1).click();
 
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains('Name: DATASET 1').should('be.visible');
       cy.contains('Name: DATASET 241').should('not.be.visible');
@@ -193,13 +194,9 @@ describe('Datasets Table', () => {
     });
 
     it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-label="Hide details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Hide details"]').first().click();
 
       cy.contains('Name: DATASET 1').should('not.be.visible');
       cy.get('[aria-label="Hide details"]').should('not.exist');

--- a/packages/datagateway-dataview/cypress/integration/dls/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/dls/datafiles.spec.ts
@@ -30,25 +30,21 @@ describe('DLS - Datafiles Table', () => {
     let columnWidth = 0;
 
     cy.window()
-      .then(window => {
+      .then((window) => {
         const windowWidth = window.innerWidth;
         columnWidth = (windowWidth - 40 - 40) / 4;
       })
       .then(() => expect(columnWidth).to.not.equal(0));
 
-    cy.get('[role="columnheader"]')
-      .eq(2)
-      .as('nameColumn');
-    cy.get('[role="columnheader"]')
-      .eq(3)
-      .as('locationColumn');
+    cy.get('[role="columnheader"]').eq(2).as('nameColumn');
+    cy.get('[role="columnheader"]').eq(3).as('locationColumn');
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
 
-    cy.get('@locationColumn').should($column => {
+    cy.get('@locationColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
@@ -59,14 +55,33 @@ describe('DLS - Datafiles Table', () => {
       .trigger('mousemove', { clientX: 400 })
       .trigger('mouseup');
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.greaterThan(columnWidth);
     });
 
-    cy.get('@locationColumn').should($column => {
+    cy.get('@locationColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
+    });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@locationColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
     });
   });
 
@@ -125,9 +140,7 @@ describe('DLS - Datafiles Table', () => {
 
   describe('should be able to filter by', () => {
     it('text', () => {
-      cy.get('[aria-label="Filter by Location"]')
-        .find('input')
-        .type('ok');
+      cy.get('[aria-label="Filter by Location"]').find('input').type('ok');
 
       cy.get('[aria-rowcount="1"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
@@ -143,13 +156,11 @@ describe('DLS - Datafiles Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-day[tabindex="0"]')
-        .first()
-        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
 
       cy.contains('OK').click();
 
-      let date = new Date();
+      const date = new Date();
       date.setDate(1);
 
       cy.get('[aria-label="Create Time date filter to"]').should(
@@ -167,13 +178,9 @@ describe('DLS - Datafiles Table', () => {
     });
 
     it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Name"]')
-        .find('input')
-        .type('5');
+      cy.get('[aria-label="Filter by Name"]').find('input').type('5');
 
-      cy.get('[aria-label="Filter by Location"]')
-        .find('input')
-        .type('.png');
+      cy.get('[aria-label="Filter by Location"]').find('input').type('.png');
 
       cy.get('[aria-rowcount="1"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
@@ -184,22 +191,16 @@ describe('DLS - Datafiles Table', () => {
 
   describe('should be able to view details', () => {
     it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains('Name: Datafile 24').should('be.visible');
       cy.get('[aria-label="Hide details"]').should('exist');
     });
 
     it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .eq(1)
-        .click();
+      cy.get('[aria-label="Show details"]').eq(1).click();
 
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains('Name: Datafile 24').should('be.visible');
       cy.contains('Name: Datafile 3377').should('not.be.visible');
@@ -207,13 +208,9 @@ describe('DLS - Datafiles Table', () => {
     });
 
     it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-label="Hide details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Hide details"]').first().click();
 
       cy.contains('Name: Datafile 24').should('not.be.visible');
       cy.get('[aria-label="Hide details"]').should('not.exist');

--- a/packages/datagateway-dataview/cypress/integration/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/dls/datasets.spec.ts
@@ -70,6 +70,25 @@ describe('DLS - Datasets Table', () => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@datafileCountColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
   describe('should be able to sort by', () => {

--- a/packages/datagateway-dataview/cypress/integration/dls/myData.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/dls/myData.spec.ts
@@ -58,6 +58,25 @@ describe('DLS - MyData Table', () => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@visitIdColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
   describe.skip('should be able to sort by', () => {

--- a/packages/datagateway-dataview/cypress/integration/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/dls/proposals.spec.ts
@@ -10,9 +10,7 @@ describe('DLS - Proposals Table', () => {
   });
 
   it('should be able to click a proposal to see its investigations', () => {
-    cy.get('[role="gridcell"] a')
-      .first()
-      .click({ force: true });
+    cy.get('[role="gridcell"] a').first().click({ force: true });
 
     cy.location('pathname').should(
       'eq',
@@ -30,25 +28,21 @@ describe('DLS - Proposals Table', () => {
     let columnWidth = 0;
 
     cy.window()
-      .then(window => {
+      .then((window) => {
         const windowWidth = window.innerWidth;
         columnWidth = windowWidth / 2;
       })
       .then(() => expect(columnWidth).to.not.equal(0));
 
-    cy.get('[role="columnheader"]')
-      .eq(0)
-      .as('titleColumn');
-    cy.get('[role="columnheader"]')
-      .eq(1)
-      .as('nameColumn');
+    cy.get('[role="columnheader"]').eq(0).as('titleColumn');
+    cy.get('[role="columnheader"]').eq(1).as('nameColumn');
 
-    cy.get('@titleColumn').should($column => {
+    cy.get('@titleColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
@@ -59,14 +53,33 @@ describe('DLS - Proposals Table', () => {
       .trigger('mousemove', { clientX: 500 })
       .trigger('mouseup');
 
-    cy.get('@titleColumn').should($column => {
+    cy.get('@titleColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.greaterThan(columnWidth);
     });
 
-    cy.get('@nameColumn').should($column => {
+    cy.get('@nameColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
+    });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 1000 })
+      .trigger('mouseup');
+
+    cy.get('@nameColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
     });
   });
 
@@ -127,9 +140,7 @@ describe('DLS - Proposals Table', () => {
 
   describe('should be able to filter by', () => {
     it('text', () => {
-      cy.get('[aria-label="Filter by Title"]')
-        .find('input')
-        .type('dog');
+      cy.get('[aria-label="Filter by Title"]').find('input').type('dog');
 
       cy.get('[aria-rowcount="4"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
@@ -138,9 +149,7 @@ describe('DLS - Proposals Table', () => {
     });
 
     it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Title"]')
-        .find('input')
-        .type('dog');
+      cy.get('[aria-label="Filter by Title"]').find('input').type('dog');
 
       cy.get('[aria-label="Filter by Name"]')
         .find('input')

--- a/packages/datagateway-dataview/cypress/integration/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/dls/visits.spec.ts
@@ -65,6 +65,25 @@ describe('DLS - Visits Table', () => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@datasetCountColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
   describe('should be able to sort by', () => {

--- a/packages/datagateway-dataview/cypress/integration/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/investigations.spec.ts
@@ -10,9 +10,7 @@ describe('Investigations Table', () => {
   });
 
   it('should be able to click an investigation to see its datasets', () => {
-    cy.get('[role="gridcell"] a')
-      .first()
-      .click({ force: true });
+    cy.get('[role="gridcell"] a').first().click({ force: true });
     cy.location('pathname').should('eq', '/browse/investigation/1/dataset');
   });
 
@@ -26,25 +24,21 @@ describe('Investigations Table', () => {
     let columnWidth = 0;
 
     cy.window()
-      .then(window => {
+      .then((window) => {
         const windowWidth = window.innerWidth;
         columnWidth = (windowWidth - 40 - 40) / 8;
       })
       .then(() => expect(columnWidth).to.not.equal(0));
 
-    cy.get('[role="columnheader"]')
-      .eq(2)
-      .as('titleColumn');
-    cy.get('[role="columnheader"]')
-      .eq(3)
-      .as('visitColumn');
+    cy.get('[role="columnheader"]').eq(2).as('titleColumn');
+    cy.get('[role="columnheader"]').eq(3).as('visitColumn');
 
-    cy.get('@titleColumn').should($column => {
+    cy.get('@titleColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
 
-    cy.get('@visitColumn').should($column => {
+    cy.get('@visitColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
@@ -55,14 +49,33 @@ describe('Investigations Table', () => {
       .trigger('mousemove', { clientX: 200 })
       .trigger('mouseup');
 
-    cy.get('@titleColumn').should($column => {
+    cy.get('@titleColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.greaterThan(columnWidth);
     });
 
-    cy.get('@visitColumn').should($column => {
+    cy.get('@visitColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
+    });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@visitColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
     });
   });
 
@@ -122,9 +135,7 @@ describe('Investigations Table', () => {
 
   describe('should be able to filter by', () => {
     it('text', () => {
-      cy.get('[aria-label="Filter by Title"]')
-        .find('input')
-        .type('dog');
+      cy.get('[aria-label="Filter by Title"]').find('input').type('dog');
 
       cy.get('[aria-rowcount="4"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('1');
@@ -138,13 +149,11 @@ describe('Investigations Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-day[tabindex="0"]')
-        .first()
-        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
 
       cy.contains('OK').click();
 
-      let date = new Date();
+      const date = new Date();
       date.setDate(1);
 
       cy.get('[aria-label="Start Date date filter to"]').should(
@@ -159,13 +168,9 @@ describe('Investigations Table', () => {
     });
 
     it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Title"]')
-        .find('input')
-        .type('dog');
+      cy.get('[aria-label="Filter by Title"]').find('input').type('dog');
 
-      cy.get('[aria-label="Filter by Visit ID"]')
-        .find('input')
-        .type('9');
+      cy.get('[aria-label="Filter by Visit ID"]').find('input').type('9');
 
       cy.get('[aria-rowcount="2"]').should('exist');
     });
@@ -173,9 +178,7 @@ describe('Investigations Table', () => {
 
   describe('should be able to view details', () => {
     it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains(
         'Title: Including spend increase ability music skill former. Agreement director concern once technology sometimes someone staff.'
@@ -184,13 +187,9 @@ describe('Investigations Table', () => {
     });
 
     it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .eq(2)
-        .click();
+      cy.get('[aria-label="Show details"]').eq(2).click();
 
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains(
         'Title: Including spend increase ability music skill former. Agreement director concern once technology sometimes someone staff.'
@@ -202,13 +201,9 @@ describe('Investigations Table', () => {
     });
 
     it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-label="Hide details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Hide details"]').first().click();
 
       cy.contains(
         'Title: Including spend increase ability music skill former. Agreement director concern once technology sometimes someone staff.'

--- a/packages/datagateway-dataview/cypress/integration/isis/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/isis/datafiles.spec.ts
@@ -64,6 +64,25 @@ describe('ISIS - Datafiles Table', () => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@locationColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
   describe('should be able to sort by', () => {

--- a/packages/datagateway-dataview/cypress/integration/isis/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/isis/datasets.spec.ts
@@ -71,6 +71,25 @@ describe('ISIS - Datasets Table', () => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@sizeColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
   describe('should be able to sort by', () => {

--- a/packages/datagateway-dataview/cypress/integration/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/isis/facilityCycles.spec.ts
@@ -62,6 +62,25 @@ describe('ISIS - FacilityCycles Table', () => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@descriptionColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
   describe('should be able to sort by', () => {

--- a/packages/datagateway-dataview/cypress/integration/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/isis/investigations.spec.ts
@@ -62,6 +62,25 @@ describe('ISIS - Investigations Table', () => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@visitColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
   describe('should be able to sort by', () => {

--- a/packages/datagateway-dataview/cypress/integration/isis/myData.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/isis/myData.spec.ts
@@ -10,9 +10,7 @@ describe('ISIS - MyData Table', () => {
   });
 
   it('should be able to click an investigation to see its datasets', () => {
-    cy.get('[role="gridcell"] a')
-      .first()
-      .click({ force: true });
+    cy.get('[role="gridcell"] a').first().click({ force: true });
     cy.location('pathname').should(
       'eq',
       '/browse/instrument/5/facilityCycle/10/investigation/1/dataset'
@@ -30,25 +28,21 @@ describe('ISIS - MyData Table', () => {
     let columnWidth = 0;
 
     cy.window()
-      .then(window => {
+      .then((window) => {
         const windowWidth = window.innerWidth;
         columnWidth = (windowWidth - 40 - 40) / 8;
       })
       .then(() => expect(columnWidth).to.not.equal(0));
 
-    cy.get('[role="columnheader"]')
-      .eq(2)
-      .as('titleColumn');
-    cy.get('[role="columnheader"]')
-      .eq(3)
-      .as('doiColumn');
+    cy.get('[role="columnheader"]').eq(2).as('titleColumn');
+    cy.get('[role="columnheader"]').eq(3).as('doiColumn');
 
-    cy.get('@titleColumn').should($column => {
+    cy.get('@titleColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
 
-    cy.get('@doiColumn').should($column => {
+    cy.get('@doiColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.equal(columnWidth);
     });
@@ -59,26 +53,44 @@ describe('ISIS - MyData Table', () => {
       .trigger('mousemove', { clientX: 200 })
       .trigger('mouseup');
 
-    cy.get('@titleColumn').should($column => {
+    cy.get('@titleColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.greaterThan(columnWidth);
     });
 
-    cy.get('@doiColumn').should($column => {
+    cy.get('@doiColumn').should(($column) => {
       const { width } = $column[0].getBoundingClientRect();
       expect(width).to.be.lessThan(columnWidth);
     });
+
+    // table width should grow if a column grows too large
+    cy.get('.react-draggable')
+      .first()
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 800 })
+      .trigger('mouseup');
+
+    cy.get('@doiColumn').should(($column) => {
+      const { width } = $column[0].getBoundingClientRect();
+      expect(width).to.be.equal(70);
+    });
+
+    cy.get('[aria-label="grid"]').then(($grid) => {
+      const { width } = $grid[0].getBoundingClientRect();
+      cy.window().should(($window) => {
+        expect(width).to.be.greaterThan($window.innerWidth);
+      });
+    });
   });
 
-  // we only have one row - so can't properly test sorting
-  describe.skip('should be able to sort by', () => {});
+  describe.skip('should be able to sort by', () => {
+    // we only have one row - so can't properly test sorting
+  });
 
   describe('should be able to filter by', () => {
     it('text', () => {
       cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-label="Filter by Title"]')
-        .find('input')
-        .type('invalid');
+      cy.get('[aria-label="Filter by Title"]').find('input').type('invalid');
 
       cy.get('[aria-rowcount="0"]').should('exist');
     });
@@ -91,13 +103,11 @@ describe('ISIS - MyData Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-day[tabindex="0"]')
-        .first()
-        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
 
       cy.contains('OK').click();
 
-      let date = new Date();
+      const date = new Date();
       date.setDate(1);
 
       cy.get('[aria-label="Start Date date filter to"]').should(
@@ -116,9 +126,7 @@ describe('ISIS - MyData Table', () => {
 
       cy.get('[aria-rowcount="1"]').should('exist');
 
-      cy.get('[aria-label="Filter by Title"]')
-        .find('input')
-        .type('invalid');
+      cy.get('[aria-label="Filter by Title"]').find('input').type('invalid');
 
       cy.get('[aria-rowcount="0"]').should('exist');
     });
@@ -134,9 +142,7 @@ describe('ISIS - MyData Table', () => {
     });
 
     it('when not other row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.contains('Proposal: INVESTIGATION 1').should('be.visible');
       cy.get('[aria-label="Hide details"]').should('exist');
@@ -146,9 +152,7 @@ describe('ISIS - MyData Table', () => {
     // as well since we are currently limited to 1 investigation to test.
 
     it('and view investigation details, users, samples and publications', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
       cy.get('[aria-controls="investigation-details-panel"]').should(
         'be.visible'
@@ -183,13 +187,9 @@ describe('ISIS - MyData Table', () => {
     });
 
     it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-label="Hide details"]')
-        .first()
-        .click();
+      cy.get('[aria-label="Hide details"]').first().click();
 
       cy.contains('Proposal: INVESTIGATION 1').should('not.be.visible');
       cy.get('[aria-label="Hide details"]').should('not.exist');


### PR DESCRIPTION
## Description
This fixes various CSS issues to do with the column headers - specifically the misalignment of headers with their respective columns - and also improves how the resizing works. Now, if a user resizes a column, it is "locked" into that size and resizing another column will not shrink that column. I believe this is similar to how resizing in TopCAT works. Also, I set minimum column sizes and a minimum table size which mean that columns will never shrink to nothing and if the user's screen is too small, or they have made some columns very large, the table will scroll horizontally.

Additionally, I reversed the changes Tim made to make headers hug the bottom of the table - this is both due to practical reasons in that the rearrangement of the contents of the cell made it easier for them to be arranged as they are now and for my personal reasons that I think the column labels should be lined up together, and the only way to achieve that is via aligning at the top due to different filter sizes. If people disagree I can change the header alignment back to hug the bottom of the table again.

GIF:

![resize-table-test](https://user-images.githubusercontent.com/22525471/88193524-ad3cd700-cc35-11ea-9818-321f25988d7e.gif)


## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage

## Agile board tracking
Closes #123 and closes #124 
