### PR TITLE
Use env.production to provide prefix for settings files #569

### DIFF
--- a/packages/datagateway-dataview/.env.production
+++ b/packages/datagateway-dataview/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_DATAVIEW_SETTINGS_PATH=/datagateway-dataview-settings.json
+REACT_APP_DATAVIEW_BUILD_DIRECTORY=/

--- a/packages/datagateway-dataview/.env.production
+++ b/packages/datagateway-dataview/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_DATAVIEW_SETTINGS_PATH=/plugins/datagateway-dataview/datagateway-dataview-settings.json
+REACT_APP_DATAVIEW_SETTINGS_PATH=/datagateway-dataview-settings.json

--- a/packages/datagateway-dataview/.env.production
+++ b/packages/datagateway-dataview/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_DATAVIEW_SETTINGS_PATH=/plugins/datagateway-dataview/datagateway-dataview-settings.json

--- a/packages/datagateway-dataview/src/i18n.ts
+++ b/packages/datagateway-dataview/src/i18n.ts
@@ -3,6 +3,10 @@ import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+const loadPath = process.env.REACT_APP_DATAVIEW_BUILD_DIRECTORY
+  ? process.env.REACT_APP_DATAVIEW_BUILD_DIRECTORY + 'res/default.json'
+  : '/res/default.json';
+
 i18n
   .use(Backend)
   .use(LanguageDetector)
@@ -11,7 +15,7 @@ i18n
     fallbackLng: 'en',
     debug: process.env.NODE_ENV === 'development',
     backend: {
-      loadPath: '/res/default.json',
+      loadPath: loadPath,
     },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default

--- a/packages/datagateway-dataview/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-dataview/src/state/actions/actions.test.tsx
@@ -288,7 +288,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-dataview-settings.json: facilityName is undefined in settings'
+      'Error loading /datagateway-dataview-settings.json: facilityName is undefined in settings'
     );
   });
 
@@ -307,7 +307,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-dataview-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
+      'Error loading /datagateway-dataview-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
     );
   });
 
@@ -329,7 +329,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-dataview-settings.json: No routes provided in the settings'
+      'Error loading /datagateway-dataview-settings.json: No routes provided in the settings'
     );
   });
 
@@ -357,7 +357,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-dataview-settings.json: Route provided does not have all the required entries (section, link, displayName)'
+      'Error loading /datagateway-dataview-settings.json: Route provided does not have all the required entries (section, link, displayName)'
     );
   });
 
@@ -371,9 +371,24 @@ describe('Actions', () => {
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
       expect.stringContaining(
-        `Error loading datagateway-dataview-settings.json: `
+        `Error loading /datagateway-dataview-settings.json: `
       )
     );
+  });
+
+  it('logs an error if settings.json fails to be loaded with custom path', async () => {
+    process.env.REACT_APP_DATAVIEW_SETTINGS_PATH = 'custom/path.json';
+    (axios.get as jest.Mock).mockImplementationOnce(() => Promise.reject({}));
+
+    const asyncAction = configureApp();
+    await asyncAction(dispatch, getState);
+
+    expect(log.error).toHaveBeenCalled();
+    const mockLog = (log.error as jest.Mock).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      expect.stringContaining(`Error loading custom/path.json: `)
+    );
+    delete process.env.REACT_APP_DATAVIEW_SETTINGS_PATH;
   });
 
   it('logs an error if settings.json is invalid JSON object', async () => {
@@ -389,7 +404,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-dataview-settings.json: Invalid format'
+      'Error loading /datagateway-dataview-settings.json: Invalid format'
     );
   });
 });

