### PR TITLE
Anon login for all DG cypress tests #554

### DIFF
--- a/packages/datagateway-dataview/cypress/integration/breadcrumbs.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/breadcrumbs.spec.ts
@@ -1,7 +1,7 @@
 describe('Breadcrumbs Component', () => {
   beforeEach(() => {
     // Get a session and visit the table.
-    cy.login('user', 'password');
+    cy.login();
 
     // Create route and aliases.
     cy.intercept('/investigations/').as('getInvestigation');

--- a/packages/datagateway-dataview/cypress/integration/card/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/datasets.spec.ts
@@ -2,7 +2,7 @@ describe('Datasets Cards', () => {
   beforeEach(() => {
     cy.intercept('**/datasets/count*').as('getDatasetsCount');
     cy.intercept('**/datasets?order*').as('getDatasetsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/investigation/1/dataset').wait(
       ['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'],
       { timeout: 10000 }

--- a/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
@@ -2,7 +2,7 @@ describe('DLS - Datasets Cards', () => {
   beforeEach(() => {
     cy.intercept('**/datasets/count*').as('getDatasetsCount');
     cy.intercept('**/datasets?order*').as('getDatasetsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/proposal/INVESTIGATION%201/investigation/1/dataset').wait(
       ['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'],
       {

--- a/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
@@ -2,7 +2,7 @@ describe('DLS - Proposals Cards', () => {
   beforeEach(() => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/proposal/').wait(
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }

--- a/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
@@ -2,7 +2,7 @@ describe('DLS - Visits Cards', () => {
   beforeEach(() => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/proposal/INVESTIGATION%201/investigation/').wait(
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }

--- a/packages/datagateway-dataview/cypress/integration/card/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/investigations.spec.ts
@@ -2,7 +2,7 @@ describe('Investigations Cards', () => {
   beforeEach(() => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/investigation').wait(
       [
         '@getInvestigationsCount',

--- a/packages/datagateway-dataview/cypress/integration/card/isis/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/datasets.spec.ts
@@ -2,7 +2,7 @@ describe('ISIS - Datasets Cards', () => {
   beforeEach(() => {
     cy.intercept('**/datasets/count*').as('getDatasetsCount');
     cy.intercept('**/datasets?order*').as('getDatasetsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit(
       '/browse/instrument/1/facilityCycle/14/investigation/87/dataset'
     ).wait(['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'], {

--- a/packages/datagateway-dataview/cypress/integration/card/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/facilityCycles.spec.ts
@@ -3,7 +3,7 @@ describe('ISIS - FacilityCycles Cards', () => {
     cy.intercept('**/facilitycycles/count*').as('getFacilityCyclesCount');
     cy.intercept('**/facilitycycles?order*').as('getFacilityCyclesOrder');
     cy.intercept('instruments/1').as('instrument');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/instrument/1/facilityCycle?view=card').wait(
       ['@instrument', '@getFacilityCyclesCount', '@getFacilityCyclesOrder'],
       { timeout: 10000 }

--- a/packages/datagateway-dataview/cypress/integration/card/isis/instruments.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/instruments.spec.ts
@@ -2,7 +2,7 @@ describe('ISIS - Instruments Cards', () => {
   beforeEach(() => {
     cy.intercept('**/instruments/count*').as('getInstrumentsCount');
     cy.intercept('**/instruments?order*').as('getInstrumentsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/instrument').wait(
       ['@getInstrumentsCount', '@getInstrumentsOrder'],
       { timeout: 10000 }

--- a/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
@@ -2,7 +2,7 @@ describe('ISIS - Investigations Cards', () => {
   beforeEach(() => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/instrument/1/facilityCycle/14/investigation').wait(
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }

--- a/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
@@ -2,7 +2,7 @@ describe('ISIS - Studies Cards', () => {
   beforeEach(() => {
     cy.intercept('**/studyinvestigations/count*').as('getStudiesCount');
     cy.intercept('**/studyinvestigations?order*').as('getStudiesOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browseStudyHierarchy/instrument/1/study').wait(
       ['@getStudiesCount', '@getStudiesOrder'],
       { timeout: 10000 }

--- a/packages/datagateway-dataview/cypress/integration/card/pageContainer.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/pageContainer.spec.ts
@@ -2,7 +2,7 @@ describe('PageContainer Component', () => {
   beforeEach(() => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/investigation/').wait(
       [
         '@getInvestigationsCount',

--- a/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
@@ -394,7 +394,6 @@ describe('Add/remove from cart functionality', () => {
 
         cy.get('[aria-label="grid"]').scrollTo('bottom').wait('@getDatafiles');
         cy.get('[aria-label="grid"]').scrollTo('bottom');
-        // cy.get('[aria-label="grid"]').scrollTo('bottom');
         cy.get(`[aria-label="select row 54"]`).should('be.checked');
         cy.get('[aria-label="select all rows"]').check();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 })
@@ -439,7 +438,6 @@ describe('Add/remove from cart functionality', () => {
 
         cy.get('[aria-label="grid"]').scrollTo('bottom').wait('@getDatafiles');
         cy.get('[aria-label="grid"]').scrollTo('bottom');
-        // cy.get('[aria-label="grid"]').scrollTo('bottom');
         cy.get('[aria-label="select row 53"]').should('not.be.checked');
         cy.get('[aria-label="select row 54"]').should('be.checked');
       });

--- a/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
@@ -1,6 +1,6 @@
 describe('Add/remove from cart functionality', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.clearDownloadCart();
     cy.intercept('/datasets/').as('getDataset');
     cy.intercept('/investigations/').as('getInvestigation');
@@ -394,6 +394,7 @@ describe('Add/remove from cart functionality', () => {
 
         cy.get('[aria-label="grid"]').scrollTo('bottom').wait('@getDatafiles');
         cy.get('[aria-label="grid"]').scrollTo('bottom');
+        // cy.get('[aria-label="grid"]').scrollTo('bottom');
         cy.get(`[aria-label="select row 54"]`).should('be.checked');
         cy.get('[aria-label="select all rows"]').check();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 })
@@ -438,6 +439,7 @@ describe('Add/remove from cart functionality', () => {
 
         cy.get('[aria-label="grid"]').scrollTo('bottom').wait('@getDatafiles');
         cy.get('[aria-label="grid"]').scrollTo('bottom');
+        // cy.get('[aria-label="grid"]').scrollTo('bottom');
         cy.get('[aria-label="select row 53"]').should('not.be.checked');
         cy.get('[aria-label="select row 54"]').should('be.checked');
       });

--- a/packages/datagateway-dataview/cypress/integration/table/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/datafiles.spec.ts
@@ -4,7 +4,7 @@ describe('Datafiles Table', () => {
     cy.intercept('/datasets/25').as('datasets');
     cy.intercept('/datafiles/count').as('datafilesCount');
     cy.intercept('/datafiles?order=').as('datafilesOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/investigation/1/dataset/25/datafile');
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/datasets.spec.ts
@@ -1,6 +1,6 @@
 describe('Datasets Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/investigation/1/dataset');
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/dls/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/datafiles.spec.ts
@@ -3,7 +3,7 @@ describe('DLS - Datafiles Table', () => {
     cy.intercept('/datafiles/count').as('datafilesCount');
     cy.intercept('/datasets/25').as('datasets');
     cy.intercept('/datafiles?order=').as('datafilesOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit(
       '/browse/proposal/INVESTIGATION%201/investigation/1/dataset/25/datafile'
     ).wait(['@datafilesCount', '@datasets', '@datafilesOrder'], {

--- a/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
@@ -4,7 +4,7 @@ describe('DLS - Datasets Table', () => {
     cy.intercept('/investigations/findone').as('investigationsFindOne');
     cy.intercept('/datasets/count?').as('datasetsCount');
     cy.intercept('/datasets?').as('datasets');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit(
       '/browse/proposal/INVESTIGATION%201/investigation/1/dataset'
     ).wait(

--- a/packages/datagateway-dataview/cypress/integration/table/dls/myData.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/myData.spec.ts
@@ -1,7 +1,7 @@
 describe('DLS - MyData Table', () => {
   beforeEach(() => {
     cy.intercept('/datasets/count').as('getDatasetCount');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/my-data/DLS').wait(['@getDatasetCount'], { timeout: 10000 });
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/proposals.spec.ts
@@ -1,6 +1,6 @@
 describe('DLS - Proposals Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.intercept('/investigations?').as('investigations');
     cy.intercept('/investigations/count?').as('investigationsCount');
     cy.visit('/browse/proposal');

--- a/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
@@ -1,6 +1,6 @@
 describe('DLS - Visits Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.intercept('/investigations?').as('investigations');
     cy.intercept('/investigations/count?').as('investigationsCount');
     cy.intercept('/investigations/findone?').as('investigationsFindOne');

--- a/packages/datagateway-dataview/cypress/integration/table/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/investigations.spec.ts
@@ -1,6 +1,6 @@
 describe('Investigations Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/investigation');
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/datafiles.spec.ts
@@ -5,7 +5,7 @@ describe('ISIS - Datafiles Table', () => {
     cy.intercept('/datasets/118').as('datasets');
     cy.intercept('/datafiles/count').as('datafilesCount');
     cy.intercept('/datafiles?order=').as('datafilesOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit(
       '/browse/instrument/1/facilityCycle/14/investigation/87/dataset/118/datafile'
     ).wait(

--- a/packages/datagateway-dataview/cypress/integration/table/isis/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/datasets.spec.ts
@@ -2,7 +2,7 @@ describe('ISIS - Datasets Table', () => {
   beforeEach(() => {
     cy.intercept('/datasets/count').as('datasetsCount');
     cy.intercept('/datasets?order=').as('datasetsOrder');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit(
       '/browse/instrument/1/facilityCycle/14/investigation/87/dataset'
     ).wait(['@datasetsCount', '@datasetsOrder'], { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
@@ -1,6 +1,6 @@
 describe('ISIS - FacilityCycles Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/instrument/1/facilityCycle');
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/instruments.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/instruments.spec.ts
@@ -1,6 +1,6 @@
 describe('ISIS - Instruments Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/instrument');
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
@@ -1,6 +1,6 @@
 describe('ISIS - Investigations Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browse/instrument/1/facilityCycle/14/investigation');
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/myData.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/myData.spec.ts
@@ -1,7 +1,7 @@
 describe('ISIS - MyData Table', () => {
   beforeEach(() => {
     cy.intercept('/investigations/count').as('getInvestigationCount');
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/my-data/ISIS').wait(['@getInvestigationCount'], {
       timeout: 10000,
     });

--- a/packages/datagateway-dataview/cypress/integration/table/isis/studies.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/studies.spec.ts
@@ -1,6 +1,6 @@
 describe('ISIS - Studies Table', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/browseStudyHierarchy/instrument/1/study');
   });
 

--- a/packages/datagateway-dataview/cypress/integration/table/pageContainer.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/pageContainer.spec.ts
@@ -1,6 +1,6 @@
 describe('PageContainer Component', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
 
     cy.visit('/browse/investigation/');
   });

--- a/packages/datagateway-dataview/cypress/support/commands.js
+++ b/packages/datagateway-dataview/cypress/support/commands.js
@@ -55,13 +55,21 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', () => {
-  cy.request('POST', 'http://scigateway-preprod.esc.rl.ac.uk:8000/login', {
-    mnemonic: 'anon',
+  cy.request({
+    method: 'POST',
+    url: 'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/session',
+    body: {
+      json: JSON.stringify({
+        plugin: 'anon',
+      }),
+    },
+    form: true,
   }).then((response) => {
     const jwtHeader = { alg: 'HS256', typ: 'JWT' };
-    const payload = JSON.parse(parseJwt(response.body));
-    // Fake the username for my-data tests
-    payload.username = 'Robert499';
+    const payload = {
+      sessionId: response.body.sessionId,
+      username: 'Robert499',
+    };
     const jwt = jsrsasign.KJUR.jws.JWS.sign('HS256', jwtHeader, payload, 'shh');
     window.localStorage.setItem('scigateway:token', jwt);
   });

--- a/packages/datagateway-dataview/cypress/support/commands.js
+++ b/packages/datagateway-dataview/cypress/support/commands.js
@@ -54,26 +54,16 @@ export const readSciGatewayToken = () => {
   };
 };
 
-Cypress.Commands.add('login', (username, password) => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
-    cy.request('POST', `${settings.apiUrl}/sessions`, {
-      username: username,
-      password: password,
-    }).then((response) => {
-      const jwtHeader = { alg: 'HS256', typ: 'JWT' };
-      const payload = {
-        sessionId: response.body.sessionID,
-        username: 'Robert499',
-      };
-      const jwt = jsrsasign.KJUR.jws.JWS.sign(
-        'HS256',
-        jwtHeader,
-        payload,
-        'shh'
-      );
-
-      window.localStorage.setItem('scigateway:token', jwt);
-    });
+Cypress.Commands.add('login', () => {
+  cy.request('POST', 'http://scigateway-preprod.esc.rl.ac.uk:8000/login', {
+    mnemonic: 'anon',
+  }).then((response) => {
+    const jwtHeader = { alg: 'HS256', typ: 'JWT' };
+    const payload = JSON.parse(parseJwt(response.body));
+    // Fake the username for my-data tests
+    payload.username = 'Robert499';
+    const jwt = jsrsasign.KJUR.jws.JWS.sign('HS256', jwtHeader, payload, 'shh');
+    window.localStorage.setItem('scigateway:token', jwt);
   });
 });
 

--- a/packages/datagateway-dataview/cypress/support/commands.js
+++ b/packages/datagateway-dataview/cypress/support/commands.js
@@ -55,6 +55,7 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', () => {
+  // TODO Use the ICAT backend for this request once it is enabled for pre-prod
   cy.request({
     method: 'POST',
     url: 'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/session',

--- a/packages/datagateway-dataview/cypress/support/index.d.ts
+++ b/packages/datagateway-dataview/cypress/support/index.d.ts
@@ -1,9 +1,6 @@
 declare namespace Cypress {
   interface Chainable<Subject> {
-    login(
-      username: string,
-      password: string
-    ): Cypress.Chainable<Cypress.Response>;
+    login(): Cypress.Chainable<Cypress.Response>;
     clearDownloadCart(): Cypress.Chainable<Cypress.Response>;
   }
 }

--- a/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
@@ -2,7 +2,7 @@ describe('Download Cart', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/topcat/user/cart/**').as('fetchCart');
     cy.intercept('GET', '**/topcat/user/downloads**').as('fetchDownloads');
-    cy.login('root', 'pw');
+    cy.login();
     cy.clearDownloadCart();
 
     cy.seedDownloadCart().then(() => {

--- a/packages/datagateway-download/cypress/integration/downloadConfirmation.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadConfirmation.spec.ts
@@ -1,7 +1,7 @@
 describe('Download Confirmation', () => {
   before(() => {
     // Ensure the download cart is cleared before running tests.
-    cy.login('root', 'pw');
+    cy.login();
     cy.clearDownloadCart();
   });
 
@@ -12,7 +12,7 @@ describe('Download Confirmation', () => {
     
     cy.intercept('GET', '**/ids/isTwoLevel').as('fetchIsTwoLevel');
     cy.intercept('GET', '**/topcat/user/cart/**').as('fetchCart');
-    cy.login('root', 'pw');
+    cy.login();
 
     // Ensure the cart is clear before running tests.
     cy.clearDownloadCart();

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -1,7 +1,7 @@
 describe('Download Status', () => {
   before(() => {
     // Ensure the downloads are cleared before running tests.
-    cy.login('download-e2e-tests', 'pw');
+    cy.login();
 
     // Seed the initial downloads.
     cy.clearDownloads();
@@ -9,7 +9,7 @@ describe('Download Status', () => {
 
   beforeEach(() => {
     cy.intercept('GET', '**/topcat/user/downloads**').as('fetchDownloads');
-    cy.login('download-e2e-tests', 'pw');
+    cy.login();
 
     // Ensure the downloads are cleared before running tests.
     cy.clearDownloads();

--- a/packages/datagateway-download/cypress/support/commands.js
+++ b/packages/datagateway-download/cypress/support/commands.js
@@ -90,14 +90,22 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', () => {
-  cy.request('POST', 'http://scigateway-preprod.esc.rl.ac.uk:8000/login', {
-    mnemonic: 'anon',
+  cy.request({
+    method: 'POST',
+    url: 'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/session',
+    body: {
+      json: JSON.stringify({
+        plugin: 'anon',
+      }),
+    },
+    form: true,
   }).then((response) => {
     const jwtHeader = { alg: 'HS256', typ: 'JWT' };
-    const payload = JSON.parse(parseJwt(response.body));
-    payload.username = 'test';
+    const payload = {
+      sessionId: response.body.sessionId,
+      username: 'test',
+    };
     const jwt = jsrsasign.KJUR.jws.JWS.sign('HS256', jwtHeader, payload, 'shh');
-
     window.localStorage.setItem('scigateway:token', jwt);
   });
 });

--- a/packages/datagateway-download/cypress/support/commands.js
+++ b/packages/datagateway-download/cypress/support/commands.js
@@ -89,23 +89,13 @@ export const readSciGatewayToken = () => {
   };
 };
 
-Cypress.Commands.add('login', (username, password) => {
-  cy.request({
-    method: 'POST',
-    url: 'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/session',
-    body: {
-      json: JSON.stringify({
-        plugin: 'simple',
-        credentials: [{ username: username }, { password: password }],
-      }),
-    },
-    form: true,
+Cypress.Commands.add('login', () => {
+  cy.request('POST', 'http://scigateway-preprod.esc.rl.ac.uk:8000/login', {
+    mnemonic: 'anon',
   }).then((response) => {
     const jwtHeader = { alg: 'HS256', typ: 'JWT' };
-    const payload = {
-      sessionId: response.body.sessionId,
-      username: 'test',
-    };
+    const payload = JSON.parse(parseJwt(response.body));
+    payload.username = 'test';
     const jwt = jsrsasign.KJUR.jws.JWS.sign('HS256', jwtHeader, payload, 'shh');
 
     window.localStorage.setItem('scigateway:token', jwt);

--- a/packages/datagateway-download/cypress/support/index.d.ts
+++ b/packages/datagateway-download/cypress/support/index.d.ts
@@ -1,8 +1,6 @@
 declare namespace Cypress {
   interface Chainable<Subject> {
     login(
-      username: string,
-      password: string,
       noRootCredentials?: boolean
     ): Cypress.Chainable<Cypress.Response>;
     clearDownloadCart(): Cypress.Chainable<Cypress.Response>;

--- a/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
@@ -1,6 +1,6 @@
 describe('Datafile search tab', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/search/data/');
     cy.intercept('/investigations/count?where=%7B%22ID').as(
       'investigationsCount'

--- a/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
@@ -1,6 +1,6 @@
 describe('Dataset search tab', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/search/data/');
     cy.intercept('/investigations/count?where=%7B%22ID').as(
       'investigationsCount'

--- a/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
@@ -1,6 +1,6 @@
 describe('Investigation search tab', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
     cy.visit('/search/data/');
     cy.intercept('/investigations/count?where=%7B%22ID').as(
       'investigationsCount'

--- a/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
@@ -1,6 +1,6 @@
 describe('SearchBoxContainer Component', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
 
     cy.visit('/search/data/');
   });

--- a/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
@@ -1,6 +1,6 @@
 describe('SearchPageContainer Component', () => {
   beforeEach(() => {
-    cy.login('user', 'password');
+    cy.login();
 
     cy.visit('/search/data/');
   });

--- a/packages/datagateway-search/cypress/support/commands.js
+++ b/packages/datagateway-search/cypress/support/commands.js
@@ -55,14 +55,22 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', () => {
-  cy.request('POST', 'http://scigateway-preprod.esc.rl.ac.uk:8000/login', {
-    mnemonic: 'anon',
+  cy.request({
+    method: 'POST',
+    url: 'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/session',
+    body: {
+      json: JSON.stringify({
+        plugin: 'anon',
+      }),
+    },
+    form: true,
   }).then((response) => {
     const jwtHeader = { alg: 'HS256', typ: 'JWT' };
-    const payload = JSON.parse(parseJwt(response.body));
-    payload.username = 'test';
+    const payload = {
+      sessionId: response.body.sessionId,
+      username: 'test',
+    };
     const jwt = jsrsasign.KJUR.jws.JWS.sign('HS256', jwtHeader, payload, 'shh');
-
     window.localStorage.setItem('scigateway:token', jwt);
   });
 });

--- a/packages/datagateway-search/cypress/support/commands.js
+++ b/packages/datagateway-search/cypress/support/commands.js
@@ -54,26 +54,16 @@ export const readSciGatewayToken = () => {
   };
 };
 
-Cypress.Commands.add('login', (username, password) => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
-    cy.request('POST', `${settings.apiUrl}/sessions`, {
-      username: username,
-      password: password,
-    }).then((response) => {
-      const jwtHeader = { alg: 'HS256', typ: 'JWT' };
-      const payload = {
-        sessionId: response.body.sessionID,
-        username: 'test',
-      };
-      const jwt = jsrsasign.KJUR.jws.JWS.sign(
-        'HS256',
-        jwtHeader,
-        payload,
-        'shh'
-      );
+Cypress.Commands.add('login', () => {
+  cy.request('POST', 'http://scigateway-preprod.esc.rl.ac.uk:8000/login', {
+    mnemonic: 'anon',
+  }).then((response) => {
+    const jwtHeader = { alg: 'HS256', typ: 'JWT' };
+    const payload = JSON.parse(parseJwt(response.body));
+    payload.username = 'test';
+    const jwt = jsrsasign.KJUR.jws.JWS.sign('HS256', jwtHeader, payload, 'shh');
 
-      window.localStorage.setItem('scigateway:token', jwt);
-    });
+    window.localStorage.setItem('scigateway:token', jwt);
   });
 });
 

--- a/packages/datagateway-search/cypress/support/commands.js
+++ b/packages/datagateway-search/cypress/support/commands.js
@@ -55,6 +55,7 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', () => {
+  // TODO Use the ICAT backend for this request once it is enabled for pre-prod
   cy.request({
     method: 'POST',
     url: 'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/session',

--- a/packages/datagateway-search/cypress/support/index.d.ts
+++ b/packages/datagateway-search/cypress/support/index.d.ts
@@ -1,9 +1,6 @@
 declare namespace Cypress {
   interface Chainable<Subject> {
-    login(
-      username: string,
-      password: string
-    ): Cypress.Chainable<Cypress.Response>;
+    login(): Cypress.Chainable<Cypress.Response>;
     clearDownloadCart(): Cypress.Chainable<Cypress.Response>;
   }
 }


### PR DESCRIPTION
## Description
Changed the cypress login command to use anonymous login, which allows the carts used in concurrent E2E to be treated seperately, which should reduce errors in E2E tests.

The url is currently hardcoded in `cypress/support/commands.js` as we were already doing this in `downloads` and we don't have a dedicated setting for authUrl  (`8000` isn't accessible outside the RAL network so fails on integration tests?). We were previously using the apiUrl to authenticate in `search` and `dataview`.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] To manually test, run `yarn e2e:interactive` in two dataview terminals and run the cartSelection test in both at the same time. All tests should pass on electron (using chrome I got errors when scrolling). For reference when running concurrent tests with the old login method I got 1-2 outright failures and ~5 tests passing with retries of the 48 in the cartSelection file.

## Agile board tracking
closes #554 