### PR TITLE
Translate download status strings, update filters and tests #486

### DIFF
--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -213,6 +213,10 @@ export interface Download {
   [key: string]: string | number | boolean | DownloadItem[] | undefined;
 }
 
+export interface FormattedDownload extends Omit<Download, 'status'> {
+  status: string;
+}
+
 export interface SubmitCart {
   cartItems: DownloadCartItem[];
   facilityName: string;
@@ -233,7 +237,12 @@ export type ICATEntity =
   | FacilityCycle
   | StudyInvestigation;
 
-export type Entity = (ICATEntity | DownloadCartTableItem | Download) & {
+export type Entity = (
+  | ICATEntity
+  | DownloadCartTableItem
+  | Download
+  | FormattedDownload
+) & {
   // We will have to ignore the any typing here to access
   // Entity attributes with string indexing.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -19,7 +19,12 @@
     "download_disabled_tooltip": "Instant download not supported for {{transport}} download type",
     "download_disabled_button": "Instant download not supported for {{filename}}",
     "download": "Download {{filename}}",
-    "remove": "Remove {{filename}} from downloads"
+    "remove": "Remove {{filename}} from downloads",
+    "complete": "Available",
+    "expired": "Expired",
+    "paused": "Paused",
+    "preparing": "Preparing",
+    "restoring": "Restoring from tape"
   },
   "downloadConfirmDialog": {
     "close_arialabel": "Close download confirmation dialog",

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
@@ -45,7 +45,6 @@ exports[`Download Status Table renders correctly 1`] = `
               "label": "downloadStatus.transport",
             },
             Object {
-              "cellContentRenderer": [Function],
               "dataKey": "status",
               "filterComponent": [Function],
               "label": "downloadStatus.status",

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -106,6 +106,24 @@ describe('Download Status Table', () => {
       transport: 'globus',
       userName: 'test user',
     },
+    {
+      createdAt: '2020-03-01T15:57:28Z',
+      downloadItems: [{ entityId: 5, entityType: 'investigation', id: 5 }],
+      email: 'test5@email.com',
+      facilityName: 'LILS',
+      fileName: 'test-file-5',
+      fullName: 'Person 5',
+      id: 5,
+      isDeleted: false,
+      isEmailSent: true,
+      isTwoLevel: false,
+      preparedId: 'test-prepared-id',
+      sessionId: 'test-session-id',
+      size: 5000,
+      status: 'PAUSED',
+      transport: 'globus',
+      userName: 'test user',
+    },
   ];
 
   (fetchDownloads as jest.Mock).mockImplementation(() =>
@@ -135,6 +153,39 @@ describe('Download Status Table', () => {
       />
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('translates the status strings correctly', async () => {
+    const wrapper = mount(
+      <div id="datagateway-download">
+        <DownloadStatusTable
+          refreshTable={false}
+          setRefreshTable={jest.fn()}
+          setLastChecked={jest.fn()}
+        />
+      </div>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(
+      wrapper.find('[aria-rowindex=1]').find('[aria-colindex=3]').text()
+    ).toEqual('downloadStatus.paused');
+    expect(
+      wrapper.find('[aria-rowindex=2]').find('[aria-colindex=3]').text()
+    ).toEqual('downloadStatus.expired');
+    expect(
+      wrapper.find('[aria-rowindex=3]').find('[aria-colindex=3]').text()
+    ).toEqual('downloadStatus.restoring');
+    expect(
+      wrapper.find('[aria-rowindex=4]').find('[aria-colindex=3]').text()
+    ).toEqual('downloadStatus.preparing');
+    expect(
+      wrapper.find('[aria-rowindex=5]').find('[aria-colindex=3]').text()
+    ).toEqual('downloadStatus.complete');
   });
 
   it('fetches the download items on load', async () => {
@@ -286,7 +337,7 @@ describe('Download Status Table', () => {
         '[aria-label="downloadStatus.remove {filename:test-file-1}"]'
       )
     ).toBe(false);
-    expect(wrapper.exists('[aria-rowcount=3]')).toBe(true);
+    expect(wrapper.exists('[aria-rowcount=4]')).toBe(true);
   });
 
   it('sorts data when headers are clicked', async () => {
@@ -314,7 +365,7 @@ describe('Download Status Table', () => {
 
     accessMethodSortLabel.simulate('click');
 
-    expect(firstNameCell.text()).toEqual('test-file-4');
+    expect(firstNameCell.text()).toEqual('test-file-5');
 
     accessMethodSortLabel.simulate('click');
 
@@ -396,7 +447,7 @@ describe('Download Status Table', () => {
       .find('[aria-label="Filter by downloadStatus.status"] input')
       .first();
 
-    availabilityFilterInput.instance().value = 'complete';
+    availabilityFilterInput.instance().value = 'downloadStatus.complete';
     availabilityFilterInput.simulate('change');
 
     expect(wrapper.exists('[aria-rowcount=1]')).toBe(true);
@@ -409,7 +460,7 @@ describe('Download Status Table', () => {
     availabilityFilterInput.instance().value = '';
     availabilityFilterInput.simulate('change');
 
-    expect(wrapper.exists('[aria-rowcount=4]')).toBe(true);
+    expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
 
   it('filters data when date filter is altered', async () => {
@@ -435,7 +486,7 @@ describe('Download Status Table', () => {
     dateFromFilterInput.instance().value = '2020-01-01';
     dateFromFilterInput.simulate('change');
 
-    expect(wrapper.exists('[aria-rowcount=4]')).toBe(true);
+    expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
 
     const dateToFilterInput = wrapper.find(
       '[aria-label="downloadStatus.createdAt date filter to"]'
@@ -470,6 +521,6 @@ describe('Download Status Table', () => {
     dateToFilterInput.instance().value = '';
     dateToFilterInput.simulate('change');
 
-    expect(wrapper.exists('[aria-rowcount=4]')).toBe(true);
+    expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
 });

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -4,7 +4,7 @@ import { Grid, Paper, IconButton, LinearProgress } from '@material-ui/core';
 import {
   Table,
   Order,
-  Download,
+  FormattedDownload,
   TextColumnFilter,
   TableActionProps,
   DateColumnFilter,
@@ -35,7 +35,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
       | { value?: string | number; type: string }
       | { startDate?: string; endDate?: string };
   }>({});
-  const [data, setData] = React.useState<Download[]>([]);
+  const [data, setData] = React.useState<FormattedDownload[]>([]);
   const [dataLoaded, setDataLoaded] = React.useState(false);
 
   const { refreshTable, setRefreshTable, setLastChecked } = props;
@@ -60,7 +60,29 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
           facilityName: settings.facilityName,
           downloadApiUrl: settings.downloadApiUrl,
         }).then((downloads) => {
-          setData([...downloads].reverse());
+          // Replace the status field here
+          const formattedDownloads = downloads.map((download) => {
+            let formattedStatus = '';
+            switch (download.status) {
+              case 'COMPLETE':
+                formattedStatus = t('downloadStatus.complete');
+                break;
+              case 'EXPIRED':
+                formattedStatus = t('downloadStatus.expired');
+                break;
+              case 'PAUSED':
+                formattedStatus = t('downloadStatus.paused');
+                break;
+              case 'PREPARING':
+                formattedStatus = t('downloadStatus.preparing');
+                break;
+              case 'RESTORING':
+                formattedStatus = t('downloadStatus.restoring');
+                break;
+            }
+            return { ...download, status: formattedStatus };
+          });
+          setData([...formattedDownloads].reverse());
           setDataLoaded(true);
 
           // Set the time at which we set the download data.
@@ -76,6 +98,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
     settings.facilityName,
     settings.downloadApiUrl,
     dgDownloadElement,
+    t,
   ]);
 
   const textFilter = (label: string, dataKey: string): React.ReactElement => (
@@ -100,10 +123,9 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
       label={label}
       onChange={(value: { value?: string | number; type: string } | null) => {
         if (value && typeof value.value === 'string') {
-          // We convert the input value to uppercase to match the table value.
           setFilters({
             ...filters,
-            [dataKey]: { value: value.value.toUpperCase(), type: value.type },
+            [dataKey]: { value: value.value, type: value.type },
           });
         } else {
           const { [dataKey]: value, ...restOfFilters } = filters;
@@ -138,8 +160,8 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
             'value' in value &&
             typeof value.value === 'string' &&
             (value.type === 'include'
-              ? !tableValue.includes(value.value)
-              : tableValue.includes(value.value))
+              ? !tableValue.toLowerCase().includes(value.value.toLowerCase())
+              : tableValue.toLowerCase().includes(value.value.toLowerCase()))
           ) {
             return false;
           } else if (
@@ -170,7 +192,10 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
       return true;
     });
 
-    function sortDownloadItems(a: Download, b: Download): number {
+    function sortDownloadItems(
+      a: FormattedDownload,
+      b: FormattedDownload
+    ): number {
       for (const [sortColumn, sortDirection] of Object.entries(sort)) {
         const aColumnValue = a[sortColumn];
         const bColumnValue = b[sortColumn];
@@ -237,15 +262,15 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
               {
                 label: t('downloadStatus.status'),
                 dataKey: 'status',
-                cellContentRenderer: (props: TableCellProps) => {
-                  if (props.cellData) {
-                    const status: string = props.cellData;
-                    return (
-                      status.substring(0, 1).toUpperCase() +
-                      status.substring(1).toLowerCase()
-                    );
-                  }
-                },
+                // cellContentRenderer: (props: TableCellProps) => {
+                //   if (props.cellData) {
+                //     const status: string = props.cellData;
+                //     return (
+                //       status.substring(0, 1).toUpperCase() +
+                //       status.substring(1).toLowerCase()
+                //     );
+                //   }
+                // },
                 filterComponent: availabilityFilter,
               },
               {
@@ -276,8 +301,8 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
             actionsWidth={100}
             actions={[
               function DownloadButton({ rowData }: TableActionProps) {
-                const downloadItem = rowData as Download;
-                const isDownloadable = downloadItem.transport.match(
+                const downloadItem = rowData as FormattedDownload;
+                const isDownloadable = (downloadItem.transport as string).match(
                   /https|http/
                 )
                   ? true
@@ -301,8 +326,8 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                         <IconButton
                           component="a"
                           href={getDataUrl(
-                            downloadItem.preparedId,
-                            downloadItem.fileName
+                            downloadItem.preparedId as string,
+                            downloadItem.fileName as string
                           )}
                           target="_blank"
                           aria-label={t('downloadStatus.download', {
@@ -343,7 +368,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
               function RemoveButton({
                 rowData,
               }: TableActionProps): JSX.Element {
-                const downloadItem = rowData as Download;
+                const downloadItem = rowData as FormattedDownload;
                 const [isDeleting, setIsDeleting] = React.useState(false);
 
                 return (
@@ -357,7 +382,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                       setIsDeleting(true);
                       setTimeout(
                         () =>
-                          downloadDeleted(downloadItem.id, true, {
+                          downloadDeleted(downloadItem.id as number, true, {
                             facilityName: settings.facilityName,
                             downloadApiUrl: settings.downloadApiUrl,
                           }).then(() =>

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -262,15 +262,6 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
               {
                 label: t('downloadStatus.status'),
                 dataKey: 'status',
-                // cellContentRenderer: (props: TableCellProps) => {
-                //   if (props.cellData) {
-                //     const status: string = props.cellData;
-                //     return (
-                //       status.substring(0, 1).toUpperCase() +
-                //       status.substring(1).toLowerCase()
-                //     );
-                //   }
-                // },
                 filterComponent: availabilityFilter,
               },
               {


### PR DESCRIPTION
## Description
Added translation strings for the possible values of `Download.status` based on what is currently done in topcat (https://github.com/icatproject/topcat/blob/master/yo/app/languages/lang.json#L375). This also involved changing how we handle casing in the filters; before we displayed the `status` (which was always uppercase in the data) with standard capitalisation, and forced any filter input to upper case for the string comparisons. Now, since translation and casing is handled by `res/default.json`, we make both the filter input and displayed string lower case when comparing them. Functionally this should behave the same i.e. the case of the filter is ignored.

## Testing instructions

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] In the download status table, check filtering for display text that appears in the status field filters correctly irrespective of input casing (e.g. available, AVAILABLE, AvAiL etc. all work)
- [x] In the download status table, check filtering for text of the original `status` value doesn't work, for example we map `COMPLETE` to `Available`, so (include) filtering for `complete` should not return anything 

## Agile board tracking
closes #486