### PR TITLE
Fix date search in datagateway-search for only one date

### DIFF
--- a/packages/datagateway-search/src/search/searchButton.component.test.tsx
+++ b/packages/datagateway-search/src/search/searchButton.component.test.tsx
@@ -235,7 +235,7 @@ describe('Search Button component tests', () => {
           query: {
             target: 'Datafile',
             lower: '201311110000',
-            upper: '210001012359',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -278,7 +278,7 @@ describe('Search Button component tests', () => {
           query: {
             target: 'Dataset',
             lower: '201311110000',
-            upper: '210001012359',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -321,7 +321,7 @@ describe('Search Button component tests', () => {
           query: {
             target: 'Investigation',
             lower: '201311110000',
-            upper: '210001012359',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -357,7 +357,7 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Datafile',
-            lower: '198401010000',
+            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -400,7 +400,7 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Dataset',
-            lower: '198401010000',
+            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -443,7 +443,7 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Investigation',
-            lower: '198401010000',
+            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -472,8 +472,8 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Datafile',
-            lower: '198401010000',
-            upper: '210001012359',
+            lower: '0000001010000',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -511,8 +511,8 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Dataset',
-            lower: '198401010000',
-            upper: '210001012359',
+            lower: '0000001010000',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -550,8 +550,8 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Investigation',
-            lower: '198401010000',
-            upper: '210001012359',
+            lower: '0000001010000',
+            upper: '9000012312359',
           },
           sessionId: null,
         },

--- a/packages/datagateway-search/src/search/searchButton.component.test.tsx
+++ b/packages/datagateway-search/src/search/searchButton.component.test.tsx
@@ -206,6 +206,252 @@ describe('Search Button component tests', () => {
     );
   });
 
+  it('builds correct parameters for datafile request if only start date is in use', () => {
+    state.dgsearch = {
+      ...state.dgsearch,
+      selectDate: {
+        ...state.dgsearch.selectDate,
+        startDate: new Date('2013-11-11'),
+      },
+    };
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <SearchButton />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('button[aria-label="searchBox.search_button_arialabel"]')
+      .simulate('click');
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Datafile',
+            lower: '201311110000',
+            upper: '210001012359',
+          },
+          sessionId: null,
+        },
+      }
+    );
+  });
+
+  it('builds correct parameters for dataset request if only start date is in use', () => {
+    state.dgsearch = {
+      ...state.dgsearch,
+      selectDate: {
+        ...state.dgsearch.selectDate,
+        startDate: new Date('2013-11-11'),
+      },
+      checkBox: {
+        ...state.dgsearch.checkBox,
+        dataset: true,
+        datafile: false,
+        investigation: false,
+      },
+    };
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <SearchButton />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('button[aria-label="searchBox.search_button_arialabel"]')
+      .simulate('click');
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Dataset',
+            lower: '201311110000',
+            upper: '210001012359',
+          },
+          sessionId: null,
+        },
+      }
+    );
+  });
+
+  it('builds correct parameters for investigation request if only start date is in use', () => {
+    state.dgsearch = {
+      ...state.dgsearch,
+      selectDate: {
+        ...state.dgsearch.selectDate,
+        startDate: new Date('2013-11-11'),
+      },
+      checkBox: {
+        ...state.dgsearch.checkBox,
+        dataset: false,
+        datafile: false,
+        investigation: true,
+      },
+    };
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <SearchButton />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('button[aria-label="searchBox.search_button_arialabel"]')
+      .simulate('click');
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Investigation',
+            lower: '201311110000',
+            upper: '210001012359',
+          },
+          sessionId: null,
+        },
+      }
+    );
+  });
+
+  it('builds correct parameters for datafile request if only end date is in use', () => {
+    state.dgsearch = {
+      ...state.dgsearch,
+      selectDate: {
+        ...state.dgsearch.selectDate,
+        endDate: new Date('2016-11-11'),
+      },
+    };
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <SearchButton />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('button[aria-label="searchBox.search_button_arialabel"]')
+      .simulate('click');
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Datafile',
+            lower: '198401010000',
+            upper: '201611112359',
+          },
+          sessionId: null,
+        },
+      }
+    );
+  });
+
+  it('builds correct parameters for dataset request if only end date is in use', () => {
+    state.dgsearch = {
+      ...state.dgsearch,
+      selectDate: {
+        ...state.dgsearch.selectDate,
+        endDate: new Date('2016-11-11'),
+      },
+      checkBox: {
+        ...state.dgsearch.checkBox,
+        dataset: true,
+        datafile: false,
+        investigation: false,
+      },
+    };
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <SearchButton />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('button[aria-label="searchBox.search_button_arialabel"]')
+      .simulate('click');
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Dataset',
+            lower: '198401010000',
+            upper: '201611112359',
+          },
+          sessionId: null,
+        },
+      }
+    );
+  });
+
+  it('builds correct parameters for investigation request if only end date is in use', () => {
+    state.dgsearch = {
+      ...state.dgsearch,
+      selectDate: {
+        ...state.dgsearch.selectDate,
+        endDate: new Date('2016-11-11'),
+      },
+      checkBox: {
+        ...state.dgsearch.checkBox,
+        dataset: false,
+        datafile: false,
+        investigation: true,
+      },
+    };
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <SearchButton />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper
+      .find('button[aria-label="searchBox.search_button_arialabel"]')
+      .simulate('click');
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Investigation',
+            lower: '198401010000',
+            upper: '201611112359',
+          },
+          sessionId: null,
+        },
+      }
+    );
+  });
+
   it('builds correct parameters for datafile request if date and search text properties are not in use', () => {
     const testStore = mockStore(state);
     const wrapper = mount(
@@ -226,6 +472,8 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Datafile',
+            lower: '198401010000',
+            upper: '210001012359',
           },
           sessionId: null,
         },
@@ -263,6 +511,8 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Dataset',
+            lower: '198401010000',
+            upper: '210001012359',
           },
           sessionId: null,
         },
