### PR TITLE
Fix cardview dark mode background colour

### DIFF
--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -40,7 +40,7 @@ import { Location as LocationType } from 'history';
 const usePaperStyles = makeStyles(
   (theme: Theme): StyleRules =>
     createStyles({
-      cardPaper: { backgroundColor: 'inhereit' },
+      cardPaper: { backgroundColor: 'inherit' },
       tablePaper: {
         height: 'calc(100vh - 180px)',
         width: '100%',


### PR DESCRIPTION
## Description
Fix a spelling mistake on the word inherit

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] CardView darkmode background is now black rather than grey: you can compare scigateway-preprod to isis prod to see the difference:

![image](https://user-images.githubusercontent.com/22525471/119126616-26aa7f00-ba2b-11eb-8fdd-cd47c2b756a9.png)

![image](https://user-images.githubusercontent.com/22525471/119126701-417cf380-ba2b-11eb-8a62-ec832e0b9879.png)


## Agile board tracking
Fixes #692 
