### PR TITLE
Replacing old 'icat:token' with new 'scigateway:token' #649

### DIFF
--- a/packages/datagateway-download/src/downloadApi.test.ts
+++ b/packages/datagateway-download/src/downloadApi.test.ts
@@ -14,6 +14,7 @@ import {
   removeAllDownloadCartItems,
   removeDownloadCartItem,
   submitCart,
+  getDataUrl,
 } from './downloadApi';
 
 const settings = {
@@ -988,6 +989,19 @@ describe('Download Status API functions test', () => {
       expect(handleICATError).toHaveBeenCalled();
       expect(handleICATError).toHaveBeenCalledWith({
         message: 'Test error message',
+      });
+    });
+  });
+
+  describe('getDataUrl', () => {
+    it('successfully constructs a download link with given parameters', () => {
+      const preparedId = 'test-prepared-id';
+      const fileName = 'test-filename';
+      const idsUrl = 'test-ids-url';
+
+      const result = getDataUrl(preparedId, fileName, idsUrl);
+      [preparedId, fileName, idsUrl].forEach((entry) => {
+        expect(result).toContain(entry);
       });
     });
   });

--- a/packages/datagateway-download/src/downloadApi.ts
+++ b/packages/datagateway-download/src/downloadApi.ts
@@ -211,19 +211,9 @@ export const downloadPreparedCart: (
   fileName: string,
   settings: { idsUrl: string }
 ) => {
-  // We need to set the preparedId and outname query parameters
-  // for the IDS download.
-  const params = {
-    sessionId: readSciGatewayToken().sessionId,
-    preparedId: preparedId,
-    outname: fileName,
-  };
-
   // Create our IDS link from the query parameters.
   const link = document.createElement('a');
-  link.href = `${settings.idsUrl}/getData?${Object.entries(params)
-    .map(([key, value]) => `${key}=${value}`)
-    .join('&')}`;
+  link.href = getDataUrl(preparedId, fileName, settings.idsUrl);
 
   // We trigger an immediate download which will begin in a new tab.
   link.style.display = 'none';
@@ -470,4 +460,15 @@ export const getCartSize: (
       0
     )
   );
+};
+
+export const getDataUrl = (
+  preparedId: string,
+  fileName: string,
+  idsUrl: string
+): string => {
+  // Construct a link to download the prepared cart.
+  return `${idsUrl}/getData?sessionId=${
+    readSciGatewayToken().sessionId
+  }&preparedId=${preparedId}&outname=${fileName}`;
 };

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -3,7 +3,7 @@ import DownloadStatusTable from './downloadStatusTable.component';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import { flushPromises } from '../setupTests';
 import { act } from 'react-dom/test-utils';
-import { fetchDownloads, downloadDeleted } from '../downloadApi';
+import { fetchDownloads, downloadDeleted, getDataUrl } from '../downloadApi';
 import { Download } from 'datagateway-common';
 
 jest.mock('../downloadApi');
@@ -132,12 +132,14 @@ describe('Download Status Table', () => {
     (fetchDownloads as jest.Mock).mockImplementation(() =>
       Promise.resolve(downloadItems)
     );
+    (getDataUrl as jest.Mock).mockImplementation(() => '/getData');
   });
 
   afterEach(() => {
     mount.cleanUp();
     (fetchDownloads as jest.Mock).mockClear();
     (downloadDeleted as jest.Mock).mockClear();
+    (getDataUrl as jest.Mock).mockClear();
     jest.useRealTimers();
   });
 

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -224,7 +224,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
   const getDataUrl = (preparedId: string, fileName: string): string => {
     // Construct a link to download the prepared cart.
     return `${settings.idsUrl}/getData?sessionId=${window.localStorage.getItem(
-      'icat:token'
+      'scigateway:token'
     )}&preparedId=${preparedId}&outname=${fileName}`;
   };
 

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -9,7 +9,7 @@ import {
   TableActionProps,
   DateColumnFilter,
 } from 'datagateway-common';
-import { fetchDownloads, downloadDeleted } from '../downloadApi';
+import { fetchDownloads, downloadDeleted, getDataUrl } from '../downloadApi';
 import { TableCellProps } from 'react-virtualized';
 import { RemoveCircle, GetApp } from '@material-ui/icons';
 import BlackTooltip from '../tooltip.component';
@@ -221,13 +221,6 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
     return filteredData.sort(sortDownloadItems);
   }, [data, sort, filters]);
 
-  const getDataUrl = (preparedId: string, fileName: string): string => {
-    // Construct a link to download the prepared cart.
-    return `${settings.idsUrl}/getData?sessionId=${window.localStorage.getItem(
-      'scigateway:token'
-    )}&preparedId=${preparedId}&outname=${fileName}`;
-  };
-
   return (
     <Grid container direction="column">
       {/* Show loading progress if data is still being loaded */}
@@ -318,7 +311,8 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                           component="a"
                           href={getDataUrl(
                             downloadItem.preparedId as string,
-                            downloadItem.fileName as string
+                            downloadItem.fileName as string,
+                            settings.idsUrl as string
                           )}
                           target="_blank"
                           aria-label={t('downloadStatus.download', {


### PR DESCRIPTION
## Description
An old 'icat:token' was still being referenced as the localStorage key for the user login token. This is being replaced.
Also refactoring code to construct download links into the downloadApi file as it makes sense to keep it here while reducing duplication.

## Testing instructions
- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
closes #649
