### PR TITLE
Prevent logging in successful unit tests #601

### DIFF
--- a/packages/datagateway-common/src/__mocks__/react-i18next.jsx
+++ b/packages/datagateway-common/src/__mocks__/react-i18next.jsx
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+// eslint-disable-next-line no-use-before-define
+import React from 'react';
+import * as reactI18next from 'react-i18next';
+
+const hasChildren = (node) =>
+  node && (node.children || (node.props && node.props.children));
+
+const getChildren = (node) =>
+  node && node.children ? node.children : node.props && node.props.children;
+
+const renderNodes = (reactNodes) => {
+  if (typeof reactNodes === 'string') {
+    return reactNodes;
+  }
+
+  return Object.keys(reactNodes).map((key, i) => {
+    const child = reactNodes[key];
+    const isElement = React.isValidElement(child);
+
+    if (typeof child === 'string') {
+      return child;
+    }
+    if (hasChildren(child)) {
+      const inner = renderNodes(getChildren(child));
+      return React.cloneElement(child, { ...child.props, key: i }, inner);
+    }
+    if (typeof child === 'object' && !isElement) {
+      return Object.keys(child).reduce(
+        (str, childKey) => `${str}${child[childKey]}`,
+        ''
+      );
+    }
+
+    return child;
+  });
+};
+
+const useMock = [(k) => k, {}];
+useMock.t = (k) => k;
+useMock.i18n = {};
+
+const applyTranslation = (Component) => {
+  const applyProps = (props) => (
+    <Component
+      t={(k, o) => (o ? `${k} ${JSON.stringify(o).replace(/"/g, '')}` : k)}
+      {...props}
+    />
+  );
+  return applyProps;
+};
+
+module.exports = {
+  // this mock makes sure any components using the translate HoC receive the t function as a prop
+  withTranslation: () => (Component) => applyTranslation(Component),
+  Trans: ({ children }) => renderNodes(children),
+  Translation: ({ children }) => children((k) => k, { i18n: {} }),
+  useTranslation: () => useMock,
+
+  // mock if needed
+  I18nextProvider: reactI18next.I18nextProvider,
+  initReactI18next: reactI18next.initReactI18next,
+  setDefaults: reactI18next.setDefaults,
+  getDefaults: reactI18next.getDefaults,
+  setI18n: reactI18next.setI18n,
+  getI18n: reactI18next.getI18n,
+};

--- a/packages/datagateway-common/src/card/cardView.component.test.tsx
+++ b/packages/datagateway-common/src/card/cardView.component.test.tsx
@@ -25,13 +25,6 @@ describe('Card View', () => {
     return mount(<CardView {...props} />);
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   const loadData = jest.fn();
   const onFilter = jest.fn();
   const onPageChange = jest.fn();
@@ -64,6 +57,13 @@ describe('Card View', () => {
       onFilter: onFilter,
       pushQuery: pushQuery,
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {
@@ -108,6 +108,10 @@ describe('Card View', () => {
       ...updatedProps,
       query: { ...updatedProps.query, page: 1, filters: { TYPE_ID: ['1'] } },
     };
+
+    // Mock console.error() when updating the filter panels. We use Accordions
+    // with dynamic default values, which works, but would log an error.
+    jest.spyOn(console, 'error').mockImplementationOnce(jest.fn());
     wrapper.setProps(updatedProps);
 
     // Apply second filter

--- a/packages/datagateway-common/src/card/cardView.component.tsx
+++ b/packages/datagateway-common/src/card/cardView.component.tsx
@@ -760,7 +760,7 @@ const CardView = (props: CardViewProps): React.ReactElement => {
                 })}
               </List>
             ) : (
-              <Grid xs={12} md={8}>
+              <Grid item xs={12} md={8}>
                 <Paper className={classes.noResultsPaper}>
                   <Typography align="center" variant="h6" component="h6">
                     {t('loading.filter_message')}

--- a/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
@@ -23,6 +23,9 @@ import { push } from 'connected-react-router';
 import PageContainer from './pageContainer.component';
 import { Provider } from 'react-redux';
 import { checkInvestigationId } from './idCheckFunctions';
+import axios from 'axios';
+import { act } from 'react-dom/test-utils';
+import { flushPromises } from '../setupTests';
 
 jest.mock('loglevel');
 jest.mock('./idCheckFunctions');
@@ -54,6 +57,10 @@ describe('PageContainer - Tests', () => {
           location: createLocation('/'),
         },
       })
+    );
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
     );
   });
 
@@ -180,7 +187,7 @@ describe('PageContainer - Tests', () => {
     expect(wrapper.exists(LinearProgress)).toBeTruthy();
   });
 
