### PR TITLE
Feature/download settings max #328

### DIFF
--- a/packages/datagateway-download/public/datagateway-download-settings.example.json
+++ b/packages/datagateway-download/public/datagateway-download-settings.example.json
@@ -3,6 +3,8 @@
   "apiUrl": "example.api.url",
   "downloadApiUrl": "example.download.api.url",
   "idsUrl": "example.ids.url",
+  "fileCountMax": 5000,
+  "totalSizeMax": 1000000000000,
   "accessMethods": {
     "https": {
       "idsUrl": "example.ids.url",

--- a/packages/datagateway-download/public/datagateway-download-settings.json
+++ b/packages/datagateway-download/public/datagateway-download-settings.json
@@ -3,6 +3,8 @@
   "apiUrl": "http://scigateway-preprod.esc.rl.ac.uk:5000",
   "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",
   "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
+  "fileCountMax": 5000,
+  "totalSizeMax": 1000000000000,
   "accessMethods": {
     "https": {
       "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",

--- a/packages/datagateway-download/server/e2e-settings.json
+++ b/packages/datagateway-download/server/e2e-settings.json
@@ -3,6 +3,8 @@
   "apiUrl": "http://scigateway-preprod.esc.rl.ac.uk:5000",
   "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",
   "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
+  "fileCountMax": 5000,
+  "totalSizeMax": 1000000000000,
   "accessMethods": {
     "https": {
       "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",

--- a/packages/datagateway-download/src/ConfigProvider.test.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.test.tsx
@@ -45,6 +45,8 @@ describe('ConfigProvider', () => {
       idsUrl: 'ids',
       apiUrl: 'api',
       downloadApiUrl: 'download-api',
+      fileCountMax: 5000,
+      totalSizeMax: 1000000000000,
       accessMethods: {
         https: {
           idsUrl: 'https-ids',
@@ -86,6 +88,8 @@ describe('ConfigProvider', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
+          fileCountMax: 5000,
+          totalSizeMax: 1000000000000,
           accessMethods: {
             https: {
               idsUrl: 'https-ids',
@@ -120,6 +124,8 @@ describe('ConfigProvider', () => {
       Promise.resolve({
         data: {
           facilityName: 'Generic',
+          fileCountMax: 5000,
+          totalSizeMax: 1000000000000,
           accessMethods: {
             https: {
               idsUrl: 'https-ids',
@@ -155,6 +161,8 @@ describe('ConfigProvider', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
+          fileCountMax: 5000,
+          totalSizeMax: 1000000000000,
         },
       })
     );
@@ -183,6 +191,8 @@ describe('ConfigProvider', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
+          fileCountMax: 5000,
+          totalSizeMax: 1000000000000,
           accessMethods: {
             https: {
               idsUrl: 'https-ids',
@@ -222,6 +232,8 @@ describe('ConfigProvider', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
+          fileCountMax: 5000,
+          totalSizeMax: 1000000000000,
           accessMethods: {},
         },
       })
@@ -282,6 +294,45 @@ describe('ConfigProvider', () => {
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
       'Error loading datagateway-download-settings.json: undefined'
+    );
+  });
+
+  it('logs an error if fileCountMax or totalSizeMax are undefined in the settings', async () => {
+    (axios.get as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        data: {
+          facilityName: 'Generic',
+          idsUrl: 'ids',
+          apiUrl: 'api',
+          downloadApiUrl: 'download-api',
+          accessMethods: {
+            https: {
+              idsUrl: 'https-ids',
+              displayName: 'HTTPS',
+              description: 'HTTP description',
+            },
+            globus: {
+              displayName: 'Globus',
+              description: 'Globus description',
+            },
+          },
+        },
+      })
+    );
+
+    // Create the wrapper and wait for it to load.
+    const wrapper = createWrapper();
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.exists('#settings')).toBe(false);
+    expect(log.error).toHaveBeenCalled();
+
+    const mockLog = (log.error as jest.Mock).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      'Error loading datagateway-download-settings.json: fileCountMax or totalSizeMax is undefined in settings'
     );
   });
 });

--- a/packages/datagateway-download/src/ConfigProvider.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.tsx
@@ -17,6 +17,9 @@ export interface DownloadSettings {
   downloadApiUrl: string;
   idsUrl: string;
 
+  fileCountMax: number;
+  totalSizeMax: number;
+
   accessMethods: DownloadSettingsAccessMethod;
 }
 
@@ -25,6 +28,8 @@ const initialConfiguration = {
   apiUrl: '',
   downloadApiUrl: '',
   idsUrl: '',
+  fileCountMax: -1,
+  totalSizeMax: -1,
   accessMethods: {},
 };
 
@@ -74,6 +79,13 @@ class ConfigProvider extends React.Component<
         ) {
           throw new Error(
             'One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
+          );
+        }
+
+        // Ensure all fileCountMax and totalSizeMax are present.
+        if (!('fileCountMax' in settings && 'totalSizeMax' in settings)) {
+          throw new Error(
+            'fileCountMax or totalSizeMax is undefined in settings'
           );
         }
 

--- a/packages/datagateway-download/src/__mocks__/axios.ts
+++ b/packages/datagateway-download/src/__mocks__/axios.ts
@@ -13,6 +13,8 @@ export default {
           apiUrl: 'http://scigateway-preprod.esc.rl.ac.uk:5000',
           downloadApiUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat',
           idsUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/ids',
+          fileCountMax: 5000,
+          totalSizeMax: 1000000000000,
           accessMethods: {
             https: {
               idsUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/ids',

--- a/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`Download cart table component renders correctly 1`] = `
         >
           Number of files: 
           Calculating...
+           / 0
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))
           id="totalSizeDisplay"
@@ -79,6 +80,7 @@ exports[`Download cart table component renders correctly 1`] = `
           Total size:
            
           0 B
+           / 0 B
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
@@ -72,7 +72,6 @@ exports[`Download cart table component renders correctly 1`] = `
         >
           Number of files: 
           Calculating...
-           / 0
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))
           id="totalSizeDisplay"
@@ -80,7 +79,6 @@ exports[`Download cart table component renders correctly 1`] = `
           Total size:
            
           0 B
-           / 0 B
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -75,6 +75,8 @@ describe('Download cart table component', () => {
     apiUrl: 'http://scigateway-preprod.esc.rl.ac.uk:5000',
     downloadApiUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat',
     idsUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/ids',
+    fileCountMax: 5000,
+    totalSizeMax: 1000000000000,
     accessMethods: {
       https: {
         idsUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/ids',

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -41,10 +41,9 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
   const [sizesLoaded, setSizesLoaded] = React.useState(true);
   const [sizesFinished, setSizesFinished] = React.useState(true);
 
-  // TODO: Determine fileCountMax and totalSizeMax from settings.
   const [fileCount, setFileCount] = React.useState<number>(-1);
-  const [fileCountMax, setFileCountMax] = React.useState<number>(-1);
-  const [totalSizeMax, setTotalSizeMax] = React.useState<number>(-1);
+  const fileCountMax = settings.fileCountMax;
+  const totalSizeMax = settings.totalSizeMax;
 
   const [showConfirmation, setShowConfirmation] = React.useState(false);
   const [isTwoLevel, setIsTwoLevel] = React.useState(false);
@@ -135,11 +134,6 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
     settings.apiUrl,
     settings.downloadApiUrl,
   ]);
-
-  React.useEffect(() => {
-    setFileCountMax(5000);
-    setTotalSizeMax(1000000000000);
-  }, [setFileCount, setFileCountMax, setTotalSizeMax]);
 
   const textFilter = (label: string, dataKey: string): React.ReactElement => (
     <TextColumnFilter


### PR DESCRIPTION
## Description
Adds in support for getting the fileCountMax and totalSizeMax used in the downloadCartTable (in datagateway-download) from the settings.

## Testing instructions

- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage

## Agile board tracking
closes #328
