### PR TITLE
add padding to search/cart icons #507

### DIFF
--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -125,7 +125,15 @@ const NavBar = (props: {
             }}
           />
         </Grid>
-        <Paper square style={{ backgroundColor: 'inherit', display: 'flex' }}>
+        <Paper
+          square
+          style={{
+            backgroundColor: 'inherit',
+            display: 'flex',
+            paddingLeft: 6,
+            paddingRight: 6,
+          }}
+        >
           <IconButton
             className="tour-dataview-search-icon"
             onClick={props.navigateToSearch}
@@ -135,7 +143,15 @@ const NavBar = (props: {
             <SearchIcon />
           </IconButton>
         </Paper>
-        <Paper square style={{ backgroundColor: 'inherit', display: 'flex' }}>
+        <Paper
+          square
+          style={{
+            backgroundColor: 'inherit',
+            display: 'flex',
+            paddingLeft: 6,
+            paddingRight: 6,
+          }}
+        >
           <IconButton
             className="tour-dataview-cart-icon"
             onClick={props.navigateToDownload}


### PR DESCRIPTION
## Description
Add padding to the cart icon (and search icon for consitency) so that large badges do not extend out of the app and generate a scrollbar.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage
- [ ] Add >99 items to cart and check no scroll bar appears for the window, and that the entirety of the badge is (just) visible

## Agile board tracking
closes #507
