### PR TITLE
investigationSearchTable links take facility into account #566

### DIFF
--- a/packages/datagateway-search/src/__snapshots__/searchPageContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageContainer.component.test.tsx.snap
@@ -1,24 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchPageContainer - Tests renders correctly at /search/data route 1`] = `
-<div
-  computedMatch={
-    Object {
-      "isExact": false,
-      "params": Object {},
-      "path": "/",
-      "url": "/",
-    }
-  }
-  location={
-    Object {
-      "hash": "",
-      "key": "testKey",
-      "pathname": "/search/data",
-      "search": "",
-    }
-  }
->
+<div>
   <WithStyles(ForwardRef(Grid))
     alignItems="flex-start"
     container={true}
@@ -64,6 +47,7 @@ exports[`SearchPageContainer - Tests renders correctly at /search/data route 1`]
       >
         <Connect(SearchPageTable)
           containerHeight="calc(100vh - 64px - 30px - 2*16px - (69px + 19rem/16) - 42px - (53px + 19rem/16) - 8px)"
+          hierarchy="data"
         />
       </WithStyles(ForwardRef(Paper))>
     </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StateType } from './state/app.types';
 import { connect } from 'react-redux';
-import { Switch, Route } from 'react-router';
+import { Switch, Route, RouteComponentProps } from 'react-router';
 import { Link } from 'react-router-dom';
 
 import { Grid, Paper, LinearProgress } from '@material-ui/core';
@@ -35,49 +35,61 @@ class SearchPageContainer extends React.Component<
           path="/"
           render={() => <Link to="/search/data">Search data</Link>}
         />
-        <div>
-          <Grid
-            container
-            direction={this.props.sideLayout ? 'row' : 'column'}
-            justify="flex-start"
-            alignItems="flex-start"
-            spacing={spacing}
-            style={{ margin: 0, width: '100%' }}
-          >
-            <Grid item id="container-search-filters">
-              {this.props.sideLayout ? (
-                <Paper style={{ height: '100%', width: '100%' }}>
-                  <SearchBoxContainerSide />
-                </Paper>
-              ) : (
-                <Paper
-                  style={{ height: '100%', width: 'calc(70vw)', minWidth: 584 }}
-                >
-                  <SearchBoxContainer />
-                </Paper>
-              )}
-            </Grid>
-
-            <Grid item id="container-search-table">
-              <Paper
-                style={{
-                  height: containerHeight,
-                  minHeight: 326,
-                  width: 'calc(70vw)',
-                  minWidth: 584,
-                }}
+        <Route
+          path="/search/:hierarchy"
+          render={({ match }: RouteComponentProps<{ hierarchy: string }>) => (
+            <div>
+              <Grid
+                container
+                direction={this.props.sideLayout ? 'row' : 'column'}
+                justify="flex-start"
+                alignItems="flex-start"
+                spacing={spacing}
+                style={{ margin: 0, width: '100%' }}
               >
-                {/* Show loading progress if data is still being loaded */}
-                {this.props.loading && (
-                  <Grid item xs={12}>
-                    <LinearProgress color="secondary" />
-                  </Grid>
-                )}
-                <SearchPageTable containerHeight={containerHeight} />
-              </Paper>
-            </Grid>
-          </Grid>
-        </div>
+                <Grid item id="container-search-filters">
+                  {this.props.sideLayout ? (
+                    <Paper style={{ height: '100%', width: '100%' }}>
+                      <SearchBoxContainerSide />
+                    </Paper>
+                  ) : (
+                    <Paper
+                      style={{
+                        height: '100%',
+                        width: 'calc(70vw)',
+                        minWidth: 584,
+                      }}
+                    >
+                      <SearchBoxContainer />
+                    </Paper>
+                  )}
+                </Grid>
+
+                <Grid item id="container-search-table">
+                  <Paper
+                    style={{
+                      height: containerHeight,
+                      minHeight: 326,
+                      width: 'calc(70vw)',
+                      minWidth: 584,
+                    }}
+                  >
+                    {/* Show loading progress if data is still being loaded */}
+                    {this.props.loading && (
+                      <Grid item xs={12}>
+                        <LinearProgress color="secondary" />
+                      </Grid>
+                    )}
+                    <SearchPageTable
+                      containerHeight={containerHeight}
+                      hierarchy={match.params.hierarchy}
+                    />
+                  </Paper>
+                </Grid>
+              </Grid>
+            </div>
+          )}
+        />
       </Switch>
     );
   }

--- a/packages/datagateway-search/src/searchPageTable.tsx
+++ b/packages/datagateway-search/src/searchPageTable.tsx
@@ -31,6 +31,12 @@ const badgeStyles = (theme: Theme): StyleRules =>
       top: '0.875em',
     },
   });
