### PR TITLE
#669 - fix cart actions to use facilityName setting

### DIFF
--- a/packages/datagateway-common/src/state/actions/cart.test.tsx
+++ b/packages/datagateway-common/src/state/actions/cart.test.tsx
@@ -67,12 +67,22 @@ describe('Cart actions', () => {
       );
 
       const asyncAction = fetchDownloadCart();
+      const getState = (): Partial<StateType> => ({
+        dgcommon: {
+          ...initialState,
+          facilityName: 'TEST',
+          urls: {
+            ...initialState.urls,
+            downloadApiUrl: 'http://example.com',
+          },
+        },
+      });
       await asyncAction(dispatch, getState, null);
 
       expect(actions[0]).toEqual(fetchDownloadCartRequest());
       expect(actions[1]).toEqual(fetchDownloadCartSuccess(mockData));
       expect(axios.get).toHaveBeenCalledWith(
-        '/user/cart/LILS',
+        'http://example.com/user/cart/TEST',
         expect.objectContaining({
           params: {
             sessionId: null,
@@ -112,6 +122,16 @@ describe('Cart actions', () => {
       );
 
       const asyncAction = addToCart('dataset', [1, 2]);
+      const getState = (): Partial<StateType> => ({
+        dgcommon: {
+          ...initialState,
+          facilityName: 'TEST',
+          urls: {
+            ...initialState.urls,
+            downloadApiUrl: 'http://example.com',
+          },
+        },
+      });
       await asyncAction(dispatch, getState, null);
 
       const params = new URLSearchParams();
@@ -121,7 +141,7 @@ describe('Cart actions', () => {
       expect(actions[0]).toEqual(addToCartRequest());
       expect(actions[1]).toEqual(addToCartSuccess(mockData));
       expect(axios.post).toHaveBeenCalledWith(
-        '/user/cart/LILS/cartItems',
+        'http://example.com/user/cart/TEST/cartItems',
         params
       );
     });
@@ -155,12 +175,22 @@ describe('Cart actions', () => {
       );
 
       const asyncAction = removeFromCart('dataset', [1, 2]);
+      const getState = (): Partial<StateType> => ({
+        dgcommon: {
+          ...initialState,
+          facilityName: 'TEST',
+          urls: {
+            ...initialState.urls,
+            downloadApiUrl: 'http://example.com',
+          },
+        },
+      });
       await asyncAction(dispatch, getState, null);
 
       expect(actions[0]).toEqual(removeFromCartRequest());
       expect(actions[1]).toEqual(removeFromCartSuccess(mockData));
       expect(axios.delete).toHaveBeenCalledWith(
-        '/user/cart/LILS/cartItems',
+        'http://example.com/user/cart/TEST/cartItems',
         expect.objectContaining({
           params: {
             sessionId: null,

--- a/packages/datagateway-common/src/state/actions/cart.tsx
+++ b/packages/datagateway-common/src/state/actions/cart.tsx
@@ -46,16 +46,15 @@ export const fetchDownloadCartRequest = (): Action => ({
   type: FetchDownloadCartRequestType,
 });
 
-// TODO: Pass in facilityName as a parameter?
 export const fetchDownloadCart = (): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
     dispatch(fetchDownloadCartRequest());
 
+    const { facilityName } = getState().dgcommon;
     const { downloadApiUrl } = getState().dgcommon.urls;
 
-    // TODO: get facility name from somewhere else...
     await axios
-      .get(`${downloadApiUrl}/user/cart/LILS`, {
+      .get(`${downloadApiUrl}/user/cart/${facilityName}`, {
         params: {
           sessionId: readSciGatewayToken().sessionId,
         },
@@ -92,7 +91,6 @@ export const addToCartRequest = (): Action => ({
   type: AddToCartRequestType,
 });
 
-// TODO: Pass in facilityName as a parameter?
 export const addToCart = (
   entityType: 'investigation' | 'dataset' | 'datafile',
   entityIds: number[]
@@ -100,6 +98,7 @@ export const addToCart = (
   return async (dispatch, getState) => {
     dispatch(addToCartRequest());
 
+    const { facilityName } = getState().dgcommon;
     const { downloadApiUrl } = getState().dgcommon.urls;
 
     const params = new URLSearchParams();
@@ -109,9 +108,8 @@ export const addToCart = (
       `${entityType} ${entityIds.join(`, ${entityType} `)}`
     );
 
-    // TODO: get facility name from somewhere else...
     await axios
-      .post(`${downloadApiUrl}/user/cart/LILS/cartItems`, params)
+      .post(`${downloadApiUrl}/user/cart/${facilityName}/cartItems`, params)
       .then((response) => {
         dispatch(addToCartSuccess(response.data));
       })
@@ -144,7 +142,6 @@ export const removeFromCartRequest = (): Action => ({
   type: RemoveFromCartRequestType,
 });
 
-// TODO: Pass in facilityName as a parameter?
 export const removeFromCart = (
   entityType: 'investigation' | 'dataset' | 'datafile',
   entityIds: number[]
@@ -152,11 +149,11 @@ export const removeFromCart = (
   return async (dispatch, getState) => {
     dispatch(removeFromCartRequest());
 
+    const { facilityName } = getState().dgcommon;
     const { downloadApiUrl } = getState().dgcommon.urls;
 
-    // TODO: get facility name from somewhere else...
     await axios
-      .delete(`${downloadApiUrl}/user/cart/LILS/cartItems`, {
+      .delete(`${downloadApiUrl}/user/cart/${facilityName}/cartItems`, {
         params: {
           sessionId: readSciGatewayToken().sessionId,
           items: `${entityType} ${entityIds.join(`, ${entityType} `)}`,

--- a/packages/datagateway-search/server/e2e-settings.json
+++ b/packages/datagateway-search/server/e2e-settings.json
@@ -1,5 +1,5 @@
 {
-  "facilityName": "Generic",
+  "facilityName": "LILS",
   "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
   "apiUrl": "http://scigateway-preprod.esc.rl.ac.uk:5000",
   "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",


### PR DESCRIPTION
## Description
Fix the TODOs and actually use the `facilityName` setting that was added to modify the cart requests to go to the correct facility.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Fixes #669 