### PR TITLE
use secondary colour for calculate button #492

### DIFF
--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`Dataset details panel component renders calculate size button when size
         <WithStyles(ForwardRef(Typography))>
           <b>
             <WithStyles(ForwardRef(Button))
-              color="primary"
+              color="secondary"
               id="calculate-size-btn"
               onClick={[Function]}
               size="small"
@@ -202,7 +202,7 @@ exports[`Dataset details panel component renders correctly 1`] = `
         <WithStyles(ForwardRef(Typography))>
           <b>
             <WithStyles(ForwardRef(Button))
-              color="primary"
+              color="secondary"
               id="calculate-size-btn"
               onClick={[Function]}
               size="small"
@@ -317,7 +317,7 @@ exports[`Dataset details panel component renders type tab when present in the da
         <WithStyles(ForwardRef(Typography))>
           <b>
             <WithStyles(ForwardRef(Button))
-              color="primary"
+              color="secondary"
               id="calculate-size-btn"
               onClick={[Function]}
               size="small"

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/visitDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/visitDetailsPanel.component.test.tsx.snap
@@ -284,7 +284,7 @@ exports[`Visit details panel component renders calculate size button when size h
         <WithStyles(ForwardRef(Typography))>
           <b>
             <WithStyles(ForwardRef(Button))
-              color="primary"
+              color="secondary"
               id="calculate-size-btn"
               onClick={[Function]}
               size="small"

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
@@ -124,7 +124,7 @@ const DatasetDetailsPanel = (
                       fetchSize(datasetData.ID);
                     }}
                     variant="outlined"
-                    color="primary"
+                    color="secondary"
                     size="small"
                     id="calculate-size-btn"
                   >

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -169,7 +169,7 @@ const VisitDetailsPanel = (
                       fetchSize(investigationData.ID);
                     }}
                     variant="outlined"
-                    color="primary"
+                    color="secondary"
                     size="small"
                     id="calculate-size-btn"
                   >


### PR DESCRIPTION
## Description
Use secondary colour for calculate buttons, and update test snapshots.

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [x] Check button appears unchanged in light mode, but is a more visble light blue in dark mode

## Agile board tracking
connect to #492
