### PR TITLE
Give routing dummy URL while navigating #537

### DIFF
--- a/packages/datagateway-common/src/state/reducers/dgcommon.reducer.test.tsx
+++ b/packages/datagateway-common/src/state/reducers/dgcommon.reducer.test.tsx
@@ -186,6 +186,14 @@ describe('DGCommon reducer', () => {
         sort: { NAME: 'asc' },
         filters: { NAME: 't' },
       },
+      savedQuery: {
+        view: 'card',
+        search: 'searchTwo',
+        page: 2,
+        results: 2,
+        sort: { NAME: 'desc' },
+        filters: { NAME: 'c' },
+      },
     };
 
     const updatedState = DGCommonReducer(state, clearTable());
@@ -196,14 +204,8 @@ describe('DGCommon reducer', () => {
       loading: false,
       downloading: false,
       error: null,
-      query: {
-        view: 'table',
-        search: 'searchOne',
-        page: 1,
-        results: 1,
-        sort: { NAME: 'asc' },
-        filters: { NAME: 't' },
-      },
+      query: initialState.query,
+      savedQuery: initialState.savedQuery,
     });
   });
 

--- a/packages/datagateway-common/src/state/reducers/dgcommon.reducer.tsx
+++ b/packages/datagateway-common/src/state/reducers/dgcommon.reducer.tsx
@@ -392,6 +392,7 @@ export function handleClearTable(state: DGCommonState): DGCommonState {
     loadedCount: false,
     downloading: false,
     error: null,
+    query: initialQuery,
     savedQuery: initialQuery,
   };
 }