--- a/packages/datagateway-dataview/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-dataview/src/state/actions/actions.test.tsx
@@ -377,7 +377,7 @@ describe('Actions', () => {
   });
 
   it('logs an error if settings.json fails to be loaded with custom path', async () => {
-    process.env.REACT_APP_DATAVIEW_SETTINGS_PATH = 'custom/path.json';
+    process.env.REACT_APP_DATAVIEW_BUILD_DIRECTORY = '/custom/directory/';
     (axios.get as jest.Mock).mockImplementationOnce(() => Promise.reject({}));
 
     const asyncAction = configureApp();
@@ -386,9 +386,11 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      expect.stringContaining(`Error loading custom/path.json: `)
+      expect.stringContaining(
+        `Error loading /custom/directory/datagateway-dataview-settings.json: `
+      )
     );
-    delete process.env.REACT_APP_DATAVIEW_SETTINGS_PATH;
+    delete process.env.REACT_APP_DATAVIEW_BUILD_DIRECTORY;
   });
 
   it('logs an error if settings.json is invalid JSON object', async () => {

--- a/packages/datagateway-dataview/src/state/actions/index.tsx
+++ b/packages/datagateway-dataview/src/state/actions/index.tsx
@@ -57,8 +57,9 @@ export const loadSelectAllSetting = (
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
-  const settingsPath = process.env.REACT_APP_DATAVIEW_SETTINGS_PATH
-    ? process.env.REACT_APP_DATAVIEW_SETTINGS_PATH
+  const settingsPath = process.env.REACT_APP_DATAVIEW_BUILD_DIRECTORY
+    ? process.env.REACT_APP_DATAVIEW_BUILD_DIRECTORY +
+      'datagateway-dataview-settings.json'
     : '/datagateway-dataview-settings.json';
   return async (dispatch) => {
     await axios

--- a/packages/datagateway-dataview/src/state/actions/index.tsx
+++ b/packages/datagateway-dataview/src/state/actions/index.tsx
@@ -57,9 +57,12 @@ export const loadSelectAllSetting = (
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
+  const settingsPath = process.env.REACT_APP_DATAVIEW_SETTINGS_PATH
+    ? process.env.REACT_APP_DATAVIEW_SETTINGS_PATH
+    : '/datagateway-dataview-settings.json';
   return async (dispatch) => {
     await axios
-      .get('/datagateway-dataview-settings.json')
+      .get(settingsPath)
       .then((res) => {
         const settings = res.data;
 
@@ -207,9 +210,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
         dispatch(settingsLoaded());
       })
       .catch((error) => {
-        log.error(
-          `Error loading datagateway-dataview-settings.json: ${error.message}`
-        );
+        log.error(`Error loading ${settingsPath}: ${error.message}`);
       });
   };
 };

--- a/packages/datagateway-download/.env.production
+++ b/packages/datagateway-download/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_DOWNLOAD_SETTINGS_PATH=/datagateway-download-settings.json
+REACT_APP_DOWNLOAD_BUILD_DIRECTORY=/

--- a/packages/datagateway-download/.env.production
+++ b/packages/datagateway-download/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_DOWNLOAD_SETTINGS_PATH=/plugins/datagateway-download/datagateway-download-settings.json
+REACT_APP_DOWNLOAD_SETTINGS_PATH=/datagateway-download-settings.json

--- a/packages/datagateway-download/.env.production
+++ b/packages/datagateway-download/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_DOWNLOAD_SETTINGS_PATH=/plugins/datagateway-download/datagateway-download-settings.json

--- a/packages/datagateway-download/src/ConfigProvider.test.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.test.tsx
@@ -400,7 +400,7 @@ describe('ConfigProvider', () => {
   });
 
   it('logs an error if settings.json fails to be loaded with custom path', async () => {
-    process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH = 'custom/path.json';
+    process.env.REACT_APP_DOWNLOAD_BUILD_DIRECTORY = '/custom/directory/';
     (axios.get as jest.Mock).mockImplementationOnce(() => Promise.reject({}));
 
     // Create the wrapper and wait for it to load.
@@ -415,9 +415,9 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading custom/path.json: undefined'
+      'Error loading /custom/directory/datagateway-download-settings.json: undefined'
     );
-    delete process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH;
+    delete process.env.REACT_APP_DOWNLOAD_BUILD_DIRECTORY;
   });
 
   it('logs an error if fails to load a settings.json and is still in a loading state', async () => {

--- a/packages/datagateway-download/src/ConfigProvider.test.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.test.tsx
@@ -236,7 +236,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: facilityName is undefined in settings'
+      'Error loading /datagateway-download-settings.json: facilityName is undefined in settings'
     );
   });
 
@@ -270,7 +270,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
+      'Error loading /datagateway-download-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
     );
   });
 
