### PR TITLE
Fix query param updates causing freezing

### DIFF
--- a/packages/datagateway-dataview/package.json
+++ b/packages/datagateway-dataview/package.json
@@ -15,6 +15,7 @@
     "connected-react-router": "^6.9.1",
     "custom-event-polyfill": "^1.0.7",
     "datagateway-common": "0.1.0",
+    "history": "^4.10.1",
     "i18next": "^19.9.0",
     "i18next-browser-languagedetector": "^6.0.0",
     "i18next-http-backend": "^1.1.1",
@@ -35,8 +36,8 @@
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.3.0",
     "single-spa-react": "^4.1.0",
-    "typescript": "4.2.2",
     "tslib": "^2.1.0",
+    "typescript": "4.2.2",
     "url-search-params-polyfill": "^8.1.0"
   },
   "scripts": {

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -35,8 +35,6 @@ import { ThunkDispatch } from 'redux-thunk';
 import { StateType } from '../state/app.types';
 import PageBreadcrumbs from './breadcrumbs.component';
 import PageRouting from './pageRouting.component';
-// history package is part of react-router, which we depend on
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Location as LocationType } from 'history';
 
 const usePaperStyles = makeStyles(

--- a/packages/datagateway-dataview/src/page/pageRouting.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageRouting.component.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// history package is part of react-router, which we depend on
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Location as LocationType } from 'history';
 import { Switch, Route, RouteComponentProps } from 'react-router';
 import { Link } from 'react-router-dom';

--- a/packages/datagateway-dataview/src/state/reducers/app.reducer.tsx
+++ b/packages/datagateway-dataview/src/state/reducers/app.reducer.tsx
@@ -2,8 +2,6 @@ import { combineReducers, Reducer } from 'redux';
 import dGDataViewReducer from './dgdataview.reducer';
 import { dGCommonReducer } from 'datagateway-common';
 import { connectRouter } from 'connected-react-router';
-// history package is part of react-router, which we depend on
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { History } from 'history';
 
 const AppReducer = (history: History): Reducer =>


### PR DESCRIPTION
## Description
Fixes bug which caused freezing when card views were navigated between via the SciGateway nav drawer. This required a lot of investigation to what was going on and I presumed it was our code causing the problem. But I got stuck and started searching the related libraries (react-redux, react-router, connected-react-router etc.) for issues and as you can see I found the issue linked in a comment in the code. The reason the bug only occurs in deployment is because that's the only time the components completely unmount (when navigating via the navbar, SciGateway unmounts the plugins), and that was the condition for the bug.

There's no unit tests since this is effectively hotfixing an issue with an underlying library, and I don't think writing any tests for this is worth much time. Similarly, due to the bug only occurring when mounted in SciGateway, no e2e tests have been written

## Testing instructions
I deployed the new version on scigateway-preprod and you can look at that to see the bug no longer occurs. I can also redeploy master for comparison.

- [x] Review code
- [x] Check Actions build
- [ ] Review changes to test coverage