--- a/packages/datagateway-dataview/src/page/__snapshots__/pageContainer.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/pageContainer.component.test.tsx.snap
@@ -50,6 +50,13 @@ exports[`PageContainer - Tests displays the correct entity count 1`] = `
       xs={12}
     >
       <ViewRouting
+        location={
+          Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+          }
+        }
         view={null}
       />
     </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -35,6 +35,9 @@ import { ThunkDispatch } from 'redux-thunk';
 import { StateType } from '../state/app.types';
 import PageBreadcrumbs from './breadcrumbs.component';
 import PageRouting from './pageRouting.component';
+// history package is part of react-router, which we depend on
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Location as LocationType } from 'history';
 
 const usePaperStyles = makeStyles(
   (theme: Theme): StyleRules =>
@@ -235,7 +238,10 @@ const CardSwitch = (props: {
   );
 };
 
-const ViewRouting = (props: { view: ViewsType }): React.ReactElement => {
+const ViewRouting = (props: {
+  view: ViewsType;
+  location: LocationType;
+}): React.ReactElement => {
   const paperClasses = usePaperStyles();
   return (
     <SwitchRouting>
@@ -254,7 +260,7 @@ const ViewRouting = (props: { view: ViewsType }): React.ReactElement => {
                 : paperClasses.tablePaper
             }
           >
-            <PageRouting view={props.view} />
+            <PageRouting view={props.view} location={props.location} />
           </Paper>
         )}
       />
@@ -262,7 +268,7 @@ const ViewRouting = (props: { view: ViewsType }): React.ReactElement => {
       <Route
         render={() => (
           <Paper square className={paperClasses.tablePaper}>
-            <PageRouting view={props.view} />
+            <PageRouting view={props.view} location={props.location} />
           </Paper>
         )}
       />
@@ -281,8 +287,7 @@ interface PageContainerDispatchProps {
 
 interface PageContainerStateProps {
   entityCount: number;
-  path: string;
-  locationSearch: string;
+  location: LocationType;
   query: QueryParams;
   savedView: ViewsType;
   loading: boolean;
@@ -296,6 +301,7 @@ interface PageContainerState {
   paths: string[];
   toggleCard: boolean;
   isCartFetched: boolean;
+  modifiedLocation: LocationType;
 }
 
 class PageContainer extends React.Component<
@@ -316,22 +322,32 @@ class PageContainer extends React.Component<
       ),
       toggleCard: this.getToggle(),
       isCartFetched: false,
+      modifiedLocation: props.location,
     };
   }
 
   public componentDidUpdate(prevProps: PageContainerCombinedProps): void {
     // Ensure if the location changes, then we update the query parameters.
-    if (
-      prevProps.path !== this.props.path ||
-      prevProps.locationSearch !== this.props.locationSearch
-    ) {
-      this.props.loadQuery(prevProps.path !== this.props.path);
+    // Use a dummy URL for the routing until we've updated the query to prevent
+    // sending requests for the old query on the new entity or vice versa.
+    if (prevProps.location.pathname !== this.props.location.pathname) {
+      this.setState({
+        ...this.state,
+        modifiedLocation: { ...this.props.location, pathname: '/' },
+      });
+      this.props.loadQuery(true);
+    } else if (prevProps.location.search !== this.props.location.search) {
+      this.props.loadQuery(false);
+    }
+
+    if (prevProps.query !== this.props.query) {
+      this.setState({ ...this.state, modifiedLocation: this.props.location });
     }
 
     // If the view query parameter was not found and the previously
     // stored view is in localstorage, update our current query with the view.
     if (this.getToggle() && !this.props.query.view)
-      this.props.pushView('card', this.props.path);
+      this.props.pushView('card', this.props.location.pathname);
 
     // Keep the query parameter for view and the state in sync, by getting the latest update.
     if (prevProps.query.view !== this.props.query.view) {
@@ -361,8 +377,10 @@ class PageContainer extends React.Component<
       .some((p) => {
         // Look for the character set where the parameter for ID would be
         // replaced with the regex to catch any character between the forward slashes.
-        const match = this.props.path.match(p.replace(/(:[^./]*)/g, '(.)+'));
-        return match && this.props.path === match[0];
+        const match = this.props.location.pathname.match(
+          p.replace(/(:[^./]*)/g, '(.)+')
+        );
+        return match && this.props.location.pathname === match[0];
       });
     return res;
   };
@@ -406,7 +424,7 @@ class PageContainer extends React.Component<
     this.storeDataView(nextView);
 
     // Add the view and push the final query parameters.
-    this.props.pushView(nextView, this.props.path);
+    this.props.pushView(nextView, this.props.location.pathname);
 
     // Set the state with the toggled card option and the saved query.
     this.setState({
@@ -449,7 +467,10 @@ class PageContainer extends React.Component<
 
           {/* Hold the table for remainder of the page */}
           <Grid item xs={12} aria-label="container-table">
-            <ViewRouting view={this.props.query.view} />
+            <ViewRouting
+              view={this.props.query.view}
+              location={this.state.modifiedLocation}
+            />
           </Grid>
         </StyledGrid>
       </Paper>
@@ -459,8 +480,7 @@ class PageContainer extends React.Component<
 
 const mapStateToProps = (state: StateType): PageContainerStateProps => ({
   entityCount: state.dgcommon.totalDataCount,
-  path: state.router.location.pathname,
-  locationSearch: state.router.location.search,
+  location: state.router.location,
   query: state.dgcommon.query,
   savedView: state.dgcommon.savedQuery.view,
   loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/page/pageRouting.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageRouting.component.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-
+// history package is part of react-router, which we depend on
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Location as LocationType } from 'history';
 import { Switch, Route, RouteComponentProps } from 'react-router';
 import { Link } from 'react-router-dom';
 
@@ -221,12 +223,13 @@ SafeDLSDatasetsCardView.displayName = 'SafeDLSDatasetsCardView';
 
 interface PageRoutingProps {
   view: ViewsType;
+  location: LocationType;
 }
 
 class PageRouting extends React.PureComponent<PageRoutingProps> {
   public render(): React.ReactNode {
     return (
-      <Switch>
+      <Switch location={this.props.location}>
         <Route
           exact
           path="/"

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
@@ -27,6 +27,7 @@ import {
   DateFilter,
   SortType,
   FiltersType,
+  ViewsType,
 } from 'datagateway-common';
 import { AnyAction } from 'redux';
 import { StateType } from '../../state/app.types';
@@ -57,6 +58,7 @@ interface DatasetTableProps {
 interface DatasetTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -93,6 +95,7 @@ const DatasetTable = (props: DatasetTableCombinedProps): React.ReactElement => {
     pushSort,
     filters,
     pushFilters,
+    view,
     investigationId,
     cartItems,
     addToCart,
@@ -195,7 +198,8 @@ const DatasetTable = (props: DatasetTableCombinedProps): React.ReactElement => {
             return datasetLink(
               investigationId,
               datasetData.ID,
-              datasetData.NAME
+              datasetData.NAME,
+              view
             );
           },
           filterComponent: textFilter,
@@ -280,6 +284,7 @@ const mapStateToProps = (state: StateType): DatasetTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -19,6 +19,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -41,6 +42,7 @@ interface DLSDatasetsTableProps {
 interface DLSDatasetsTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -81,6 +83,7 @@ const DLSDatasetsTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     investigationId,
     proposalName,
     loading,
@@ -164,7 +167,8 @@ const DLSDatasetsTable = (
           cellContentRenderer: (props: TableCellProps) =>
             tableLink(
               `/browse/proposal/${proposalName}/investigation/${investigationId}/dataset/${props.rowData.ID}/datafile`,
-              props.rowData.NAME
+              props.rowData.NAME,
+              view
             ),
           filterComponent: textFilter,
         },
@@ -250,6 +254,7 @@ const mapStateToProps = (state: StateType): DLSDatasetsTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -17,6 +17,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,6 +37,7 @@ import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 interface DLSMyDataTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -69,6 +71,7 @@ const DLSMyDataTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     loading,
     selectAllSetting,
   } = props;
@@ -138,7 +141,8 @@ const DLSMyDataTable = (
             const investigationData = props.rowData as Investigation;
             return tableLink(
               `/browse/proposal/${investigationData.NAME}/investigation/${investigationData.ID}/dataset`,
-              investigationData.TITLE
+              investigationData.TITLE,
+              view
             );
           },
           filterComponent: textFilter,
@@ -151,7 +155,8 @@ const DLSMyDataTable = (
             const investigationData = props.rowData as Investigation;
             return tableLink(
               `/browse/proposal/${investigationData.NAME}/investigation/${investigationData.ID}/dataset`,
-              investigationData.VISIT_ID
+              investigationData.VISIT_ID,
+              view
             );
           },
           filterComponent: textFilter,
@@ -258,6 +263,7 @@ const mapStateToProps = (state: StateType): DLSMyDataTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -12,6 +12,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +27,7 @@ import TitleIcon from '@material-ui/icons/Title';
 interface DLSProposalsTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -56,6 +58,7 @@ const DLSProposalsTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     loading,
     selectAllSetting,
   } = props;
@@ -96,7 +99,8 @@ const DLSProposalsTable = (
             const investigationData = props.rowData as Investigation;
             return tableLink(
               `/browse/proposal/${investigationData.NAME}/investigation`,
-              investigationData.TITLE
+              investigationData.TITLE,
+              view
             );
           },
           filterComponent: textFilter,
@@ -108,7 +112,8 @@ const DLSProposalsTable = (
           cellContentRenderer: (props: TableCellProps) => {
             return tableLink(
               `/browse/proposal/${props.rowData.NAME}/investigation`,
-              props.rowData.NAME
+              props.rowData.NAME,
+              view
             );
           },
           filterComponent: textFilter,
@@ -153,6 +158,7 @@ const mapStateToProps = (state: StateType): DLSProposalsTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
@@ -16,6 +16,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -38,6 +39,7 @@ interface DLSVisitsTableProps {
 interface DLSVisitsTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -72,6 +74,7 @@ const DLSVisitsTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     proposalName,
     loading,
     selectAllSetting,
@@ -133,7 +136,8 @@ const DLSVisitsTable = (
             const investigationData = props.rowData as Investigation;
             return tableLink(
               `/browse/proposal/${proposalName}/investigation/${investigationData.ID}/dataset`,
-              investigationData.VISIT_ID
+              investigationData.VISIT_ID,
+              view
             );
           },
           filterComponent: textFilter,
@@ -228,6 +232,7 @@ const mapStateToProps = (state: StateType): DLSVisitsTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -27,6 +27,7 @@ import {
   DateFilter,
   SortType,
   FiltersType,
+  ViewsType,
 } from 'datagateway-common';
 import { StateType } from '../../state/app.types';
 import { connect } from 'react-redux';
@@ -56,6 +57,7 @@ const useStyles = makeStyles((theme: Theme) =>
 interface InvestigationTableProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -90,6 +92,7 @@ const InvestigationTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     cartItems,
     addToCart,
     removeFromCart,
@@ -206,7 +209,8 @@ const InvestigationTable = (
             const investigationData = props.rowData as Investigation;
             return investigationLink(
               investigationData.ID,
-              investigationData.TITLE
+              investigationData.TITLE,
+              view
             );
           },
           filterComponent: textFilter,
@@ -291,6 +295,7 @@ const mapStateToProps = (state: StateType): InvestigationTableProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -23,6 +23,7 @@ import {
   FiltersType,
   SortType,
   DateFilter,
+  ViewsType,
 } from 'datagateway-common';
 import { IconButton } from '@material-ui/core';
 import { AnyAction } from 'redux';
@@ -48,6 +49,7 @@ interface ISISDatasetsTableProps {
 interface ISISDatasetsTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -90,6 +92,7 @@ const ISISDatasetsTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     investigationId,
     instrumentChildId,
     instrumentId,
@@ -195,7 +198,8 @@ const ISISDatasetsTable = (
           cellContentRenderer: (props: TableCellProps) =>
             tableLink(
               `/${pathRoot}/instrument/${instrumentId}/${instrumentChild}/${instrumentChildId}/investigation/${investigationId}/dataset/${props.rowData.ID}/datafile`,
-              props.rowData.NAME
+              props.rowData.NAME,
+              view
             ),
           filterComponent: textFilter,
         },
@@ -284,6 +288,7 @@ const mapStateToProps = (state: StateType): ISISDatasetsTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -13,6 +13,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -33,6 +34,7 @@ interface ISISFacilityCyclesTableProps {
 interface ISISFacilityCyclesTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -63,6 +65,7 @@ const ISISFacilityCyclesTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     instrumentId,
     loading,
     selectAllSetting,
@@ -113,7 +116,8 @@ const ISISFacilityCyclesTable = (
           cellContentRenderer: (props: TableCellProps) =>
             tableLink(
               `/browse/instrument/${instrumentId}/facilityCycle/${props.rowData.ID}/investigation`,
-              props.rowData.NAME
+              props.rowData.NAME,
+              view
             ),
           filterComponent: textFilter,
         },
@@ -162,6 +166,7 @@ const mapStateToProps = (
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
@@ -13,6 +13,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -32,6 +33,7 @@ interface ISISInstrumentsTableProps {
 interface ISISInstrumentsTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -63,6 +65,7 @@ const ISISInstrumentsTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     loading,
     selectAllSetting,
     studyHierarchy,
@@ -116,7 +119,8 @@ const ISISInstrumentsTable = (
             const instrumentData = props.rowData as Instrument;
             return tableLink(
               `/${pathRoot}/instrument/${instrumentData.ID}/${instrumentChild}`,
-              instrumentData.FULLNAME || instrumentData.NAME
+              instrumentData.FULLNAME || instrumentData.NAME,
+              view
             );
           },
           filterComponent: textFilter,
@@ -145,6 +149,7 @@ const mapStateToProps = (state: StateType): ISISInstrumentsTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -23,6 +23,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -49,6 +50,7 @@ interface ISISInvestigationsTableProps {
 interface ISISInvestigationsTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -102,6 +104,7 @@ const ISISInvestigationsTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     instrumentId,
     instrumentChildId,
     loading,
@@ -202,7 +205,8 @@ const ISISInvestigationsTable = (
             const investigationData = props.rowData as Investigation;
             return tableLink(
               `${urlPrefix}/${investigationData.ID}/dataset`,
-              investigationData.TITLE
+              investigationData.TITLE,
+              view
             );
           },
           filterComponent: textFilter,
@@ -215,7 +219,8 @@ const ISISInvestigationsTable = (
             const investigationData = props.rowData as Investigation;
             return tableLink(
               `${urlPrefix}/${investigationData.ID}/dataset`,
-              investigationData.VISIT_ID
+              investigationData.VISIT_ID,
+              view
             );
           },
           filterComponent: textFilter,
@@ -228,7 +233,8 @@ const ISISInvestigationsTable = (
             const investigationData = props.rowData as Investigation;
             return tableLink(
               `${urlPrefix}/${investigationData.ID}/dataset`,
-              investigationData.NAME
+              investigationData.NAME,
+              view
             );
           },
           filterComponent: textFilter,
@@ -245,7 +251,8 @@ const ISISInvestigationsTable = (
             ) {
               return tableLink(
                 `${urlPrefix}/${investigationData.ID}/dataset`,
-                investigationData.STUDYINVESTIGATION[0].STUDY.PID
+                investigationData.STUDYINVESTIGATION[0].STUDY.PID,
+                view
               );
             } else {
               return '';
@@ -406,6 +413,7 @@ const mapStateToProps = (
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -21,6 +21,7 @@ import {
   Table,
   tableLink,
   TextColumnFilter,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -41,6 +42,7 @@ import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 interface ISISMyDataTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -78,6 +80,7 @@ const ISISMyDataTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     loading,
     cartItems,
     addToCart,
@@ -183,7 +186,8 @@ const ISISMyDataTable = (
               if (facilityCycle) {
                 return tableLink(
                   `/browse/instrument/${investigationData.INVESTIGATIONINSTRUMENT[0].INSTRUMENT.ID}/facilityCycle/${facilityCycle.ID}/investigation/${investigationData.ID}/dataset`,
-                  investigationData.TITLE
+                  investigationData.TITLE,
+                  view
                 );
               } else {
                 return investigationData.TITLE;
@@ -238,7 +242,8 @@ const ISISMyDataTable = (
               if (facilityCycle) {
                 return tableLink(
                   `/browse/instrument/${investigationData.INVESTIGATIONINSTRUMENT[0].INSTRUMENT.ID}/facilityCycle/${facilityCycle.ID}/investigation/${investigationData.ID}/dataset`,
-                  investigationData.NAME
+                  investigationData.NAME,
+                  view
                 );
               } else {
                 return investigationData.NAME;
@@ -368,6 +373,7 @@ const mapStateToProps = (state: StateType): ISISMyDataTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,
     loading: state.dgcommon.loading,

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -14,6 +14,7 @@ import {
   tableLink,
   TextColumnFilter,
   fetchAllIds,
+  ViewsType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,6 +36,7 @@ interface ISISStudiesTableProps {
 interface ISISStudiesTableStoreProps {
   sort: SortType;
   filters: FiltersType;
+  view: ViewsType;
   data: Entity[];
   totalDataCount: number;
   loading: boolean;
@@ -68,6 +70,7 @@ const ISISStudiesTable = (
     pushSort,
     filters,
     pushFilters,
+    view,
     instrumentId,
     loading,
   } = props;
@@ -130,7 +133,8 @@ const ISISStudiesTable = (
           cellContentRenderer: (props: TableCellProps) =>
             tableLink(
               `/${pathRoot}/instrument/${instrumentId}/${instrumentChild}/${props.rowData.STUDY?.ID}/investigation`,
-              props.rowData.STUDY?.NAME
+              props.rowData.STUDY?.NAME,
+              view
             ),
           filterComponent: textFilter,
         },
@@ -216,6 +220,7 @@ const mapStateToProps = (state: StateType): ISISStudiesTableStoreProps => {
   return {
     sort: state.dgcommon.query.sort,
     filters: state.dgcommon.query.filters,
+    view: state.dgcommon.query.view,
     allIds: state.dgcommon.allIds,
     data: state.dgcommon.data,
     totalDataCount: state.dgcommon.totalDataCount,


### PR DESCRIPTION
## Description
When navigating the hierarchy using breadcrumbs/browser buttons, if there was a query set (e.g. filters applied) then requests were sent with the new query for the old entity (for browser navigation) or the old query with the new entity (for breadcrumbs). A side effect of this was the visual appearance of the filters being outdated.

To prevent this, have modified the `location` we pass to the router so that while we are in the process of navigating we use a dummy url so that the next entity table/card isn't loaded until the query is updated. This prevents the router and query in state getting out of sync. This also meant we need to pass the view in table links to ensure we always update the query with everything we need after the location changes.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Ensure that swapping card/table view works without additional causing duplicate requests
- [x] Ensure that normal navigation (table/card links) works in card/table views with and without queries, without causing duplicate requests
- [x] Ensure that navigation using breadcrumbs works in card/table views, with and without queries, without causing duplicate requests
- [x] Ensure that navigation using browser back buttons works in card/table views with and without queries, without causing duplicate requests

## Agile board tracking
closes #537 