@@ -300,7 +300,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: accessMethods is undefined in settings'
+      'Error loading /datagateway-download-settings.json: accessMethods is undefined in settings'
     );
   });
 
@@ -341,7 +341,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: Access method globus, defined in settings, does not contain a idsUrl'
+      'Error loading /datagateway-download-settings.json: Access method globus, defined in settings, does not contain a idsUrl'
     );
   });
 
@@ -372,7 +372,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: At least one access method should be defined under accessMethods in settings'
+      'Error loading /datagateway-download-settings.json: At least one access method should be defined under accessMethods in settings'
     );
   });
 
@@ -395,8 +395,29 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: Invalid format'
+      'Error loading /datagateway-download-settings.json: Invalid format'
     );
+  });
+
+  it('logs an error if settings.json fails to be loaded with custom path', async () => {
+    process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH = 'custom/path.json';
+    (axios.get as jest.Mock).mockImplementationOnce(() => Promise.reject({}));
+
+    // Create the wrapper and wait for it to load.
+    const wrapper = createWrapper();
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.exists('#settings')).toBe(false);
+    expect(log.error).toHaveBeenCalled();
+
+    const mockLog = (log.error as jest.Mock).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      'Error loading custom/path.json: undefined'
+    );
+    delete process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH;
   });
 
   it('logs an error if fails to load a settings.json and is still in a loading state', async () => {
@@ -414,7 +435,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: undefined'
+      'Error loading /datagateway-download-settings.json: undefined'
     );
   });
 
@@ -453,7 +474,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: fileCountMax or totalSizeMax is undefined in settings'
+      'Error loading /datagateway-download-settings.json: fileCountMax or totalSizeMax is undefined in settings'
     );
   });
 
@@ -495,7 +516,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: No routes provided in the settings'
+      'Error loading /datagateway-download-settings.json: No routes provided in the settings'
     );
   });
 
@@ -544,7 +565,7 @@ describe('ConfigProvider', () => {
 
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-download-settings.json: Route provided does not have all the required entries (section, link, displayName)'
+      'Error loading /datagateway-download-settings.json: Route provided does not have all the required entries (section, link, displayName)'
     );
   });
 });