@@ -300,6 +550,8 @@ describe('Search Button component tests', () => {
           maxCount: 300,
           query: {
             target: 'Investigation',
+            lower: '198401010000',
+            upper: '210001012359',
           },
           sessionId: null,
         },

--- a/packages/datagateway-search/src/search/searchButton.component.tsx
+++ b/packages/datagateway-search/src/search/searchButton.component.tsx
@@ -76,7 +76,7 @@ class SearchButton extends React.Component<SearchButtonCombinedProps> {
     let stringStartDate =
       this.props.startDate !== null
         ? format(this.props.startDate, 'yyyy-MM-dd')
-        : '1984-01-01';
+        : '00000-01-01';
     const stringStartDateArray = stringStartDate.split('-');
     stringStartDate =
       stringStartDateArray[0] +
@@ -87,7 +87,7 @@ class SearchButton extends React.Component<SearchButtonCombinedProps> {
     let stringEndDate =
       this.props.endDate !== null
         ? format(this.props.endDate, 'yyyy-MM-dd')
-        : '2100-01-01';
+        : '90000-12-31';
     const stringEndDateArray = stringEndDate.split('-');
     stringEndDate =
       stringEndDateArray[0] +

--- a/packages/datagateway-search/src/search/searchButton.component.tsx
+++ b/packages/datagateway-search/src/search/searchButton.component.tsx
@@ -73,27 +73,27 @@ class SearchButton extends React.Component<SearchButtonCombinedProps> {
   }
 
   public urlParamsBuilder = (datasearchtype: string): LuceneParameters => {
-    let stringStartDate = '';
-    if (this.props.startDate !== null) {
-      stringStartDate = format(this.props.startDate, 'yyyy-MM-dd');
-      const stringStartDateArray = stringStartDate.split('-');
-      stringStartDate =
-        stringStartDateArray[0] +
-        stringStartDateArray[1] +
-        stringStartDateArray[2] +
-        '0000';
-    }
+    let stringStartDate =
+      this.props.startDate !== null
+        ? format(this.props.startDate, 'yyyy-MM-dd')
+        : '1984-01-01';
+    const stringStartDateArray = stringStartDate.split('-');
+    stringStartDate =
+      stringStartDateArray[0] +
+      stringStartDateArray[1] +
+      stringStartDateArray[2] +
+      '0000';
 
-    let stringEndDate = '';
-    if (this.props.endDate !== null) {
-      stringEndDate = format(this.props.endDate, 'yyyy-MM-dd');
-      const stringEndDateArray = stringEndDate.split('-');
-      stringEndDate =
-        stringEndDateArray[0] +
-        stringEndDateArray[1] +
-        stringEndDateArray[2] +
-        '2359';
-    }
+    let stringEndDate =
+      this.props.endDate !== null
+        ? format(this.props.endDate, 'yyyy-MM-dd')
+        : '2100-01-01';
+    const stringEndDateArray = stringEndDate.split('-');
+    stringEndDate =
+      stringEndDateArray[0] +
+      stringEndDateArray[1] +
+      stringEndDateArray[2] +
+      '2359';
 
     const query: QueryParameters = {
       target: datasearchtype,
@@ -102,14 +102,8 @@ class SearchButton extends React.Component<SearchButtonCombinedProps> {
     if (this.props.searchText.length > 0) {
       query.text = this.props.searchText;
     }
-
-    if (stringStartDate.length > 0) {
-      query.lower = stringStartDate;
-    }
-
-    if (stringEndDate.length > 0) {
-      query.upper = stringEndDate;
-    }
+    query.lower = stringStartDate;
+    query.upper = stringEndDate;
 
     const queryParams = {
       sessionId: readSciGatewayToken().sessionId,


### PR DESCRIPTION
## Description
Sets a date limit to the date that is not provided so that only the results before/ after the provided date are displayed.

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [x] Navigate to _Datagateway Search_, tick all three boxes (_Investigation_, _Dataset_ and _Datafile_), pick a start date, click the _SEARCH_ button, click on the _INVESTIGATION_ tab that is present in the results table and check that only results after the picked date are displayed. Check that this is the case in the _DATASET_ and the _DATAFILE_ tab.
- [x] Repeat the above step but picking only an end date this time.

## Agile board tracking
Closes #464 
