### PR TITLE
disable DF count and RB sorting #460

### DIFF
--- a/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
@@ -168,6 +168,7 @@ const DatasetCardView = (props: DatasetCVCombinedProps): React.ReactElement => {
           icon: <ConfirmationNumber />,
           label: 'Datafile Count',
           dataKey: 'DATAFILE_COUNT',
+          disableSort: true,
         },
         {
           icon: <CalendarToday />,

--- a/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
@@ -218,6 +218,7 @@ const InvestigationCardView = (
           label: 'RB Number',
           dataKey: 'RB_NUMBER',
           filterComponent: textFilter,
+          disableSort: true,
         },
         {
           icon: <ConfirmationNumber />,

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
@@ -171,6 +171,7 @@ exports[`Dataset table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "DATAFILE_COUNT",
+        "disableSort": true,
         "icon": <Memo(ConfirmationNumberIcon) />,
         "label": "datasets.datafile_count",
       },

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`Investigation table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "RB_NUMBER",
+        "disableSort": true,
         "filterComponent": [Function],
         "icon": <Memo(FingerprintIcon) />,
         "label": "investigations.rb_number",

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
@@ -198,6 +198,7 @@ const DatasetTable = (props: DatasetTableCombinedProps): React.ReactElement => {
           icon: <ConfirmationNumberIcon />,
           label: t('datasets.datafile_count'),
           dataKey: 'DATAFILE_COUNT',
+          disableSort: true,
         },
         {
           icon: <CalendarTodayIcon />,

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -216,6 +216,7 @@ const InvestigationTable = (
           label: t('investigations.rb_number'),
           dataKey: 'RB_NUMBER',
           filterComponent: textFilter,
+          disableSort: true,
         },
         {
           icon: <PublicIcon />,


### PR DESCRIPTION
## Description
Disables sorting on fields which we don't have on the entity, which resulted in rejected requests to the API and no data in the table. Doesn't address the other aspects of #460 

## Testing instructions
- [x] Review code
- [ ] Check Travis build
- [x] Review changes to test coverage
- [x] Check we can't sort by Datafile Count in generic dataset card view
- [x] Check we can't sort by RB Number in generic investigation card/table view

## Agile board tracking
connect to #460 
