### PR TITLE
Don't include routing when datagateway-dataview element missing #574

### DIFF
--- a/packages/datagateway-dataview/src/page/__snapshots__/pageContainer.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/pageContainer.component.test.tsx.snap
@@ -48,20 +48,7 @@ exports[`PageContainer - Tests displays the correct entity count 1`] = `
       aria-label="container-table"
       item={true}
       xs={12}
-    >
-      <ViewRouting
-        loadedCount={false}
-        location={
-          Object {
-            "hash": "",
-            "pathname": "/",
-            "search": "",
-          }
-        }
-        totalDataCount={101}
-        view={null}
-      />
-    </WithStyles(ForwardRef(Grid))>
+    />
   </WithStyles(WithStyles(ForwardRef(Grid)))>
 </div>
 `;

--- a/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
@@ -181,6 +181,9 @@ describe('PageContainer - Tests', () => {
   });
 
   it('display filter warning on datafile table', () => {
+    // Mock getElementById so that it returns truthy.
+    const testElement = document.createElement('DIV');
+    document.getElementById = jest.fn(() => testElement);
     (checkInvestigationId as jest.Mock).mockImplementation(() =>
       Promise.resolve(true)
     );
@@ -222,6 +225,9 @@ describe('PageContainer - Tests', () => {
   });
 
   it('display filter warning on toggle table', () => {
+    // Mock getElementById so that it returns truthy.
+    const testElement = document.createElement('DIV');
+    document.getElementById = jest.fn(() => testElement);
     state = JSON.parse(
       JSON.stringify({
         dgcommon: {

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -510,12 +510,14 @@ class PageContainer extends React.Component<
 
           {/* Hold the table for remainder of the page */}
           <Grid item xs={12} aria-label="container-table">
-            <ViewRouting
-              view={this.props.query.view}
-              loadedCount={this.props.loadedCount}
-              totalDataCount={this.props.totalDataCount}
-              location={this.state.modifiedLocation}
-            />
+            {document.getElementById('datagateway-dataview') && (
+              <ViewRouting
+                view={this.props.query.view}
+                loadedCount={this.props.loadedCount}
+                totalDataCount={this.props.totalDataCount}
+                location={this.state.modifiedLocation}
+              />
+            )}
           </Grid>
         </StyledGrid>
       </Paper>


### PR DESCRIPTION
## Description
Add a check on the presence of an element with `id="datagateway-dataview"` for including the routing in PageContainer. The effect of this is to prevent us from sending requests for data unless the element is present, like how we do for fetching the cart. This means we'll no longer get requests while in maintenance mode (see ral-facilities/scigateway#565).

No functional change expected.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Check datagateway loads successfully as it did before 

## Agile board tracking
closes #574