-  it('display filter warning on datafile table', () => {
+  it('display filter warning on datafile table', async () => {
     // Mock getElementById so that it returns truthy.
     const testElement = document.createElement('DIV');
     document.getElementById = jest.fn(() => testElement);
@@ -219,6 +226,10 @@ describe('PageContainer - Tests', () => {
         </MemoryRouter>
       </Provider>
     );
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
     expect(
       wrapper.find('[aria-label="filter-message"]').first().text()
     ).toEqual('loading.filter_message');

--- a/packages/datagateway-dataview/src/views/card/datasetCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/datasetCardView.component.test.tsx
@@ -39,13 +39,6 @@ describe('Dataset - Card View', () => {
     );
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   beforeEach(() => {
     mount = createMount();
     shallow = createShallow();
@@ -80,6 +73,19 @@ describe('Dataset - Card View', () => {
         },
       },
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
@@ -41,13 +41,6 @@ describe('DLS Datasets - Card View', () => {
     );
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   beforeEach(() => {
     mount = createMount();
     shallow = createShallow();
@@ -81,6 +74,19 @@ describe('DLS Datasets - Card View', () => {
         },
       },
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
@@ -37,13 +37,6 @@ describe('DLS Proposals - Card View', () => {
     );
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   beforeEach(() => {
     mount = createMount();
     shallow = createShallow();
@@ -76,6 +69,13 @@ describe('DLS Proposals - Card View', () => {
         },
       },
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
@@ -39,13 +39,6 @@ describe('DLS Visits - Card View', () => {
     );
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   beforeEach(() => {
     mount = createMount();
     shallow = createShallow();
@@ -78,6 +71,13 @@ describe('DLS Visits - Card View', () => {
         },
       },
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/datagateway-dataview/src/views/card/investigationCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/investigationCardView.component.test.tsx
@@ -47,13 +47,6 @@ describe('Investigation - Card View', () => {
     );
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   beforeEach(() => {
     mount = createMount();
     shallow = createShallow();
@@ -88,6 +81,19 @@ describe('Investigation - Card View', () => {
         },
       },
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
@@ -79,6 +79,12 @@ describe('ISIS Datasets - Card View', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
     // Prevent error logging
     window.scrollTo = jest.fn();

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
@@ -37,13 +37,6 @@ describe('ISIS Facility Cycles - Card View', () => {
     );
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   beforeEach(() => {
     mount = createMount();
     shallow = createShallow();
@@ -75,6 +68,13 @@ describe('ISIS Facility Cycles - Card View', () => {
         },
       },
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.test.tsx
@@ -38,13 +38,6 @@ describe('ISIS Instruments - Card View', () => {
     );
   };
 
-  (axios.get as jest.Mock).mockImplementation(() =>
-    Promise.resolve({ data: [] })
-  );
-  global.Date.now = jest.fn(() => 1);
-  // Prevent error logging
-  window.scrollTo = jest.fn();
-
   beforeEach(() => {
     mount = createMount();
     shallow = createShallow();
@@ -77,6 +70,13 @@ describe('ISIS Instruments - Card View', () => {
         },
       },
     };
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
+    global.Date.now = jest.fn(() => 1);
+    // Prevent error logging
+    window.scrollTo = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
@@ -78,6 +78,12 @@ describe('ISIS Investigations - Card View', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
     // Prevent error logging
     window.scrollTo = jest.fn();

--- a/packages/datagateway-dataview/src/views/table/datafileTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/datafileTable.component.test.tsx
@@ -54,6 +54,12 @@ describe('Datafile table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
@@ -51,6 +51,12 @@ describe('Dataset table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
@@ -52,6 +52,12 @@ describe('DLS datafiles table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
@@ -54,6 +54,12 @@ describe('DLS Dataset table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
@@ -57,6 +57,12 @@ describe('Investigation table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
@@ -55,6 +55,12 @@ describe('ISIS datafiles table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
@@ -54,6 +54,12 @@ describe('ISIS Dataset table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -80,6 +80,12 @@ describe('ISIS Investigations table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
@@ -102,6 +102,12 @@ describe('ISIS Investigations table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 

--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
@@ -1,1082 +1,142 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchPageTable renders SearchPageTable correctly after request 1`] = `
-<Provider
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
->
-  <Connect(SearchPageTable)
-    store={
-      Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      }
-    }
+<div>
+  <WithStyles(ForwardRef(AppBar))
+    position="static"
   >
-    <SearchPageTable
-      currentTab="none"
-      datafile={
-        Array [
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-        ]
-      }
-      datafileTab={true}
-      dataset={
-        Array [
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-        ]
-      }
-      datasetTab={true}
-      investigation={
-        Array [
-          undefined,
-        ]
-      }
-      investigationTab={true}
-      requestReceived={true}
-      setCurrentTab={[Function]}
-      store={
+    <WithStyles(ForwardRef(Tabs))
+      aria-label="searchPageTable.tabs_arialabel"
+      className="tour-search-tab-select"
+      onChange={[Function]}
+      value="investigation"
+    >
+      <WithStyles(ForwardRef(Tab))
+        aria-controls="simple-tabpanel-investigation"
+        id="simple-tab-investigation"
+        label={
+          <WithStyles(WithStyles(ForwardRef(Badge)))
+            badgeContent={1}
+            id="investigation-badge"
+            showZero={true}
+          >
+            <span
+              style={
+                Object {
+                  "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                  "marginRight": "calc(0.5 * 1ch + 6px)",
+                  "paddingRight": "1ch",
+                }
+              }
+            >
+              tabs.investigation
+            </span>
+          </WithStyles(WithStyles(ForwardRef(Badge)))>
+        }
+        value="investigation"
+      />
+      <WithStyles(ForwardRef(Tab))
+        aria-controls="simple-tabpanel-dataset"
+        id="simple-tab-dataset"
+        label={
+          <WithStyles(WithStyles(ForwardRef(Badge)))
+            badgeContent={10}
+            id="dataset-badge"
+            showZero={true}
+          >
+            <span
+              style={
+                Object {
+                  "marginLeft": "calc(-0.5 * 2ch - 6px)",
+                  "marginRight": "calc(0.5 * 2ch + 6px)",
+                  "paddingRight": "1ch",
+                }
+              }
+            >
+              tabs.dataset
+            </span>
+          </WithStyles(WithStyles(ForwardRef(Badge)))>
+        }
+        value="dataset"
+      />
+      <WithStyles(ForwardRef(Tab))
+        aria-controls="simple-tabpanel-datafile"
+        id="simple-tab-datafile"
+        label={
+          <WithStyles(WithStyles(ForwardRef(Badge)))
+            badgeContent={100}
+            id="datafile-badge"
+            showZero={true}
+          >
+            <span
+              style={
+                Object {
+                  "marginLeft": "calc(-0.5 * 3ch - 6px)",
+                  "marginRight": "calc(0.5 * 3ch + 6px)",
+                  "paddingRight": "1ch",
+                }
+              }
+            >
+              tabs.datafile
+            </span>
+          </WithStyles(WithStyles(ForwardRef(Badge)))>
+        }
+        value="datafile"
+      />
+    </WithStyles(ForwardRef(Tabs))>
+  </WithStyles(ForwardRef(AppBar))>
+  <TabPanel
+    index="investigation"
+    value="investigation"
+  >
+    <WithStyles(ForwardRef(Paper))
+      elevation={0}
+      style={
         Object {
-          "clearActions": [Function],
-          "dispatch": [Function],
-          "getActions": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
+          "height": "calc(undefined - 96px)",
+          "minHeight": 230,
+          "overflowX": "auto",
         }
       }
     >
-      <div>
-        <WithStyles(ForwardRef(AppBar))
-          position="static"
-        >
-          <ForwardRef(AppBar)
-            classes={
-              Object {
-                "colorDefault": "MuiAppBar-colorDefault",
-                "colorInherit": "MuiAppBar-colorInherit",
-                "colorPrimary": "MuiAppBar-colorPrimary",
-                "colorSecondary": "MuiAppBar-colorSecondary",
-                "colorTransparent": "MuiAppBar-colorTransparent",
-                "positionAbsolute": "MuiAppBar-positionAbsolute",
-                "positionFixed": "MuiAppBar-positionFixed",
-                "positionRelative": "MuiAppBar-positionRelative",
-                "positionStatic": "MuiAppBar-positionStatic",
-                "positionSticky": "MuiAppBar-positionSticky",
-                "root": "MuiAppBar-root",
-              }
-            }
-            position="static"
-          >
-            <WithStyles(ForwardRef(Paper))
-              className="MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary"
-              component="header"
-              elevation={4}
-              square={true}
-            >
-              <ForwardRef(Paper)
-                className="MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary"
-                classes={
-                  Object {
-                    "elevation0": "MuiPaper-elevation0",
-                    "elevation1": "MuiPaper-elevation1",
-                    "elevation10": "MuiPaper-elevation10",
-                    "elevation11": "MuiPaper-elevation11",
-                    "elevation12": "MuiPaper-elevation12",
-                    "elevation13": "MuiPaper-elevation13",
-                    "elevation14": "MuiPaper-elevation14",
-                    "elevation15": "MuiPaper-elevation15",
-                    "elevation16": "MuiPaper-elevation16",
-                    "elevation17": "MuiPaper-elevation17",
-                    "elevation18": "MuiPaper-elevation18",
-                    "elevation19": "MuiPaper-elevation19",
-                    "elevation2": "MuiPaper-elevation2",
-                    "elevation20": "MuiPaper-elevation20",
-                    "elevation21": "MuiPaper-elevation21",
-                    "elevation22": "MuiPaper-elevation22",
-                    "elevation23": "MuiPaper-elevation23",
-                    "elevation24": "MuiPaper-elevation24",
-                    "elevation3": "MuiPaper-elevation3",
-                    "elevation4": "MuiPaper-elevation4",
-                    "elevation5": "MuiPaper-elevation5",
-                    "elevation6": "MuiPaper-elevation6",
-                    "elevation7": "MuiPaper-elevation7",
-                    "elevation8": "MuiPaper-elevation8",
-                    "elevation9": "MuiPaper-elevation9",
-                    "outlined": "MuiPaper-outlined",
-                    "root": "MuiPaper-root",
-                    "rounded": "MuiPaper-rounded",
-                  }
-                }
-                component="header"
-                elevation={4}
-                square={true}
-              >
-                <header
-                  className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation4"
-                >
-                  <WithStyles(ForwardRef(Tabs))
-                    aria-label="searchPageTable.tabs_arialabel"
-                    className="tour-search-tab-select"
-                    onChange={[Function]}
-                    value="none"
-                  >
-                    <ForwardRef(Tabs)
-                      aria-label="searchPageTable.tabs_arialabel"
-                      className="tour-search-tab-select"
-                      classes={
-                        Object {
-                          "centered": "MuiTabs-centered",
-                          "fixed": "MuiTabs-fixed",
-                          "flexContainer": "MuiTabs-flexContainer",
-                          "flexContainerVertical": "MuiTabs-flexContainerVertical",
-                          "indicator": "MuiTabs-indicator",
-                          "root": "MuiTabs-root",
-                          "scrollButtons": "MuiTabs-scrollButtons",
-                          "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
-                          "scrollable": "MuiTabs-scrollable",
-                          "scroller": "MuiTabs-scroller",
-                          "vertical": "MuiTabs-vertical",
-                        }
-                      }
-                      onChange={[Function]}
-                      value="none"
-                    >
-                      <div
-                        className="MuiTabs-root tour-search-tab-select"
-                      >
-                        <div
-                          className="MuiTabs-scroller MuiTabs-fixed"
-                          onScroll={[Function]}
-                          style={
-                            Object {
-                              "marginBottom": null,
-                              "overflow": "hidden",
-                            }
-                          }
-                        >
-                          <div
-                            aria-label="searchPageTable.tabs_arialabel"
-                            className="MuiTabs-flexContainer"
-                            onKeyDown={[Function]}
-                            role="tablist"
-                          >
-                            <WithStyles(ForwardRef(Tab))
-                              aria-controls="simple-tabpanel-investigation"
-                              fullWidth={false}
-                              id="simple-tab-investigation"
-                              indicator={false}
-                              key=".0"
-                              label={
-                                <WithStyles(WithStyles(ForwardRef(Badge)))
-                                  badgeContent={1}
-                                  id="investigation-badge"
-                                  showZero={true}
-                                >
-                                  <span
-                                    style={
-                                      Object {
-                                        "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                        "marginRight": "calc(0.5 * 1ch + 6px)",
-                                        "paddingRight": "1ch",
-                                      }
-                                    }
-                                  >
-                                    tabs.investigation
-                                  </span>
-                                </WithStyles(WithStyles(ForwardRef(Badge)))>
-                              }
-                              onChange={[Function]}
-                              selected={false}
-                              textColor="inherit"
-                              value="investigation"
-                            >
-                              <ForwardRef(Tab)
-                                aria-controls="simple-tabpanel-investigation"
-                                classes={
-                                  Object {
-                                    "disabled": "Mui-disabled",
-                                    "fullWidth": "MuiTab-fullWidth",
-                                    "labelIcon": "MuiTab-labelIcon",
-                                    "root": "MuiTab-root",
-                                    "selected": "Mui-selected",
-                                    "textColorInherit": "MuiTab-textColorInherit",
-                                    "textColorPrimary": "MuiTab-textColorPrimary",
-                                    "textColorSecondary": "MuiTab-textColorSecondary",
-                                    "wrapped": "MuiTab-wrapped",
-                                    "wrapper": "MuiTab-wrapper",
-                                  }
-                                }
-                                fullWidth={false}
-                                id="simple-tab-investigation"
-                                indicator={false}
-                                label={
-                                  <WithStyles(WithStyles(ForwardRef(Badge)))
-                                    badgeContent={1}
-                                    id="investigation-badge"
-                                    showZero={true}
-                                  >
-                                    <span
-                                      style={
-                                        Object {
-                                          "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                          "marginRight": "calc(0.5 * 1ch + 6px)",
-                                          "paddingRight": "1ch",
-                                        }
-                                      }
-                                    >
-                                      tabs.investigation
-                                    </span>
-                                  </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                }
-                                onChange={[Function]}
-                                selected={false}
-                                textColor="inherit"
-                                value="investigation"
-                              >
-                                <WithStyles(ForwardRef(ButtonBase))
-                                  aria-controls="simple-tabpanel-investigation"
-                                  aria-selected={false}
-                                  className="MuiTab-root MuiTab-textColorInherit"
-                                  disabled={false}
-                                  focusRipple={true}
-                                  id="simple-tab-investigation"
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  role="tab"
-                                  tabIndex={-1}
-                                >
-                                  <ForwardRef(ButtonBase)
-                                    aria-controls="simple-tabpanel-investigation"
-                                    aria-selected={false}
-                                    className="MuiTab-root MuiTab-textColorInherit"
-                                    classes={
-                                      Object {
-                                        "disabled": "Mui-disabled",
-                                        "focusVisible": "Mui-focusVisible",
-                                        "root": "MuiButtonBase-root",
-                                      }
-                                    }
-                                    disabled={false}
-                                    focusRipple={true}
-                                    id="simple-tab-investigation"
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    role="tab"
-                                    tabIndex={-1}
-                                  >
-                                    <button
-                                      aria-controls="simple-tabpanel-investigation"
-                                      aria-selected={false}
-                                      className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
-                                      disabled={false}
-                                      id="simple-tab-investigation"
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onDragLeave={[Function]}
-                                      onFocus={[Function]}
-                                      onKeyDown={[Function]}
-                                      onKeyUp={[Function]}
-                                      onMouseDown={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onMouseUp={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
-                                      role="tab"
-                                      tabIndex={-1}
-                                      type="button"
-                                    >
-                                      <span
-                                        className="MuiTab-wrapper"
-                                      >
-                                        <WithStyles(WithStyles(ForwardRef(Badge)))
-                                          badgeContent={1}
-                                          id="investigation-badge"
-                                          showZero={true}
-                                        >
-                                          <WithStyles(ForwardRef(Badge))
-                                            badgeContent={1}
-                                            classes={
-                                              Object {
-                                                "badge": "WithStyles(ForwardRef(Badge))-badge-2",
-                                              }
-                                            }
-                                            id="investigation-badge"
-                                            showZero={true}
-                                          >
-                                            <ForwardRef(Badge)
-                                              badgeContent={1}
-                                              classes={
-                                                Object {
-                                                  "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                  "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                  "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                  "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                  "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                  "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                  "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                  "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                  "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
-                                                  "colorError": "MuiBadge-colorError",
-                                                  "colorPrimary": "MuiBadge-colorPrimary",
-                                                  "colorSecondary": "MuiBadge-colorSecondary",
-                                                  "dot": "MuiBadge-dot",
-                                                  "invisible": "MuiBadge-invisible",
-                                                  "root": "MuiBadge-root",
-                                                }
-                                              }
-                                              id="investigation-badge"
-                                              showZero={true}
-                                            >
-                                              <span
-                                                className="MuiBadge-root"
-                                                id="investigation-badge"
-                                              >
-                                                <span
-                                                  style={
-                                                    Object {
-                                                      "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                                      "marginRight": "calc(0.5 * 1ch + 6px)",
-                                                      "paddingRight": "1ch",
-                                                    }
-                                                  }
-                                                >
-                                                  tabs.investigation
-                                                </span>
-                                                <span
-                                                  className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
-                                                >
-                                                  1
-                                                </span>
-                                              </span>
-                                            </ForwardRef(Badge)>
-                                          </WithStyles(ForwardRef(Badge))>
-                                        </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                      </span>
-                                      <WithStyles(memo)
-                                        center={false}
-                                      >
-                                        <ForwardRef(TouchRipple)
-                                          center={false}
-                                          classes={
-                                            Object {
-                                              "child": "MuiTouchRipple-child",
-                                              "childLeaving": "MuiTouchRipple-childLeaving",
-                                              "childPulsate": "MuiTouchRipple-childPulsate",
-                                              "ripple": "MuiTouchRipple-ripple",
-                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                              "root": "MuiTouchRipple-root",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="MuiTouchRipple-root"
-                                          >
-                                            <TransitionGroup
-                                              childFactory={[Function]}
-                                              component={null}
-                                              exit={true}
-                                            />
-                                          </span>
-                                        </ForwardRef(TouchRipple)>
-                                      </WithStyles(memo)>
-                                    </button>
-                                  </ForwardRef(ButtonBase)>
-                                </WithStyles(ForwardRef(ButtonBase))>
-                              </ForwardRef(Tab)>
-                            </WithStyles(ForwardRef(Tab))>
-                            <WithStyles(ForwardRef(Tab))
-                              aria-controls="simple-tabpanel-dataset"
-                              fullWidth={false}
-                              id="simple-tab-dataset"
-                              indicator={false}
-                              key=".1"
-                              label={
-                                <WithStyles(WithStyles(ForwardRef(Badge)))
-                                  badgeContent={10}
-                                  id="dataset-badge"
-                                  showZero={true}
-                                >
-                                  <span
-                                    style={
-                                      Object {
-                                        "marginLeft": "calc(-0.5 * 2ch - 6px)",
-                                        "marginRight": "calc(0.5 * 2ch + 6px)",
-                                        "paddingRight": "1ch",
-                                      }
-                                    }
-                                  >
-                                    tabs.dataset
-                                  </span>
-                                </WithStyles(WithStyles(ForwardRef(Badge)))>
-                              }
-                              onChange={[Function]}
-                              selected={false}
-                              textColor="inherit"
-                              value="dataset"
-                            >
-                              <ForwardRef(Tab)
-                                aria-controls="simple-tabpanel-dataset"
-                                classes={
-                                  Object {
-                                    "disabled": "Mui-disabled",
-                                    "fullWidth": "MuiTab-fullWidth",
-                                    "labelIcon": "MuiTab-labelIcon",
-                                    "root": "MuiTab-root",
-                                    "selected": "Mui-selected",
-                                    "textColorInherit": "MuiTab-textColorInherit",
-                                    "textColorPrimary": "MuiTab-textColorPrimary",
-                                    "textColorSecondary": "MuiTab-textColorSecondary",
-                                    "wrapped": "MuiTab-wrapped",
-                                    "wrapper": "MuiTab-wrapper",
-                                  }
-                                }
-                                fullWidth={false}
-                                id="simple-tab-dataset"
-                                indicator={false}
-                                label={
-                                  <WithStyles(WithStyles(ForwardRef(Badge)))
-                                    badgeContent={10}
-                                    id="dataset-badge"
-                                    showZero={true}
-                                  >
-                                    <span
-                                      style={
-                                        Object {
-                                          "marginLeft": "calc(-0.5 * 2ch - 6px)",
-                                          "marginRight": "calc(0.5 * 2ch + 6px)",
-                                          "paddingRight": "1ch",
-                                        }
-                                      }
-                                    >
-                                      tabs.dataset
-                                    </span>
-                                  </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                }
-                                onChange={[Function]}
-                                selected={false}
-                                textColor="inherit"
-                                value="dataset"
-                              >
-                                <WithStyles(ForwardRef(ButtonBase))
-                                  aria-controls="simple-tabpanel-dataset"
-                                  aria-selected={false}
-                                  className="MuiTab-root MuiTab-textColorInherit"
-                                  disabled={false}
-                                  focusRipple={true}
-                                  id="simple-tab-dataset"
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  role="tab"
-                                  tabIndex={-1}
-                                >
-                                  <ForwardRef(ButtonBase)
-                                    aria-controls="simple-tabpanel-dataset"
-                                    aria-selected={false}
-                                    className="MuiTab-root MuiTab-textColorInherit"
-                                    classes={
-                                      Object {
-                                        "disabled": "Mui-disabled",
-                                        "focusVisible": "Mui-focusVisible",
-                                        "root": "MuiButtonBase-root",
-                                      }
-                                    }
-                                    disabled={false}
-                                    focusRipple={true}
-                                    id="simple-tab-dataset"
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    role="tab"
-                                    tabIndex={-1}
-                                  >
-                                    <button
-                                      aria-controls="simple-tabpanel-dataset"
-                                      aria-selected={false}
-                                      className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
-                                      disabled={false}
-                                      id="simple-tab-dataset"
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onDragLeave={[Function]}
-                                      onFocus={[Function]}
-                                      onKeyDown={[Function]}
-                                      onKeyUp={[Function]}
-                                      onMouseDown={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onMouseUp={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
-                                      role="tab"
-                                      tabIndex={-1}
-                                      type="button"
-                                    >
-                                      <span
-                                        className="MuiTab-wrapper"
-                                      >
-                                        <WithStyles(WithStyles(ForwardRef(Badge)))
-                                          badgeContent={10}
-                                          id="dataset-badge"
-                                          showZero={true}
-                                        >
-                                          <WithStyles(ForwardRef(Badge))
-                                            badgeContent={10}
-                                            classes={
-                                              Object {
-                                                "badge": "WithStyles(ForwardRef(Badge))-badge-2",
-                                              }
-                                            }
-                                            id="dataset-badge"
-                                            showZero={true}
-                                          >
-                                            <ForwardRef(Badge)
-                                              badgeContent={10}
-                                              classes={
-                                                Object {
-                                                  "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                  "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                  "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                  "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                  "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                  "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                  "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                  "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                  "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
-                                                  "colorError": "MuiBadge-colorError",
-                                                  "colorPrimary": "MuiBadge-colorPrimary",
-                                                  "colorSecondary": "MuiBadge-colorSecondary",
-                                                  "dot": "MuiBadge-dot",
-                                                  "invisible": "MuiBadge-invisible",
-                                                  "root": "MuiBadge-root",
-                                                }
-                                              }
-                                              id="dataset-badge"
-                                              showZero={true}
-                                            >
-                                              <span
-                                                className="MuiBadge-root"
-                                                id="dataset-badge"
-                                              >
-                                                <span
-                                                  style={
-                                                    Object {
-                                                      "marginLeft": "calc(-0.5 * 2ch - 6px)",
-                                                      "marginRight": "calc(0.5 * 2ch + 6px)",
-                                                      "paddingRight": "1ch",
-                                                    }
-                                                  }
-                                                >
-                                                  tabs.dataset
-                                                </span>
-                                                <span
-                                                  className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
-                                                >
-                                                  10
-                                                </span>
-                                              </span>
-                                            </ForwardRef(Badge)>
-                                          </WithStyles(ForwardRef(Badge))>
-                                        </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                      </span>
-                                      <WithStyles(memo)
-                                        center={false}
-                                      >
-                                        <ForwardRef(TouchRipple)
-                                          center={false}
-                                          classes={
-                                            Object {
-                                              "child": "MuiTouchRipple-child",
-                                              "childLeaving": "MuiTouchRipple-childLeaving",
-                                              "childPulsate": "MuiTouchRipple-childPulsate",
-                                              "ripple": "MuiTouchRipple-ripple",
-                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                              "root": "MuiTouchRipple-root",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="MuiTouchRipple-root"
-                                          >
-                                            <TransitionGroup
-                                              childFactory={[Function]}
-                                              component={null}
-                                              exit={true}
-                                            />
-                                          </span>
-                                        </ForwardRef(TouchRipple)>
-                                      </WithStyles(memo)>
-                                    </button>
-                                  </ForwardRef(ButtonBase)>
-                                </WithStyles(ForwardRef(ButtonBase))>
-                              </ForwardRef(Tab)>
-                            </WithStyles(ForwardRef(Tab))>
-                            <WithStyles(ForwardRef(Tab))
-                              aria-controls="simple-tabpanel-datafile"
-                              fullWidth={false}
-                              id="simple-tab-datafile"
-                              indicator={false}
-                              key=".2"
-                              label={
-                                <WithStyles(WithStyles(ForwardRef(Badge)))
-                                  badgeContent={100}
-                                  id="datafile-badge"
-                                  showZero={true}
-                                >
-                                  <span
-                                    style={
-                                      Object {
-                                        "marginLeft": "calc(-0.5 * 3ch - 6px)",
-                                        "marginRight": "calc(0.5 * 3ch + 6px)",
-                                        "paddingRight": "1ch",
-                                      }
-                                    }
-                                  >
-                                    tabs.datafile
-                                  </span>
-                                </WithStyles(WithStyles(ForwardRef(Badge)))>
-                              }
-                              onChange={[Function]}
-                              selected={false}
-                              textColor="inherit"
-                              value="datafile"
-                            >
-                              <ForwardRef(Tab)
-                                aria-controls="simple-tabpanel-datafile"
-                                classes={
-                                  Object {
-                                    "disabled": "Mui-disabled",
-                                    "fullWidth": "MuiTab-fullWidth",
-                                    "labelIcon": "MuiTab-labelIcon",
-                                    "root": "MuiTab-root",
-                                    "selected": "Mui-selected",
-                                    "textColorInherit": "MuiTab-textColorInherit",
-                                    "textColorPrimary": "MuiTab-textColorPrimary",
-                                    "textColorSecondary": "MuiTab-textColorSecondary",
-                                    "wrapped": "MuiTab-wrapped",
-                                    "wrapper": "MuiTab-wrapper",
-                                  }
-                                }
-                                fullWidth={false}
-                                id="simple-tab-datafile"
-                                indicator={false}
-                                label={
-                                  <WithStyles(WithStyles(ForwardRef(Badge)))
-                                    badgeContent={100}
-                                    id="datafile-badge"
-                                    showZero={true}
-                                  >
-                                    <span
-                                      style={
-                                        Object {
-                                          "marginLeft": "calc(-0.5 * 3ch - 6px)",
-                                          "marginRight": "calc(0.5 * 3ch + 6px)",
-                                          "paddingRight": "1ch",
-                                        }
-                                      }
-                                    >
-                                      tabs.datafile
-                                    </span>
-                                  </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                }
-                                onChange={[Function]}
-                                selected={false}
-                                textColor="inherit"
-                                value="datafile"
-                              >
-                                <WithStyles(ForwardRef(ButtonBase))
-                                  aria-controls="simple-tabpanel-datafile"
-                                  aria-selected={false}
-                                  className="MuiTab-root MuiTab-textColorInherit"
-                                  disabled={false}
-                                  focusRipple={true}
-                                  id="simple-tab-datafile"
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  role="tab"
-                                  tabIndex={-1}
-                                >
-                                  <ForwardRef(ButtonBase)
-                                    aria-controls="simple-tabpanel-datafile"
-                                    aria-selected={false}
-                                    className="MuiTab-root MuiTab-textColorInherit"
-                                    classes={
-                                      Object {
-                                        "disabled": "Mui-disabled",
-                                        "focusVisible": "Mui-focusVisible",
-                                        "root": "MuiButtonBase-root",
-                                      }
-                                    }
-                                    disabled={false}
-                                    focusRipple={true}
-                                    id="simple-tab-datafile"
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    role="tab"
-                                    tabIndex={-1}
-                                  >
-                                    <button
-                                      aria-controls="simple-tabpanel-datafile"
-                                      aria-selected={false}
-                                      className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
-                                      disabled={false}
-                                      id="simple-tab-datafile"
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onDragLeave={[Function]}
-                                      onFocus={[Function]}
-                                      onKeyDown={[Function]}
-                                      onKeyUp={[Function]}
-                                      onMouseDown={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onMouseUp={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
-                                      role="tab"
-                                      tabIndex={-1}
-                                      type="button"
-                                    >
-                                      <span
-                                        className="MuiTab-wrapper"
-                                      >
-                                        <WithStyles(WithStyles(ForwardRef(Badge)))
-                                          badgeContent={100}
-                                          id="datafile-badge"
-                                          showZero={true}
-                                        >
-                                          <WithStyles(ForwardRef(Badge))
-                                            badgeContent={100}
-                                            classes={
-                                              Object {
-                                                "badge": "WithStyles(ForwardRef(Badge))-badge-2",
-                                              }
-                                            }
-                                            id="datafile-badge"
-                                            showZero={true}
-                                          >
-                                            <ForwardRef(Badge)
-                                              badgeContent={100}
-                                              classes={
-                                                Object {
-                                                  "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                  "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                  "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                  "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                  "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                  "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                  "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                  "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                  "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
-                                                  "colorError": "MuiBadge-colorError",
-                                                  "colorPrimary": "MuiBadge-colorPrimary",
-                                                  "colorSecondary": "MuiBadge-colorSecondary",
-                                                  "dot": "MuiBadge-dot",
-                                                  "invisible": "MuiBadge-invisible",
-                                                  "root": "MuiBadge-root",
-                                                }
-                                              }
-                                              id="datafile-badge"
-                                              showZero={true}
-                                            >
-                                              <span
-                                                className="MuiBadge-root"
-                                                id="datafile-badge"
-                                              >
-                                                <span
-                                                  style={
-                                                    Object {
-                                                      "marginLeft": "calc(-0.5 * 3ch - 6px)",
-                                                      "marginRight": "calc(0.5 * 3ch + 6px)",
-                                                      "paddingRight": "1ch",
-                                                    }
-                                                  }
-                                                >
-                                                  tabs.datafile
-                                                </span>
-                                                <span
-                                                  className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
-                                                >
-                                                  99+
-                                                </span>
-                                              </span>
-                                            </ForwardRef(Badge)>
-                                          </WithStyles(ForwardRef(Badge))>
-                                        </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                      </span>
-                                      <WithStyles(memo)
-                                        center={false}
-                                      >
-                                        <ForwardRef(TouchRipple)
-                                          center={false}
-                                          classes={
-                                            Object {
-                                              "child": "MuiTouchRipple-child",
-                                              "childLeaving": "MuiTouchRipple-childLeaving",
-                                              "childPulsate": "MuiTouchRipple-childPulsate",
-                                              "ripple": "MuiTouchRipple-ripple",
-                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                              "root": "MuiTouchRipple-root",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="MuiTouchRipple-root"
-                                          >
-                                            <TransitionGroup
-                                              childFactory={[Function]}
-                                              component={null}
-                                              exit={true}
-                                            />
-                                          </span>
-                                        </ForwardRef(TouchRipple)>
-                                      </WithStyles(memo)>
-                                    </button>
-                                  </ForwardRef(ButtonBase)>
-                                </WithStyles(ForwardRef(ButtonBase))>
-                              </ForwardRef(Tab)>
-                            </WithStyles(ForwardRef(Tab))>
-                          </div>
-                          <WithStyles(ForwardRef(TabIndicator))
-                            className="MuiTabs-indicator"
-                            color="secondary"
-                            orientation="horizontal"
-                            style={
-                              Object {
-                                "left": 0,
-                                "width": 0,
-                              }
-                            }
-                          >
-                            <ForwardRef(TabIndicator)
-                              className="MuiTabs-indicator"
-                              classes={
-                                Object {
-                                  "colorPrimary": "PrivateTabIndicator-colorPrimary-7",
-                                  "colorSecondary": "PrivateTabIndicator-colorSecondary-8",
-                                  "root": "PrivateTabIndicator-root-6",
-                                  "vertical": "PrivateTabIndicator-vertical-9",
-                                }
-                              }
-                              color="secondary"
-                              orientation="horizontal"
-                              style={
-                                Object {
-                                  "left": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <span
-                                className="PrivateTabIndicator-root-6 PrivateTabIndicator-colorSecondary-8 MuiTabs-indicator"
-                                style={
-                                  Object {
-                                    "left": 0,
-                                    "width": 0,
-                                  }
-                                }
-                              />
-                            </ForwardRef(TabIndicator)>
-                          </WithStyles(ForwardRef(TabIndicator))>
-                        </div>
-                      </div>
-                    </ForwardRef(Tabs)>
-                  </WithStyles(ForwardRef(Tabs))>
-                </header>
-              </ForwardRef(Paper)>
-            </WithStyles(ForwardRef(Paper))>
-          </ForwardRef(AppBar)>
-        </WithStyles(ForwardRef(AppBar))>
-        <TabPanel
-          index="investigation"
-          value="none"
-        >
-          <Styled(MuiBox)
-            aria-labelledby="simple-tab-investigation"
-            border={0}
-            component="div"
-            hidden={true}
-            id="simple-tabpanel-investigation"
-            role="tabpanel"
-          >
-            <div
-              aria-labelledby="simple-tab-investigation"
-              className="MuiBox-root MuiBox-root-3"
-              hidden={true}
-              id="simple-tabpanel-investigation"
-              role="tabpanel"
-            />
-          </Styled(MuiBox)>
-        </TabPanel>
-        <TabPanel
-          index="dataset"
-          value="none"
-        >
-          <Styled(MuiBox)
-            aria-labelledby="simple-tab-dataset"
-            border={0}
-            component="div"
-            hidden={true}
-            id="simple-tabpanel-dataset"
-            role="tabpanel"
-          >
-            <div
-              aria-labelledby="simple-tab-dataset"
-              className="MuiBox-root MuiBox-root-4"
-              hidden={true}
-              id="simple-tabpanel-dataset"
-              role="tabpanel"
-            />
-          </Styled(MuiBox)>
-        </TabPanel>
-        <TabPanel
-          index="datafile"
-          value="none"
-        >
-          <Styled(MuiBox)
-            aria-labelledby="simple-tab-datafile"
-            border={0}
-            component="div"
-            hidden={true}
-            id="simple-tabpanel-datafile"
-            role="tabpanel"
-          >
-            <div
-              aria-labelledby="simple-tab-datafile"
-              className="MuiBox-root MuiBox-root-5"
-              hidden={true}
-              id="simple-tabpanel-datafile"
-              role="tabpanel"
-            />
-          </Styled(MuiBox)>
-        </TabPanel>
-      </div>
-    </SearchPageTable>
-  </Connect(SearchPageTable)>
-</Provider>
+      <Connect(InvestigationSearchTable) />
+    </WithStyles(ForwardRef(Paper))>
+  </TabPanel>
+  <TabPanel
+    index="dataset"
+    value="investigation"
+  >
+    <WithStyles(ForwardRef(Paper))
+      elevation={0}
+      style={
+        Object {
+          "height": "calc(undefined - 96px)",
+          "minHeight": 230,
+          "overflowX": "auto",
+        }
+      }
+    >
+      <Connect(DatasetSearchTable) />
+    </WithStyles(ForwardRef(Paper))>
+  </TabPanel>
+  <TabPanel
+    index="datafile"
+    value="investigation"
+  >
+    <WithStyles(ForwardRef(Paper))
+      elevation={0}
+      style={
+        Object {
+          "height": "calc(undefined - 96px)",
+          "minHeight": 230,
+          "overflowX": "auto",
+        }
+      }
+    >
+      <Connect(DatafileSearchTable) />
+    </WithStyles(ForwardRef(Paper))>
+  </TabPanel>
+</div>
 `;
 
 exports[`SearchPageTable renders SearchPageTable correctly before request 1`] = `
@@ -1094,7 +154,7 @@ exports[`SearchPageTable renders SearchPageTable correctly before request 1`] = 
     }
   >
     <SearchPageTable
-      currentTab="none"
+      currentTab="investigation"
       datafile={Array []}
       datafileTab={false}
       dataset={Array []}

--- a/packages/datagateway-search/src/searchPageTable.test.tsx
+++ b/packages/datagateway-search/src/searchPageTable.test.tsx
@@ -5,26 +5,33 @@ import { MemoryRouter } from 'react-router';
 
 import SearchPageTable from './searchPageTable';
 
-import { mount as enzymeMount } from 'enzyme';
-import { createMount } from '@material-ui/core/test-utils';
+import { mount as enzymeMount, shallow as enzymeShallow } from 'enzyme';
+import { createMount, createShallow } from '@material-ui/core/test-utils';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { initialState } from './state/reducers/dgsearch.reducer';
 import { dGCommonInitialState } from 'datagateway-common';
 import { setCurrentTab } from './state/actions/actions';
+import axios from 'axios';
 
 describe('SearchPageTable', () => {
   let mount: typeof enzymeMount;
+  let shallow: typeof enzymeShallow;
   let state: StateType;
 
   beforeEach(() => {
     mount = createMount();
+    shallow = createShallow({ untilSelector: 'Paper' });
 
     state = JSON.parse(
       JSON.stringify({ dgsearch: initialState, dgcommon: dGCommonInitialState })
     );
 
     state.dgsearch.requestReceived = true;
+
+    (axios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: [] })
+    );
   });
 
   it('renders SearchPageTable correctly before request', () => {
@@ -45,7 +52,7 @@ describe('SearchPageTable', () => {
         datasetTab: true,
         datafileTab: true,
         investigationTab: true,
-        currentTab: 'none',
+        currentTab: 'investigation',
       },
       searchData: {
         investigation: Array(1),
@@ -54,7 +61,7 @@ describe('SearchPageTable', () => {
       },
     };
     const mockStore = configureStore([thunk]);
-    const wrapper = mount(
+    const wrapper = shallow(
       <Provider store={mockStore(state)}>
         <SearchPageTable store={mockStore(state)} />
       </Provider>
@@ -69,7 +76,7 @@ describe('SearchPageTable', () => {
         datasetTab: true,
         datafileTab: true,
         investigationTab: true,
-        currentTab: 'none',
+        currentTab: 'investigation',
       },
     };
 
@@ -83,8 +90,9 @@ describe('SearchPageTable', () => {
       </Provider>
     );
 
-    expect(testStore.getActions()).toHaveLength(1);
-    expect(testStore.getActions()[0]).toEqual(setCurrentTab('investigation'));
+    expect(testStore.getActions()).toContainEqual(
+      setCurrentTab('investigation')
+    );
   });
 
   it('defaults to dataset tab when investigation tab is hidden', () => {
@@ -92,14 +100,14 @@ describe('SearchPageTable', () => {
       ...state.dgsearch,
       checkBox: {
         dataset: true,
-        datafile: true,
+        datafile: false,
         investigation: false,
       },
       tabs: {
         datasetTab: true,
-        datafileTab: true,
+        datafileTab: false,
         investigationTab: false,
-        currentTab: 'none',
+        currentTab: 'investigation',
       },
     };
 
@@ -132,7 +140,7 @@ describe('SearchPageTable', () => {
         datasetTab: false,
         datafileTab: true,
         investigationTab: false,
-        currentTab: 'none',
+        currentTab: 'investigation',
       },
     };
 
@@ -160,7 +168,7 @@ describe('SearchPageTable', () => {
         datasetTab: true,
         datafileTab: true,
         investigationTab: true,
-        currentTab: 'none',
+        currentTab: 'investigation',
       },
     };
     const mockStore = configureStore([thunk]);
@@ -173,15 +181,15 @@ describe('SearchPageTable', () => {
       </Provider>
     );
 
-    expect(testStore.getActions()).toHaveLength(1);
-    expect(testStore.getActions()[0]).toEqual(setCurrentTab('investigation'));
+    expect(testStore.getActions()).toContainEqual(
+      setCurrentTab('investigation')
+    );
 
     wrapper
       .find('[aria-controls="simple-tabpanel-dataset"]')
       .first()
       .simulate('click');
 
-    expect(testStore.getActions()).toHaveLength(2);
-    expect(testStore.getActions()[1]).toEqual(setCurrentTab('dataset'));
+    expect(testStore.getActions()).toContainEqual(setCurrentTab('dataset'));
   });
 });

--- a/packages/datagateway-search/src/searchPageTable.tsx
+++ b/packages/datagateway-search/src/searchPageTable.tsx
@@ -103,15 +103,13 @@ const SearchPageTable = (
   const [t] = useTranslation();
 
   useEffect(() => {
-    let newState = 'none';
     if (investigationTab) {
-      newState = 'investigation';
+      setCurrentTab('investigation');
     } else if (datasetTab) {
-      newState = 'dataset';
+      setCurrentTab('dataset');
     } else if (datafileTab) {
-      newState = 'datafile';
+      setCurrentTab('datafile');
     }
-    setCurrentTab(newState);
   }, [setCurrentTab, investigationTab, datasetTab, datafileTab]);
 
   const handleChange = (
@@ -161,7 +159,9 @@ const SearchPageTable = (
                 value="investigation"
                 {...a11yProps('investigation')}
               />
-            ) : null}
+            ) : (
+              <Tab value="investigation" style={{ display: 'none' }} />
+            )}
             {datasetTab ? (
               <Tab
                 label={
@@ -188,7 +188,9 @@ const SearchPageTable = (
                 value="dataset"
                 {...a11yProps('dataset')}
               />
-            ) : null}
+            ) : (
+              <Tab value="dataset" style={{ display: 'none' }} />
+            )}
             {datafileTab ? (
               <Tab
                 label={
@@ -215,7 +217,9 @@ const SearchPageTable = (
                 value="datafile"
                 {...a11yProps('datafile')}
               />
-            ) : null}
+            ) : (
+              <Tab value="datafile" style={{ display: 'none' }} />
+            )}
           </Tabs>
         </AppBar>
 

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
@@ -96,11 +96,11 @@ describe('dgsearch reducer', () => {
   });
 
   it('should set currentTab property when setCurrentTab action is sent', () => {
-    expect(state.tabs.currentTab).toEqual('none');
+    expect(state.tabs.currentTab).toEqual('investigation');
 
-    const updatedState = DGSearchReducer(state, setCurrentTab('investigation'));
+    const updatedState = DGSearchReducer(state, setCurrentTab('dataset'));
 
-    expect(updatedState.tabs.currentTab).toEqual('investigation');
+    expect(updatedState.tabs.currentTab).toEqual('dataset');
   });
 
   it('should set start date property when select start date action is sent', () => {

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
@@ -40,7 +40,7 @@ export const initialState: DGSearchState = {
     datasetTab: false,
     datafileTab: false,
     investigationTab: false,
-    currentTab: 'none',
+    currentTab: 'investigation',
   },
   requestReceived: false,
   searchData: {

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Datafile search table component renders correctly 1`] = `
   data={
     Array [
       Object {
+        "CREATE_TIME": "2019-07-23",
         "DATASET_ID": 1,
         "FILESIZE": 1,
         "ID": 1,

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -45,12 +45,19 @@ describe('Datafile search table component', () => {
         LOCATION: '/test1',
         FILESIZE: 1,
         MOD_TIME: '2019-07-23',
+        CREATE_TIME: '2019-07-23',
         DATASET_ID: 1,
       },
     ];
     state.dgcommon.allIds = [1];
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
+    );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
     );
     global.Date.now = jest.fn(() => 1);
   });
@@ -69,7 +76,7 @@ describe('Datafile search table component', () => {
     mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -121,7 +128,7 @@ describe('Datafile search table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -147,7 +154,7 @@ describe('Datafile search table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -165,7 +172,7 @@ describe('Datafile search table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -190,7 +197,7 @@ describe('Datafile search table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -222,7 +229,7 @@ describe('Datafile search table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -244,7 +251,7 @@ describe('Datafile search table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -255,7 +262,7 @@ describe('Datafile search table component', () => {
   it('renders details panel correctly', () => {
     const wrapper = shallow(
       <MemoryRouter>
-        <DatafileSearchTable store={mockStore(state)} datasetId="1" />
+        <DatafileSearchTable store={mockStore(state)} />
       </MemoryRouter>
     );
     const detailsPanelWrapper = shallow(
@@ -270,7 +277,7 @@ describe('Datafile search table component', () => {
     const wrapper = mount(
       <Provider store={mockStore(state)}>
         <MemoryRouter>
-          <DatafileSearchTable datasetId="1" />
+          <DatafileSearchTable />
         </MemoryRouter>
       </Provider>
     );

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -48,6 +48,12 @@ describe('Dataset table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 
@@ -65,7 +71,7 @@ describe('Dataset table component', () => {
     mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatasetSearchTable investigationId="1" />
+          <DatasetSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -79,9 +85,7 @@ describe('Dataset table component', () => {
 
   it('sends fetchDatasets action when loadMoreRows is called', () => {
     const testStore = mockStore(state);
-    const wrapper = shallow(
-      <DatasetSearchTable investigationId="1" store={testStore} />
-    );
+    const wrapper = shallow(<DatasetSearchTable store={testStore} />);
 
     wrapper.prop('loadMoreRows')({ startIndex: 50, stopIndex: 74 });
 
@@ -119,7 +123,7 @@ describe('Dataset table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatasetSearchTable investigationId="1" />
+          <DatasetSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -145,7 +149,7 @@ describe('Dataset table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatasetSearchTable investigationId="1" />
+          <DatasetSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -163,7 +167,7 @@ describe('Dataset table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatasetSearchTable investigationId="1" />
+          <DatasetSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -188,7 +192,7 @@ describe('Dataset table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatasetSearchTable investigationId="1" />
+          <DatasetSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -220,7 +224,7 @@ describe('Dataset table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <DatasetSearchTable investigationId="1" />
+          <DatasetSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -236,7 +240,7 @@ describe('Dataset table component', () => {
   it('renders details panel correctly', () => {
     const wrapper = shallow(
       <MemoryRouter>
-        <DatasetSearchTable store={mockStore(state)} investigationId="1" />
+        <DatasetSearchTable store={mockStore(state)} />
       </MemoryRouter>
     );
     const detailsPanelWrapper = shallow(
@@ -251,7 +255,7 @@ describe('Dataset table component', () => {
     const wrapper = mount(
       <Provider store={mockStore(state)}>
         <MemoryRouter>
-          <DatasetSearchTable investigationId="1" />
+          <DatasetSearchTable />
         </MemoryRouter>
       </Provider>
     );

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
@@ -290,11 +290,7 @@ describe('Investigation Search Table component', () => {
   it('renders details panel correctly', () => {
     const wrapper = shallow(
       <MemoryRouter>
-        <InvestigationSearchTable
-          store={mockStore(state)}
-          instrumentId="4"
-          facilityCycleId="5"
-        />
+        <InvestigationSearchTable store={mockStore(state)} />
       </MemoryRouter>
     );
     const detailsPanelWrapper = shallow(

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
@@ -94,6 +94,12 @@ describe('Investigation Search Table component', () => {
     (axios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
+    (axios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
+    (axios.delete as jest.Mock).mockImplementation(() =>
+      Promise.resolve({ data: {} })
+    );
     global.Date.now = jest.fn(() => 1);
   });
 
@@ -103,11 +109,7 @@ describe('Investigation Search Table component', () => {
 
   it('renders correctly', () => {
     const wrapper = shallow(
-      <InvestigationSearchTable
-        store={mockStore(state)}
-        instrumentId="4"
-        facilityCycleId="5"
-      />
+      <InvestigationSearchTable store={mockStore(state)} />
     );
     expect(wrapper).toMatchSnapshot();
   });
@@ -117,7 +119,7 @@ describe('Investigation Search Table component', () => {
     mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <InvestigationSearchTable instrumentId="4" facilityCycleId="5" />
+          <InvestigationSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -133,13 +135,7 @@ describe('Investigation Search Table component', () => {
 
   it('sends fetchInvestigations action when loadMoreRows is called', () => {
     const testStore = mockStore(state);
-    const wrapper = shallow(
-      <InvestigationSearchTable
-        instrumentId="4"
-        facilityCycleId="5"
-        store={testStore}
-      />
-    );
+    const wrapper = shallow(<InvestigationSearchTable store={testStore} />);
 
     wrapper.prop('loadMoreRows')({ startIndex: 50, stopIndex: 74 });
 
@@ -177,7 +173,7 @@ describe('Investigation Search Table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <InvestigationSearchTable instrumentId="4" facilityCycleId="5" />
+          <InvestigationSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -203,7 +199,7 @@ describe('Investigation Search Table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <InvestigationSearchTable instrumentId="4" facilityCycleId="5" />
+          <InvestigationSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -221,7 +217,7 @@ describe('Investigation Search Table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <InvestigationSearchTable instrumentId="4" facilityCycleId="5" />
+          <InvestigationSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -246,7 +242,7 @@ describe('Investigation Search Table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <InvestigationSearchTable instrumentId="4" facilityCycleId="5" />
+          <InvestigationSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -278,7 +274,7 @@ describe('Investigation Search Table component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MemoryRouter>
-          <InvestigationSearchTable instrumentId="4" facilityCycleId="5" />
+          <InvestigationSearchTable />
         </MemoryRouter>
       </Provider>
     );
@@ -313,7 +309,7 @@ describe('Investigation Search Table component', () => {
     const wrapper = mount(
       <Provider store={mockStore(state)}>
         <MemoryRouter>
-          <InvestigationSearchTable instrumentId="4" facilityCycleId="5" />
+          <InvestigationSearchTable />
         </MemoryRouter>
       </Provider>
     );


### PR DESCRIPTION
## Description

- Add `__mocks__/react-i18next.jsx` to common so we can mock translations for refactored cardview components
- Explicitly mock `console.error` in one of the cardView tests. The error is for using a dynamic variable to set whether an Accordion (aka ExpansionPanel) is expanded by default. I've had a look at how these panels are controlled, and I don't think we want to change our functionality here, so just surpressed the warning in the tests.
- Add `item` to `Grid` in cardView (no functional change expected)
- Treat id checks as asynchronous in `pageContainer` tests like we do in `pageRouting`
- In lots of tests, move mocked `axios.get` into `beforeEach` and/or add in mocking for `axios.post` and `axios.delete` (corresponding to adding and removing to/from cart) to prevent unhandled request logging
- Reduce size of `searchPageTable` snapshot by using `shallow` instead of `mount`
- Change how we treat disabled tabs in search, instead of removing them and using `none` as a placeholding (which leads to errors about having a value that doesn't correspond to a tab) use a `Tab` set to `display: 'none'`. This should achieve the same functionality as before but without the warnings.
 
## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Check no logging in successful unit tests
- [ ] Check functionality of tabs in search is unaffected: unchecking an entity and researching should remove that tab from the UI and the default table dispalyed should be the first of the three entities that's checked.

## Agile board tracking
closes #601 