### PR TITLE
#485 - support HTML in access method description

### DIFF
--- a/packages/datagateway-download/src/downloadConfirmation/__snapshots__/downloadConfirmDialog.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadConfirmation/__snapshots__/downloadConfirmDialog.component.test.tsx.snap
@@ -572,7 +572,11 @@ exports[`DownloadConfirmDialog does not load the download speed/time table when 
                                     class="MuiTypography-root MuiTypography-body1"
                                     id="confirm-access-method-https-description"
                                   >
-                                    Example description for HTTPS access method.
+                                    Example description for 
+                                    <b>
+                                      HTTPS
+                                    </b>
+                                     access method.
                                   </p>
                                 </span>
                               </div>
@@ -2771,7 +2775,11 @@ exports[`DownloadConfirmDialog does not load the download speed/time table when 
                                                                                                           class="MuiTypography-root MuiTypography-body1"
                                                                                                           id="confirm-access-method-https-description"
                                                                                                         >
-                                                                                                          Example description for HTTPS access method.
+                                                                                                          Example description for 
+                                                                                                          <b>
+                                                                                                            HTTPS
+                                                                                                          </b>
+                                                                                                           access method.
                                                                                                         </p>
                                                                                                       </span>
                                                                                                     </div>
@@ -3077,6 +3085,11 @@ exports[`DownloadConfirmDialog does not load the download speed/time table when 
                                                         </ForwardRef(Typography)>
                                                       </WithStyles(ForwardRef(Typography))>
                                                       <WithStyles(ForwardRef(Typography))
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "Example description for <b>HTTPS</b> access method.",
+                                                          }
+                                                        }
                                                         id="confirm-access-method-https-description"
                                                       >
                                                         <ForwardRef(Typography)
@@ -3114,14 +3127,22 @@ exports[`DownloadConfirmDialog does not load the download speed/time table when 
                                                               "subtitle2": "MuiTypography-subtitle2",
                                                             }
                                                           }
+                                                          dangerouslySetInnerHTML={
+                                                            Object {
+                                                              "__html": "Example description for <b>HTTPS</b> access method.",
+                                                            }
+                                                          }
                                                           id="confirm-access-method-https-description"
                                                         >
                                                           <p
                                                             className="MuiTypography-root MuiTypography-body1"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "Example description for <b>HTTPS</b> access method.",
+                                                              }
+                                                            }
                                                             id="confirm-access-method-https-description"
-                                                          >
-                                                            Example description for HTTPS access method.
-                                                          </p>
+                                                          />
                                                         </ForwardRef(Typography)>
                                                       </WithStyles(ForwardRef(Typography))>
                                                     </span>
@@ -4472,7 +4493,11 @@ exports[`DownloadConfirmDialog renders correctly 1`] = `
                                     class="MuiTypography-root MuiTypography-body1"
                                     id="confirm-access-method-https-description"
                                   >
-                                    Example description for HTTPS access method.
+                                    Example description for 
+                                    <b>
+                                      HTTPS
+                                    </b>
+                                     access method.
                                   </p>
                                 </span>
                               </div>
@@ -6722,7 +6747,11 @@ exports[`DownloadConfirmDialog renders correctly 1`] = `
                                                                                                           class="MuiTypography-root MuiTypography-body1"
                                                                                                           id="confirm-access-method-https-description"
                                                                                                         >
-                                                                                                          Example description for HTTPS access method.
+                                                                                                          Example description for 
+                                                                                                          <b>
+                                                                                                            HTTPS
+                                                                                                          </b>
+                                                                                                           access method.
                                                                                                         </p>
                                                                                                       </span>
                                                                                                     </div>
@@ -7079,6 +7108,11 @@ exports[`DownloadConfirmDialog renders correctly 1`] = `
                                                         </ForwardRef(Typography)>
                                                       </WithStyles(ForwardRef(Typography))>
                                                       <WithStyles(ForwardRef(Typography))
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "Example description for <b>HTTPS</b> access method.",
+                                                          }
+                                                        }
                                                         id="confirm-access-method-https-description"
                                                       >
                                                         <ForwardRef(Typography)
@@ -7116,14 +7150,22 @@ exports[`DownloadConfirmDialog renders correctly 1`] = `
                                                               "subtitle2": "MuiTypography-subtitle2",
                                                             }
                                                           }
+                                                          dangerouslySetInnerHTML={
+                                                            Object {
+                                                              "__html": "Example description for <b>HTTPS</b> access method.",
+                                                            }
+                                                          }
                                                           id="confirm-access-method-https-description"
                                                         >
                                                           <p
                                                             className="MuiTypography-root MuiTypography-body1"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "Example description for <b>HTTPS</b> access method.",
+                                                              }
+                                                            }
                                                             id="confirm-access-method-https-description"
-                                                          >
-                                                            Example description for HTTPS access method.
-                                                          </p>
+                                                          />
                                                         </ForwardRef(Typography)>
                                                       </WithStyles(ForwardRef(Typography))>
                                                     </span>

--- a/packages/datagateway-download/src/downloadConfirmation/downloadConfirmDialog.component.test.tsx
+++ b/packages/datagateway-download/src/downloadConfirmation/downloadConfirmDialog.component.test.tsx
@@ -43,7 +43,7 @@ const mockedSettings = {
     https: {
       idsUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/ids',
       displayName: 'HTTPS',
-      description: 'Example description for HTTPS access method.',
+      description: 'Example description for <b>HTTPS</b> access method.',
     },
     globus: {
       idsUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/ids',

--- a/packages/datagateway-download/src/downloadConfirmation/downloadConfirmDialog.component.tsx
+++ b/packages/datagateway-download/src/downloadConfirmation/downloadConfirmDialog.component.tsx
@@ -594,9 +594,10 @@ const DownloadConfirmDialog: React.FC<DownloadConfirmDialogProps> = (
 
                         <Typography
                           id={`confirm-access-method-${type}-description`}
-                        >
-                          {methodInfo.description}
-                        </Typography>
+                          dangerouslySetInnerHTML={{
+                            __html: methodInfo.description || '',
+                          }}
+                        />
                       </span>
                     ))}
                 </Grid>


### PR DESCRIPTION
## Description
Use `dangerouslySetInnerHTML` to allow parsing of HTML in download method descriptions - this is required for Diamond for the Restore to SCARF and Restore to DLS download methods. Otherwise, I tested with the "Restore to DLS" text and the HTML rendered correctly and the modal scrolls properly and there are no other UI issues so I consider #485 done with this PR.

## Testing instructions
You could always test to see if HTML is rendered like I do in the test with a < b > tag (or other simple HTML tag). Or just trust that this simple change does indeed work ;)
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #485 