--- a/packages/datagateway-download/src/ConfigProvider.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.tsx
@@ -67,8 +67,9 @@ class ConfigProvider extends React.Component<
   }
 
   private updateConfigurationState = async (): Promise<void> => {
-    const settingsPath = process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH
-      ? process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH
+    const settingsPath = process.env.REACT_APP_DOWNLOAD_BUILD_DIRECTORY
+      ? process.env.REACT_APP_DOWNLOAD_BUILD_DIRECTORY +
+        'datagateway-download-settings.json'
       : '/datagateway-download-settings.json';
     const settings = await axios
       .get<DownloadSettings>(settingsPath)

--- a/packages/datagateway-download/src/ConfigProvider.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.tsx
@@ -67,8 +67,11 @@ class ConfigProvider extends React.Component<
   }
 
   private updateConfigurationState = async (): Promise<void> => {
+    const settingsPath = process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH
+      ? process.env.REACT_APP_DOWNLOAD_SETTINGS_PATH
+      : '/datagateway-download-settings.json';
     const settings = await axios
-      .get<DownloadSettings>('/datagateway-download-settings.json')
+      .get<DownloadSettings>(settingsPath)
       .then((res) => {
         const settings = res.data;
 
@@ -138,9 +141,7 @@ class ConfigProvider extends React.Component<
         return settings;
       })
       .catch((error) => {
-        log.error(
-          `Error loading datagateway-download-settings.json: ${error.message}`
-        );
+        log.error(`Error loading ${settingsPath}: ${error.message}`);
         return null;
       });
 

--- a/packages/datagateway-download/src/i18n.ts
+++ b/packages/datagateway-download/src/i18n.ts
@@ -3,6 +3,10 @@ import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+const loadPath = process.env.REACT_APP_DOWNLOAD_BUILD_DIRECTORY
+  ? process.env.REACT_APP_DOWNLOAD_BUILD_DIRECTORY + 'res/default.json'
+  : '/res/default.json';
+
 i18n
   .use(Backend)
   .use(LanguageDetector)
@@ -11,7 +15,7 @@ i18n
     fallbackLng: 'en',
     debug: process.env.NODE_ENV === 'development',
     backend: {
-      loadPath: '/res/default.json',
+      loadPath: loadPath,
     },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default

--- a/packages/datagateway-search/.env.production
+++ b/packages/datagateway-search/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_SEARCH_SETTINGS_PATH=/datagateway-search-settings.json
+REACT_APP_SEARCH_BUILD_DIRECTORY=/

--- a/packages/datagateway-search/.env.production
+++ b/packages/datagateway-search/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_SEARCH_SETTINGS_PATH=/plugins/datagateway-search/datagateway-search-settings.json

--- a/packages/datagateway-search/.env.production
+++ b/packages/datagateway-search/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_SEARCH_SETTINGS_PATH=/plugins/datagateway-search/datagateway-search-settings.json
+REACT_APP_SEARCH_SETTINGS_PATH=/datagateway-search-settings.json

--- a/packages/datagateway-search/src/i18n.ts
+++ b/packages/datagateway-search/src/i18n.ts
@@ -3,6 +3,10 @@ import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+const loadPath = process.env.REACT_APP_SEARCH_BUILD_DIRECTORY
+  ? process.env.REACT_APP_SEARCH_BUILD_DIRECTORY + 'res/default.json'
+  : '/res/default.json';
+
 i18n
   .use(Backend)
   .use(LanguageDetector)
@@ -11,7 +15,7 @@ i18n
     fallbackLng: 'en',
     debug: process.env.NODE_ENV === 'development',
     backend: {
-      loadPath: '/res/default.json',
+      loadPath: loadPath,
     },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -182,7 +182,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-search-settings.json: facilityName is undefined in settings'
+      'Error loading /datagateway-search-settings.json: facilityName is undefined in settings'
     );
   });
 
@@ -201,7 +201,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-search-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
+      'Error loading /datagateway-search-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
     );
   });
 
@@ -223,7 +223,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-search-settings.json: No routes provided in the settings'
+      'Error loading /datagateway-search-settings.json: No routes provided in the settings'
     );
   });
 
@@ -251,7 +251,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-search-settings.json: Route provided does not have all the required entries (section, link, displayName)'
+      'Error loading /datagateway-search-settings.json: Route provided does not have all the required entries (section, link, displayName)'
     );
   });
 