+
+interface SearchTableProps {
+  containerHeight: string;
+  hierarchy: string;
+}
+
 interface SearchTableStoreProps {
   requestReceived: boolean;
   datafile: number[];
@@ -79,8 +85,7 @@ function a11yProps(index: string): React.ReactFragment {
 const StyledBadge = withStyles(badgeStyles)(Badge);
 
 const SearchPageTable = (
-  props: SearchTableStoreProps &
-    SearchTableDispatchProps & { containerHeight: string }
+  props: SearchTableProps & SearchTableStoreProps & SearchTableDispatchProps
 ): React.ReactElement => {
   const {
     requestReceived,
@@ -93,6 +98,7 @@ const SearchPageTable = (
     currentTab,
     setCurrentTab,
     containerHeight,
+    hierarchy,
   } = props;
   const [t] = useTranslation();
 
@@ -223,7 +229,7 @@ const SearchPageTable = (
               }}
               elevation={0}
             >
-              <InvestigationSearchTable />
+              <InvestigationSearchTable hierarchy={hierarchy} />
             </Paper>
           </TabPanel>
         ) : null}

--- a/packages/datagateway-search/src/setupTests.ts
+++ b/packages/datagateway-search/src/setupTests.ts
@@ -35,3 +35,6 @@ export const dispatch = (action: Action): void | Promise<void> => {
 };
 
 export const flushPromises = (): Promise<void> => new Promise(setImmediate);
+
+// Mock lodash.debounce to return the function we want to call.
+jest.mock('lodash.debounce', () => (fn: (args: unknown) => unknown) => fn);

--- a/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
@@ -62,11 +62,25 @@ exports[`Investigation Search Table component renders correctly 1`] = `
       Object {
         "DOI": "doi 1",
         "ENDDATE": "2019-06-11",
+        "FACILITY": Object {
+          "FACILITYCYCLE": Array [
+            Object {
+              "ENDDATE": "2020-06-11",
+              "FACILITY_ID": 2,
+              "ID": 2,
+              "NAME": "facility cycle name",
+              "STARTDATE": "2000-06-10",
+            },
+          ],
+          "ID": 2,
+          "NAME": "facility name",
+        },
         "ID": 1,
         "INVESTIGATIONINSTRUMENT": Array [
           Object {
             "ID": 1,
             "INSTRUMENT": Object {
+              "FACILITY_ID": 1,
               "ID": 3,
               "NAME": "LARMOR",
             },
@@ -83,7 +97,10 @@ exports[`Investigation Search Table component renders correctly 1`] = `
             "ID": 6,
             "INVESTIGATION_ID": 1,
             "STUDY": Object {
+              "CREATE_TIME": "2019-06-10",
               "ID": 7,
+              "MOD_TIME": "2019-06-10",
+              "NAME": "study name",
               "PID": "study pid",
             },
             "STUDY_ID": 7,

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -90,6 +90,32 @@ describe('Datafile search table component', () => {
     expect(testStore.getActions()[0]).toEqual(fetchDatafilesRequest(1));
   });
 
+  it('sends filterTable action on text filter', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatafileSearchTable />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const filterInput = wrapper
+      .find('[aria-label="Filter by datafiles.name"] input')
+      .first();
+    filterInput.instance().value = 'test';
+    filterInput.simulate('change');
+
+    expect(testStore.getActions()[4]).toEqual(
+      filterTable('NAME', { type: 'include', value: 'test' })
+    );
+
+    filterInput.instance().value = '';
+    filterInput.simulate('change');
+
+    expect(testStore.getActions()[5]).toEqual(filterTable('NAME', null));
+  });
+
   it('sends filterTable action on date filter', () => {
     const testStore = mockStore(state);
     const wrapper = mount(

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -88,6 +88,32 @@ describe('Dataset table component', () => {
     expect(testStore.getActions()[0]).toEqual(fetchDatasetsRequest(1));
   });
 
+  it('sends filterTable action on text filter', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const filterInput = wrapper
+      .find('[aria-label="Filter by datasets.name"] input')
+      .first();
+    filterInput.instance().value = 'test';
+    filterInput.simulate('change');
+
+    expect(testStore.getActions()[4]).toEqual(
+      filterTable('NAME', { type: 'include', value: 'test' })
+    );
+
+    filterInput.instance().value = '';
+    filterInput.simulate('change');
+
+    expect(testStore.getActions()[5]).toEqual(filterTable('NAME', null));
+  });
+
   it('sends filterTable action on date filter', () => {
     const testStore = mockStore(state);
     const wrapper = mount(


### PR DESCRIPTION
## Description
Extract the hierarchy from the url of the search plugin and use it to format links in the investigationSearchTable with the correct hierarchy. `/search/dls` and `/search/isis` will give their respective links, anything else (e.g. `/search/data`) will default to the generic hierarchy link. ISIS relies on possibly undefined values, so if any can't be found then it will just render text rather than a link. When serving search through SG, would therefore expect the link registered to be changed from `/search/data` to `/search/isis` for example.

Also mocked `lodash.debounce` in the search unit tests like we do in the other plugins so we can test the text filters. This is unrelated to the issue, but the increased coverage made it easier to check branching statements I'd introduced were covered by unit tests.

## Testing instructions
To check validity of links, either serve both dataview and search through SG or run both dataview and search standalone and just modify the port number after clicking the link in search to check the url is valid in dataview.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Check generic links go to valid generic url
- [x] Check DLS links go to valid DLS url
- [x] Check ISIS links go to valid ISIS url

## Agile board tracking
closes #566 