### PR TITLE
Bugfix/remove git add

### DIFF
--- a/packages/datagateway-common/package.json
+++ b/packages/datagateway-common/package.json
@@ -77,13 +77,11 @@
   "lint-staged": {
     "src/**/*.{tsx,ts,js,jsx,json}": [
       "eslint --max-warnings=0 --ext=tsx --ext=ts --ext=js --ext=jsx  --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "cypress/**/*.{tsx,ts,js,jsx,json}": [
       "eslint --max-warnings=0 --ext=tsx --ext=ts --ext=js --ext=jsx --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "browserslist": {

--- a/packages/datagateway-dataview/package.json
+++ b/packages/datagateway-dataview/package.json
@@ -81,13 +81,11 @@
   "lint-staged": {
     "src/**/*.{tsx,ts,js,jsx,json}": [
       "eslint --max-warnings=0 --ext=tsx --ext=ts --ext=js --ext=jsx  --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "cypress/**/*.{tsx,ts,js,jsx}": [
       "eslint --max-warnings=0 --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "devDependencies": {

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -86,13 +86,11 @@
   "lint-staged": {
     "src/**/*.{tsx,js,jsx,json}": [
       "eslint --max-warnings=0 --ext=tsx --ext=ts --ext=js --ext=jsx --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "cypress/**/*.{tsx,js,jsx}": [
       "eslint --max-warnings=0 --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "jest": {

--- a/packages/datagateway-search/package.json
+++ b/packages/datagateway-search/package.json
@@ -79,13 +79,11 @@
   "lint-staged": {
     "src/**/*.{tsx,ts,js,jsx,json}": [
       "eslint --max-warnings=0 --ext=tsx --ext=ts --ext=js --ext=jsx  --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "cypress/**/*.{tsx,ts,js,jsx}": [
       "eslint --max-warnings=0 --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Addresses #471 by removing `git add` in the pre-commit hooks for each plugin `package.json`.

## Testing instructions

- [x] Committing code does not bring up a message to remove the `git add` in the config.

## Agile board tracking
Closes #471 