@@ -265,9 +265,24 @@ describe('Actions', () => {
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
       expect.stringContaining(
-        `Error loading datagateway-search-settings.json: `
+        `Error loading /datagateway-search-settings.json: `
       )
     );
+  });
+
+  it('logs an error if settings.json fails to be loaded with custom path', async () => {
+    process.env.REACT_APP_SEARCH_SETTINGS_PATH = 'custom/path.json';
+    (axios.get as jest.Mock).mockImplementationOnce(() => Promise.reject({}));
+
+    const asyncAction = configureApp();
+    await asyncAction(dispatch, getState);
+
+    expect(log.error).toHaveBeenCalled();
+    const mockLog = (log.error as jest.Mock).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      expect.stringContaining(`Error loading custom/path.json: `)
+    );
+    delete process.env.REACT_APP_SEARCH_SETTINGS_PATH;
   });
 
   it('logs an error if settings.json is invalid JSON object', async () => {
@@ -283,7 +298,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading datagateway-search-settings.json: Invalid format'
+      'Error loading /datagateway-search-settings.json: Invalid format'
     );
   });
 });

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -271,7 +271,7 @@ describe('Actions', () => {
   });
 
   it('logs an error if settings.json fails to be loaded with custom path', async () => {
-    process.env.REACT_APP_SEARCH_SETTINGS_PATH = 'custom/path.json';
+    process.env.REACT_APP_SEARCH_BUILD_DIRECTORY = '/custom/directory/';
     (axios.get as jest.Mock).mockImplementationOnce(() => Promise.reject({}));
 
     const asyncAction = configureApp();
@@ -280,9 +280,11 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      expect.stringContaining(`Error loading custom/path.json: `)
+      expect.stringContaining(
+        `Error loading /custom/directory/datagateway-search-settings.json: `
+      )
     );
-    delete process.env.REACT_APP_SEARCH_SETTINGS_PATH;
+    delete process.env.REACT_APP_SEARCH_BUILD_DIRECTORY;
   });
 
   it('logs an error if settings.json is invalid JSON object', async () => {

--- a/packages/datagateway-search/src/state/actions/index.tsx
+++ b/packages/datagateway-search/src/state/actions/index.tsx
@@ -19,9 +19,12 @@ export const settingsLoaded = (): Action => ({
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
+  const settingsPath = process.env.REACT_APP_SEARCH_SETTINGS_PATH
+    ? process.env.REACT_APP_SEARCH_SETTINGS_PATH
+    : '/datagateway-search-settings.json';
   return async (dispatch) => {
     await axios
-      .get('/datagateway-search-settings.json')
+      .get(settingsPath)
       .then((res) => {
         const settings = res.data;
 
@@ -155,9 +158,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
         dispatch(settingsLoaded());
       })
       .catch((error) => {
-        log.error(
-          `Error loading datagateway-search-settings.json: ${error.message}`
-        );
+        log.error(`Error loading ${settingsPath}: ${error.message}`);
       });
   };
 };

--- a/packages/datagateway-search/src/state/actions/index.tsx
+++ b/packages/datagateway-search/src/state/actions/index.tsx
@@ -19,8 +19,9 @@ export const settingsLoaded = (): Action => ({
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
-  const settingsPath = process.env.REACT_APP_SEARCH_SETTINGS_PATH
-    ? process.env.REACT_APP_SEARCH_SETTINGS_PATH
+  const settingsPath = process.env.REACT_APP_SEARCH_BUILD_DIRECTORY
+    ? process.env.REACT_APP_SEARCH_BUILD_DIRECTORY +
+      'datagateway-search-settings.json'
     : '/datagateway-search-settings.json';
   return async (dispatch) => {
     await axios


### PR DESCRIPTION
## Description
Have added a check for an environment variable to set the directory used to load the settings file and `res/default.json` (these were the two files mentioned in the issue and I haven't seen any other files with hardcoded locations but I may have missed something). This is specified in `.env.production` which is used when building the plugin but not when testing or running in standalone (note that because the E2E tests use the build command they are also affected by the value in this file). The value can either be changed directly or overridden by a `.local` version of the environment file, as described here https://create-react-app.dev/docs/adding-custom-environment-variables/#what-other-env-files-can-be-used. If a value isn't available we default back to `/` so development should be unaffected.

As mentioned above this is injected at build time. I had a look into doing this at runtime instead, and you could do it by running a .js file to collect the values of any environment variables in the `start` or `prestart` commands, then overwriting another file in your build folder which in turn is added to `index.html`. The drawbacks of this are that you still need to know where your build folder is to overwrite, and the script that holds the environment variables would need to be added to SG's build folder/index rather than the index of the plugins, so SG is then containing the code for the plugins to a certain extent. That along with the fact it's just a more complicated way of doing it led me to go with the on build approach.

Also I orginally didn't fully understand the issue, so if at any point I've got what we need from this change wrong let me know.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

For each plugin:
- [ ] Change the value of `REACT_APP_<PLUGIN>_BUILD_DIRECTORY` in `.env.production` or add an `.env.production.local` file with a different value
- [ ] Check that when run standalone, the custom directory is ignored and the plugin loads the settings/strings from the default location
- [ ] Check that when building and serving through SG, the custom path is used. In practice this means it will fail to load unless you create a copy of the files at the specified location in SG's public folder (rather than DG's build folder).

## Agile board tracking
closes #569 
