### PR TITLE
Configuring links for all search results #566

### DIFF
--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -51,6 +51,7 @@ export interface Datafile {
   location?: string;
   description?: string;
   parameters?: DatafileParameter[];
+  dataset?: Dataset;
 }
 
 export interface InvestigationInstrument {

--- a/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
@@ -88,4 +88,24 @@ describe('Datafile search tab', () => {
       .contains('Datafile')
       .should('not.exist');
   });
+
+  it('should link to a parent dataset', () => {
+    cy.get('[aria-label="Search text input"]')
+      .find('#filled-search')
+      .type('4961');
+
+    cy.get('[aria-label="Submit search button"]')
+      .click()
+      .wait(['@investigations', '@investigations', '@investigationsCount'], {
+        timeout: 10000,
+      });
+    cy.get('[aria-label="Search table tabs"]')
+      .contains('Datafile')
+      .contains('1')
+      .click()
+      .wait(['@datafiles', '@datafiles', '@datafilesCount'], {
+        timeout: 10000,
+      });
+    cy.get('[href="/browse/investigation/219/dataset/172/datafile"');
+  });
 });

--- a/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
@@ -106,6 +106,6 @@ describe('Datafile search tab', () => {
       .wait(['@datafiles', '@datafiles', '@datafilesCount'], {
         timeout: 10000,
       });
-    cy.get('[href="/browse/investigation/219/dataset/172/datafile"');
+    cy.get('[href="/browse/investigation/219/dataset/172/datafile"]');
   });
 });

--- a/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
@@ -92,4 +92,32 @@ describe('Dataset search tab', () => {
       .contains('Dataset')
       .should('not.exist');
   });
+
+  it('should link to a dataset', () => {
+    cy.get('[aria-label="Start date input"]').type('2003-01-01');
+    cy.get('[aria-label="End date input"]').type('2004-01-01');
+
+    cy.get('[aria-label="Submit search button"]').click();
+
+    cy.get('[aria-label="Search table tabs"]')
+      .contains('Dataset')
+      .contains('1')
+      .click();
+
+    cy.get('[href="/browse/investigation/12/dataset/68/datafile"');
+  });
+
+  it('should link to a parent investigation', () => {
+    cy.get('[aria-label="Start date input"]').type('2003-01-01');
+    cy.get('[aria-label="End date input"]').type('2004-01-01');
+
+    cy.get('[aria-label="Submit search button"]').click();
+
+    cy.get('[aria-label="Search table tabs"]')
+      .contains('Dataset')
+      .contains('1')
+      .click();
+
+    cy.get('[href="/browse/investigation/12/dataset"');
+  });
 });

--- a/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
@@ -104,7 +104,7 @@ describe('Dataset search tab', () => {
       .contains('1')
       .click();
 
-    cy.get('[href="/browse/investigation/12/dataset/68/datafile"');
+    cy.get('[href="/browse/investigation/12/dataset/68/datafile"]');
   });
 
   it('should link to a parent investigation', () => {
@@ -118,6 +118,6 @@ describe('Dataset search tab', () => {
       .contains('1')
       .click();
 
-    cy.get('[href="/browse/investigation/12/dataset"');
+    cy.get('[href="/browse/investigation/12/dataset"]');
   });
 });

--- a/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
@@ -106,4 +106,17 @@ describe('Investigation search tab', () => {
       .contains('Investigation')
       .should('not.exist');
   });
+
+  it('should link to an investigation', () => {
+    cy.get('[aria-label="Search text input"]')
+      .find('#filled-search')
+      .type('dog');
+
+    cy.get('[aria-label="Submit search button"]')
+      .click()
+      .wait(['@investigations', '@investigationsCount'], {
+        timeout: 10000,
+      });
+    cy.get('[href="/browse/investigation/3/dataset"');
+  });
 });

--- a/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
@@ -117,6 +117,6 @@ describe('Investigation search tab', () => {
       .wait(['@investigations', '@investigationsCount'], {
         timeout: 10000,
       });
-    cy.get('[href="/browse/investigation/3/dataset"');
+    cy.get('[href="/browse/investigation/3/dataset"]');
   });
 });

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -44,13 +44,15 @@
     "create_time": "Create Time",
     "modified_time": "Modified Time",
     "datafile_count": "Datafile Count",
-    "description": "Description"
+    "description": "Description",
+    "investigation": "Investigation"
   },
   "datafiles": {
     "name": "Name",
     "modified_time": "Modified Time",
     "location": "Location",
-    "size": "Size"
+    "size": "Size",
+    "dataset": "Dataset"
   },
   "app": {
     "error": "Something went wrong..."

--- a/packages/datagateway-search/src/searchPageTable.tsx
+++ b/packages/datagateway-search/src/searchPageTable.tsx
@@ -247,7 +247,7 @@ const SearchPageTable = (
               }}
               elevation={0}
             >
-              <DatasetSearchTable />
+              <DatasetSearchTable hierarchy={hierarchy} />
             </Paper>
           </TabPanel>
         ) : null}
@@ -261,7 +261,7 @@ const SearchPageTable = (
               }}
               elevation={0}
             >
-              <DatafileSearchTable />
+              <DatafileSearchTable hierarchy={hierarchy} />
             </Paper>
           </TabPanel>
         ) : null}

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Datafile search table component renders correctly 1`] = `
       },
       Object {
         "cellContentRenderer": [Function],
-        "dataKey": "dataset",
+        "dataKey": "dataset.name",
         "filterComponent": [Function],
         "label": "datafiles.dataset",
       },

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -50,15 +50,15 @@ exports[`Datafile search table component renders correctly 1`] = `
             "doi": "doi 1",
             "endDate": "2019-06-11",
             "facility": Object {
-              "id": 2,
+              "id": 8,
               "name": "facility name",
             },
-            "id": 1,
+            "id": 3,
             "investigationInstruments": Array [
               Object {
-                "id": 1,
+                "id": 4,
                 "instrument": Object {
-                  "id": 3,
+                  "id": 5,
                   "name": "LARMOR",
                 },
               },
@@ -89,7 +89,7 @@ exports[`Datafile search table component renders correctly 1`] = `
           "startDate": "2019-07-24",
         },
         "fileSize": 1,
-        "id": 3,
+        "id": 1,
         "location": "/datafiletest",
         "modTime": "2019-07-23",
         "name": "Datafile test name",

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Datafile search table component renders correctly 1`] = `
   columns={
     Array [
       Object {
+        "cellContentRenderer": [Function],
         "dataKey": "name",
         "filterComponent": [Function],
         "label": "datafiles.name",
@@ -25,6 +26,12 @@ exports[`Datafile search table component renders correctly 1`] = `
         "label": "datafiles.size",
       },
       Object {
+        "cellContentRenderer": [Function],
+        "dataKey": "dataset",
+        "filterComponent": [Function],
+        "label": "datafiles.dataset",
+      },
+      Object {
         "dataKey": "modTime",
         "disableHeaderWrap": true,
         "filterComponent": [Function],
@@ -35,12 +42,57 @@ exports[`Datafile search table component renders correctly 1`] = `
   data={
     Array [
       Object {
-        "dataset": 1,
+        "dataset": Object {
+          "createTime": "2019-07-23",
+          "endDate": "2019-07-25",
+          "id": 2,
+          "investigation": Object {
+            "doi": "doi 1",
+            "endDate": "2019-06-11",
+            "facility": Object {
+              "id": 2,
+              "name": "facility name",
+            },
+            "id": 1,
+            "investigationInstruments": Array [
+              Object {
+                "id": 1,
+                "instrument": Object {
+                  "id": 3,
+                  "name": "LARMOR",
+                },
+              },
+            ],
+            "name": "Investigation test name",
+            "rbNumber": "1",
+            "size": 1,
+            "startDate": "2019-06-10",
+            "studyInvestigations": Array [
+              Object {
+                "id": 6,
+                "study": Object {
+                  "createTime": "2019-06-10",
+                  "id": 7,
+                  "modTime": "2019-06-10",
+                  "name": "study name",
+                  "pid": "study pid",
+                },
+              },
+            ],
+            "summary": "foo bar",
+            "title": "Investigation test title",
+            "visitId": "1",
+          },
+          "modTime": "2019-07-23",
+          "name": "Dataset test name",
+          "size": 1,
+          "startDate": "2019-07-24",
+        },
         "fileSize": 1,
-        "id": 1,
-        "location": "/test1",
+        "id": 3,
+        "location": "/datafiletest",
         "modTime": "2019-07-23",
-        "name": "Test 1",
+        "name": "Datafile test name",
       },
     ]
   }
@@ -64,7 +116,7 @@ exports[`Datafile search table component renders details panel correctly 1`] = `
       :
     </b>
      
-    Test 1
+    Datafile test name
   </WithStyles(ForwardRef(Typography))>
   <WithStyles(ForwardRef(Typography))>
     <b>
@@ -80,7 +132,7 @@ exports[`Datafile search table component renders details panel correctly 1`] = `
       :
     </b>
      
-    /test1
+    /datafiletest
   </WithStyles(ForwardRef(Typography))>
 </div>
 `;

--- a/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
@@ -175,7 +175,7 @@ exports[`Dataset table component renders correctly 1`] = `
       },
       Object {
         "cellContentRenderer": [Function],
-        "dataKey": "investigation",
+        "dataKey": "investigation.title",
         "filterComponent": [Function],
         "label": "datasets.investigation",
       },

--- a/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
@@ -1,6 +1,157 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dataset table component renders Dataset title as a link 1`] = `"Test 1"`;
+exports[`Dataset table component renders Dataset title as a link 1`] = `
+<WithStyles(ForwardRef(Link))
+  component={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "displayName": "Link",
+      "propTypes": Object {
+        "innerRef": [Function],
+        "onClick": [Function],
+        "replace": [Function],
+        "target": [Function],
+        "to": [Function],
+      },
+      "render": [Function],
+    }
+  }
+  to="/browse/investigation/1/dataset/2/datafile"
+>
+  <ForwardRef(Link)
+    classes={
+      Object {
+        "button": "MuiLink-button",
+        "focusVisible": "Mui-focusVisible",
+        "root": "MuiLink-root",
+        "underlineAlways": "MuiLink-underlineAlways",
+        "underlineHover": "MuiLink-underlineHover",
+        "underlineNone": "MuiLink-underlineNone",
+      }
+    }
+    component={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "displayName": "Link",
+        "propTypes": Object {
+          "innerRef": [Function],
+          "onClick": [Function],
+          "replace": [Function],
+          "target": [Function],
+          "to": [Function],
+        },
+        "render": [Function],
+      }
+    }
+    to="/browse/investigation/1/dataset/2/datafile"
+  >
+    <WithStyles(ForwardRef(Typography))
+      className="MuiLink-root MuiLink-underlineHover"
+      color="primary"
+      component={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "displayName": "Link",
+          "propTypes": Object {
+            "innerRef": [Function],
+            "onClick": [Function],
+            "replace": [Function],
+            "target": [Function],
+            "to": [Function],
+          },
+          "render": [Function],
+        }
+      }
+      onBlur={[Function]}
+      onFocus={[Function]}
+      to="/browse/investigation/1/dataset/2/datafile"
+      variant="inherit"
+    >
+      <ForwardRef(Typography)
+        className="MuiLink-root MuiLink-underlineHover"
+        classes={
+          Object {
+            "alignCenter": "MuiTypography-alignCenter",
+            "alignJustify": "MuiTypography-alignJustify",
+            "alignLeft": "MuiTypography-alignLeft",
+            "alignRight": "MuiTypography-alignRight",
+            "body1": "MuiTypography-body1",
+            "body2": "MuiTypography-body2",
+            "button": "MuiTypography-button",
+            "caption": "MuiTypography-caption",
+            "colorError": "MuiTypography-colorError",
+            "colorInherit": "MuiTypography-colorInherit",
+            "colorPrimary": "MuiTypography-colorPrimary",
+            "colorSecondary": "MuiTypography-colorSecondary",
+            "colorTextPrimary": "MuiTypography-colorTextPrimary",
+            "colorTextSecondary": "MuiTypography-colorTextSecondary",
+            "displayBlock": "MuiTypography-displayBlock",
+            "displayInline": "MuiTypography-displayInline",
+            "gutterBottom": "MuiTypography-gutterBottom",
+            "h1": "MuiTypography-h1",
+            "h2": "MuiTypography-h2",
+            "h3": "MuiTypography-h3",
+            "h4": "MuiTypography-h4",
+            "h5": "MuiTypography-h5",
+            "h6": "MuiTypography-h6",
+            "noWrap": "MuiTypography-noWrap",
+            "overline": "MuiTypography-overline",
+            "paragraph": "MuiTypography-paragraph",
+            "root": "MuiTypography-root",
+            "srOnly": "MuiTypography-srOnly",
+            "subtitle1": "MuiTypography-subtitle1",
+            "subtitle2": "MuiTypography-subtitle2",
+          }
+        }
+        color="primary"
+        component={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "displayName": "Link",
+            "propTypes": Object {
+              "innerRef": [Function],
+              "onClick": [Function],
+              "replace": [Function],
+              "target": [Function],
+              "to": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        onBlur={[Function]}
+        onFocus={[Function]}
+        to="/browse/investigation/1/dataset/2/datafile"
+        variant="inherit"
+      >
+        <Link
+          className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          to="/browse/investigation/1/dataset/2/datafile"
+        >
+          <LinkAnchor
+            className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="/browse/investigation/1/dataset/2/datafile"
+            navigate={[Function]}
+            onBlur={[Function]}
+            onFocus={[Function]}
+          >
+            <a
+              className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+              href="/browse/investigation/1/dataset/2/datafile"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+            >
+              Dataset test name
+            </a>
+          </LinkAnchor>
+        </Link>
+      </ForwardRef(Typography)>
+    </WithStyles(ForwardRef(Typography))>
+  </ForwardRef(Link)>
+</WithStyles(ForwardRef(Link))>
+`;
 
 exports[`Dataset table component renders correctly 1`] = `
 <WithStyles(VirtualizedTable)
@@ -12,6 +163,7 @@ exports[`Dataset table component renders correctly 1`] = `
   columns={
     Array [
       Object {
+        "cellContentRenderer": [Function],
         "dataKey": "name",
         "filterComponent": [Function],
         "label": "datasets.name",
@@ -20,6 +172,12 @@ exports[`Dataset table component renders correctly 1`] = `
         "dataKey": "datafileCount",
         "disableSort": true,
         "label": "datasets.datafile_count",
+      },
+      Object {
+        "cellContentRenderer": [Function],
+        "dataKey": "investigation",
+        "filterComponent": [Function],
+        "label": "datasets.investigation",
       },
       Object {
         "dataKey": "createTime",
@@ -39,10 +197,49 @@ exports[`Dataset table component renders correctly 1`] = `
     Array [
       Object {
         "createTime": "2019-07-23",
-        "id": 1,
+        "endDate": "2019-07-25",
+        "id": 2,
+        "investigation": Object {
+          "doi": "doi 1",
+          "endDate": "2019-06-11",
+          "facility": Object {
+            "id": 2,
+            "name": "facility name",
+          },
+          "id": 1,
+          "investigationInstruments": Array [
+            Object {
+              "id": 1,
+              "instrument": Object {
+                "id": 3,
+                "name": "LARMOR",
+              },
+            },
+          ],
+          "name": "Investigation test name",
+          "rbNumber": "1",
+          "size": 1,
+          "startDate": "2019-06-10",
+          "studyInvestigations": Array [
+            Object {
+              "id": 6,
+              "study": Object {
+                "createTime": "2019-06-10",
+                "id": 7,
+                "modTime": "2019-06-10",
+                "name": "study name",
+                "pid": "study pid",
+              },
+            },
+          ],
+          "summary": "foo bar",
+          "title": "Investigation test title",
+          "visitId": "1",
+        },
         "modTime": "2019-07-23",
-        "name": "Test 1",
+        "name": "Dataset test name",
         "size": 1,
+        "startDate": "2019-07-24",
       },
     ]
   }
@@ -66,7 +263,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       :
     </b>
      
-    Test 1
+    Dataset test name
   </WithStyles(ForwardRef(Typography))>
   <WithStyles(ForwardRef(Typography))>
     <b>
@@ -74,7 +271,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       :
     </b>
      
-    Test 1
+    Dataset test name
   </WithStyles(ForwardRef(Typography))>
 </div>
 `;

--- a/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Dataset table component renders Dataset title as a link 1`] = `
       "render": [Function],
     }
   }
-  to="/browse/investigation/1/dataset/2/datafile"
+  to="/browse/investigation/2/dataset/1/datafile"
 >
   <ForwardRef(Link)
     classes={
@@ -43,7 +43,7 @@ exports[`Dataset table component renders Dataset title as a link 1`] = `
         "render": [Function],
       }
     }
-    to="/browse/investigation/1/dataset/2/datafile"
+    to="/browse/investigation/2/dataset/1/datafile"
   >
     <WithStyles(ForwardRef(Typography))
       className="MuiLink-root MuiLink-underlineHover"
@@ -64,7 +64,7 @@ exports[`Dataset table component renders Dataset title as a link 1`] = `
       }
       onBlur={[Function]}
       onFocus={[Function]}
-      to="/browse/investigation/1/dataset/2/datafile"
+      to="/browse/investigation/2/dataset/1/datafile"
       variant="inherit"
     >
       <ForwardRef(Typography)
@@ -120,25 +120,25 @@ exports[`Dataset table component renders Dataset title as a link 1`] = `
         }
         onBlur={[Function]}
         onFocus={[Function]}
-        to="/browse/investigation/1/dataset/2/datafile"
+        to="/browse/investigation/2/dataset/1/datafile"
         variant="inherit"
       >
         <Link
           className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
           onBlur={[Function]}
           onFocus={[Function]}
-          to="/browse/investigation/1/dataset/2/datafile"
+          to="/browse/investigation/2/dataset/1/datafile"
         >
           <LinkAnchor
             className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-            href="/browse/investigation/1/dataset/2/datafile"
+            href="/browse/investigation/2/dataset/1/datafile"
             navigate={[Function]}
             onBlur={[Function]}
             onFocus={[Function]}
           >
             <a
               className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-              href="/browse/investigation/1/dataset/2/datafile"
+              href="/browse/investigation/2/dataset/1/datafile"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -198,20 +198,20 @@ exports[`Dataset table component renders correctly 1`] = `
       Object {
         "createTime": "2019-07-23",
         "endDate": "2019-07-25",
-        "id": 2,
+        "id": 1,
         "investigation": Object {
           "doi": "doi 1",
           "endDate": "2019-06-11",
           "facility": Object {
-            "id": 2,
+            "id": 7,
             "name": "facility name",
           },
-          "id": 1,
+          "id": 2,
           "investigationInstruments": Array [
             Object {
-              "id": 1,
+              "id": 3,
               "instrument": Object {
-                "id": 3,
+                "id": 4,
                 "name": "LARMOR",
               },
             },
@@ -222,10 +222,10 @@ exports[`Dataset table component renders correctly 1`] = `
           "startDate": "2019-06-10",
           "studyInvestigations": Array [
             Object {
-              "id": 6,
+              "id": 5,
               "study": Object {
                 "createTime": "2019-06-10",
-                "id": 7,
+                "id": 6,
                 "modTime": "2019-06-10",
                 "name": "study name",
                 "pid": "study pid",

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -55,7 +55,7 @@ describe('Datafile search table component', () => {
       {
         id: 3,
         name: 'Datafile test name',
-        location: '/datafiletest1',
+        location: '/datafiletest',
         fileSize: 1,
         modTime: '2019-07-23',
         dataset: {
@@ -351,7 +351,7 @@ describe('Datafile search table component', () => {
       {
         id: 3,
         name: 'Datafile test name',
-        location: '/datafiletest1',
+        location: '/datafiletest',
         fileSize: 1,
         modTime: '2019-07-23',
         dataset: {},
@@ -382,7 +382,9 @@ describe('Datafile search table component', () => {
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
       `/browse/investigation/1/dataset/2/datafile`
     );
-    expect(wrapper.find('[aria-colindex=3]').text()).toEqual('Datafile test 1');
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Datafile test name'
+    );
   });
 
   it('renders DLS link correctly', () => {
@@ -396,7 +398,7 @@ describe('Datafile search table component', () => {
     );
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      '/browse/proposal/Investigation test name/investigation/1/dataset/2/datafile'
+      '/browse/proposal/Dataset test name/investigation/1/dataset/2/datafile'
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Datafile test name'

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -491,12 +491,6 @@ describe('Datafile search table component', () => {
   });
 
   it('does not render ISIS link when facilityCycleId cannot be found', async () => {
-    // (axios.get as jest.Mock).mockImplementationOnce(() =>
-    //   Promise.resolve({
-    //     data: [],
-    //   })
-    // );
-
     const testStore = mockStore(state);
     const wrapper = mount(
       <Provider store={testStore}>
@@ -547,6 +541,61 @@ describe('Datafile search table component', () => {
 
     expect(wrapper.find('[aria-colindex=3]').find('a')).toHaveLength(0);
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Datafile test name'
+    );
+  });
+
+  it('displays only the datafile name when there is no DLS dataset to link to', () => {
+    state.dgcommon.data = [
+      {
+        id: 1,
+        name: 'Datafile test name',
+        location: '/datafiletest',
+        fileSize: 1,
+        modTime: '2019-07-23',
+        dataset: {},
+      },
+    ];
+
+    const wrapper = mount(
+      <Provider store={mockStore(state)}>
+        <MemoryRouter>
+          <DatafileSearchTable hierarchy="dls" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find('[aria-colindex=3]').find('p').text()).toEqual(
+      'Datafile test name'
+    );
+  });
+
+  it('displays only the datafile name when there is no ISIS investigation to link to', async () => {
+    state.dgcommon.data = [
+      {
+        id: 1,
+        name: 'Datafile test name',
+        location: '/datafiletest',
+        fileSize: 1,
+        modTime: '2019-07-23',
+        dataset: {},
+      },
+    ];
+
+    const wrapper = mount(
+      <Provider store={mockStore(state)}>
+        <MemoryRouter>
+          <DatafileSearchTable hierarchy="isis" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.find('[aria-colindex=3]').find('p').text()).toEqual(
       'Datafile test name'
     );
   });

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -53,7 +53,7 @@ describe('Datafile search table component', () => {
     );
     state.dgcommon.data = [
       {
-        id: 3,
+        id: 1,
         name: 'Datafile test name',
         location: '/datafiletest',
         fileSize: 1,
@@ -67,7 +67,7 @@ describe('Datafile search table component', () => {
           startDate: '2019-07-24',
           endDate: '2019-07-25',
           investigation: {
-            id: 1,
+            id: 3,
             title: 'Investigation test title',
             name: 'Investigation test name',
             summary: 'foo bar',
@@ -77,9 +77,9 @@ describe('Datafile search table component', () => {
             size: 1,
             investigationInstruments: [
               {
-                id: 1,
+                id: 4,
                 instrument: {
-                  id: 3,
+                  id: 5,
                   name: 'LARMOR',
                 },
               },
@@ -99,7 +99,7 @@ describe('Datafile search table component', () => {
             startDate: '2019-06-10',
             endDate: '2019-06-11',
             facility: {
-              id: 2,
+              id: 8,
               name: 'facility name',
             },
           },
@@ -349,7 +349,7 @@ describe('Datafile search table component', () => {
     // this can happen when navigating between tables and the previous table's state still exists
     state.dgcommon.data = [
       {
-        id: 3,
+        id: 1,
         name: 'Datafile test name',
         location: '/datafiletest',
         fileSize: 1,
@@ -380,7 +380,7 @@ describe('Datafile search table component', () => {
     );
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      `/browse/investigation/1/dataset/2/datafile`
+      `/browse/investigation/3/dataset/2/datafile`
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Datafile test name'
@@ -398,7 +398,7 @@ describe('Datafile search table component', () => {
     );
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      '/browse/proposal/Dataset test name/investigation/1/dataset/2/datafile'
+      '/browse/proposal/Dataset test name/investigation/3/dataset/2/datafile'
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Datafile test name'
@@ -437,7 +437,7 @@ describe('Datafile search table component', () => {
       Promise.resolve({
         data: [
           {
-            id: 2,
+            id: 4,
             name: 'facility cycle name',
             startDate: '2000-06-10',
             endDate: '2020-06-11',
@@ -461,7 +461,7 @@ describe('Datafile search table component', () => {
     });
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      `/browse/instrument/3/facilityCycle/2/investigation/1/dataset/2/datafile`
+      `/browse/instrument/5/facilityCycle/4/investigation/3/dataset/2/datafile`
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Datafile test name'

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -14,12 +14,24 @@ import {
   addToCartRequest,
   removeFromCartRequest,
   fetchDatafileCountRequest,
+  // handleICATError,
 } from 'datagateway-common';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router';
 import axios from 'axios';
 import { dGCommonInitialState } from 'datagateway-common';
+// import { act } from 'react-dom/test-utils';
+
+jest.mock('datagateway-common', () => {
+  const originalModule = jest.requireActual('datagateway-common');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    handleICATError: jest.fn(),
+  };
+});
 
 describe('Datafile search table component', () => {
   let shallow;

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
@@ -130,14 +130,19 @@ const DatafileSearchTable = (
         return datafileData.name;
       }
 
-      if (datafileData.dataset.startDate && facilityCycles.length) {
+      if (
+        facilityCycles.length &&
+        datafileData.dataset?.investigation?.startDate
+      ) {
         const filteredFacilityCycles: FacilityCycle[] = facilityCycles.filter(
           (facilityCycle: FacilityCycle) =>
-            datafileData.dataset?.startDate &&
+            datafileData.dataset?.investigation?.startDate &&
             facilityCycle.startDate &&
             facilityCycle.endDate &&
-            datafileData.dataset?.startDate >= facilityCycle.startDate &&
-            datafileData.dataset?.startDate <= facilityCycle.endDate
+            datafileData.dataset.investigation.startDate >=
+              facilityCycle.startDate &&
+            datafileData.dataset.investigation.startDate <=
+              facilityCycle.endDate
         );
         if (filteredFacilityCycles.length) {
           facilityCycleId = filteredFacilityCycles[0].id;
@@ -148,7 +153,7 @@ const DatafileSearchTable = (
         return linkType === 'dataset'
           ? tableLink(
               `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datafileData.dataset.investigation.id}/dataset/${datafileData.dataset.id}`,
-              datafileData.dataset?.name
+              datafileData.dataset.name
             )
           : tableLink(
               `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datafileData.dataset.investigation.id}/dataset/${datafileData.dataset.id}/datafile`,
@@ -175,7 +180,6 @@ const DatafileSearchTable = (
             datafileData.name
           );
     }
-
     if (linkType === 'dataset')
       return datafileData.dataset ? datafileData.dataset.name : '';
     return datafileData.name;
@@ -342,7 +346,11 @@ const mapDispatchToProps = (
           },
           {
             filterType: 'include',
-            filterValue: '"dataset"',
+            filterValue: JSON.stringify({
+              dataset: {
+                investigation: { investigationInstruments: 'instrument' },
+              },
+            }),
           },
         ],
       })

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
@@ -343,7 +343,7 @@ const mapDispatchToProps = (
           },
           {
             filterType: 'include',
-            filterValue: 'dataset',
+            filterValue: '"dataset"',
           },
         ],
       })

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
@@ -309,7 +309,7 @@ const DatafileSearchTable = (
         },
         {
           label: t('datafiles.dataset'),
-          dataKey: 'dataset',
+          dataKey: 'dataset.name',
           cellContentRenderer: (cellProps: TableCellProps) => {
             const datafileData = cellProps.rowData as Datafile;
             return hierarchyLink(datafileData, 'dataset');

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
@@ -97,17 +97,21 @@ const DatafileSearchTable = (
   const dlsLink = (
     datafileData: Datafile,
     linkType = 'datafile'
-  ): React.ReactElement => {
-    if (linkType === 'dataset') {
-      return tableLink(
-        `/browse/proposal/${datafileData.dataset?.investigation?.name}/investigation/${datafileData.dataset?.investigation?.id}/dataset/${datafileData.dataset?.id}/datafile`,
-        datafileData.dataset?.name
-      );
+  ): React.ReactElement | string => {
+    if (datafileData.dataset?.investigation) {
+      return linkType === 'dataset'
+        ? tableLink(
+            `/browse/proposal/${datafileData.dataset.investigation.name}/investigation/${datafileData.dataset.investigation?.id}/dataset/${datafileData.dataset.id}/datafile`,
+            datafileData.dataset.name
+          )
+        : tableLink(
+            `/browse/proposal/${datafileData.dataset.name}/investigation/${datafileData.dataset.investigation.id}/dataset/${datafileData.dataset.id}/datafile`,
+            datafileData.name
+          );
     }
-    return tableLink(
-      `/browse/proposal/${datafileData.dataset?.name}/investigation/${datafileData.dataset?.investigation?.id}/dataset/${datafileData.dataset.id}/datafile`,
-      datafileData.name
-    );
+    if (linkType === 'dataset')
+      return datafileData.dataset ? datafileData.dataset.name : '';
+    return datafileData.name;
   };
 
   const isisLink = React.useCallback(
@@ -121,10 +125,12 @@ const DatafileSearchTable = (
           datafileData.dataset?.investigation?.investigationInstruments[0]
             .instrument?.id;
       } else {
+        if (linkType === 'dataset')
+          return datafileData.dataset ? datafileData.dataset.name : '';
         return datafileData.name;
       }
 
-      if (datafileData.startDate && facilityCycles.length) {
+      if (datafileData.dataset.startDate && facilityCycles.length) {
         const filteredFacilityCycles: FacilityCycle[] = facilityCycles.filter(
           (facilityCycle: FacilityCycle) =>
             datafileData.dataset?.startDate &&
@@ -139,19 +145,17 @@ const DatafileSearchTable = (
       }
 
       if (facilityCycleId) {
-        if (linkType === 'dataset') {
-          return tableLink(
-            `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datafileData.dataset?.investigation?.id}/dataset/${datafileData.dataset?.id}`,
-            datafileData.dataset?.name
-          );
-        }
-        return tableLink(
-          `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datafileData.dataset?.investigation?.id}/dataset/${datafileData.dataset?.id}/datafile`,
-          datafileData.name
-        );
-      } else {
-        return datafileData.name;
+        return linkType === 'dataset'
+          ? tableLink(
+              `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datafileData.dataset.investigation.id}/dataset/${datafileData.dataset.id}`,
+              datafileData.dataset?.name
+            )
+          : tableLink(
+              `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datafileData.dataset.investigation.id}/dataset/${datafileData.dataset.id}/datafile`,
+              datafileData.name
+            );
       }
+      return linkType === 'dataset' ? '' : datafileData.name;
     },
     [facilityCycles]
   );
@@ -159,19 +163,22 @@ const DatafileSearchTable = (
   const genericLink = (
     datafileData: Datafile,
     linkType = 'datafile'
-  ): React.ReactElement => {
-    // generic link for dataset
-    if (linkType === 'dataset') {
-      return tableLink(
-        `/browse/investigation/${datafileData.dataset?.investigation?.id}/dataset/${datafileData.dataset?.id}/datafile`,
-        datafileData.dataset?.name
-      );
+  ): React.ReactElement | string => {
+    if (datafileData.dataset?.investigation) {
+      return linkType === 'dataset'
+        ? tableLink(
+            `/browse/investigation/${datafileData.dataset.investigation.id}/dataset/${datafileData.dataset.id}/datafile`,
+            datafileData.dataset.name
+          )
+        : tableLink(
+            `/browse/investigation/${datafileData.dataset.investigation.id}/dataset/${datafileData.dataset.id}/datafile`,
+            datafileData.name
+          );
     }
-    // generic link for datafile
-    return tableLink(
-      `/browse/investigation/${datafileData.dataset?.investigation?.id}/dataset/${datafileData.dataset?.id}/datafile`,
-      datafileData.name
-    );
+
+    if (linkType === 'dataset')
+      return datafileData.dataset ? datafileData.dataset.name : '';
+    return datafileData.name;
   };
 
   const hierarchyLink = React.useMemo(() => {

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -13,12 +13,25 @@ import {
   removeFromCartRequest,
   fetchDatasetCountRequest,
   fetchAllIdsRequest,
+  dGCommonInitialState,
+  handleICATError,
 } from 'datagateway-common';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router';
 import axios from 'axios';
-import { dGCommonInitialState } from 'datagateway-common';
+import { act } from 'react-dom/test-utils';
+import { flushPromises } from '../setupTests';
+
+jest.mock('datagateway-common', () => {
+  const originalModule = jest.requireActual('datagateway-common');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    handleICATError: jest.fn(),
+  };
+});
 
 describe('Dataset table component', () => {
   let shallow;
@@ -36,11 +49,50 @@ describe('Dataset table component', () => {
     );
     state.dgcommon.data = [
       {
-        id: 1,
-        name: 'Test 1',
+        id: 2,
+        name: 'Dataset test name',
         size: 1,
         modTime: '2019-07-23',
         createTime: '2019-07-23',
+        startDate: '2019-07-24',
+        endDate: '2019-07-25',
+        investigation: {
+          id: 1,
+          title: 'Investigation test title',
+          name: 'Investigation test name',
+          summary: 'foo bar',
+          visitId: '1',
+          rbNumber: '1',
+          doi: 'doi 1',
+          size: 1,
+          investigationInstruments: [
+            {
+              id: 1,
+              instrument: {
+                id: 3,
+                name: 'LARMOR',
+              },
+            },
+          ],
+          studyInvestigations: [
+            {
+              id: 6,
+              study: {
+                id: 7,
+                pid: 'study pid',
+                name: 'study name',
+                modTime: '2019-06-10',
+                createTime: '2019-06-10',
+              },
+            },
+          ],
+          startDate: '2019-06-10',
+          endDate: '2019-06-11',
+          facility: {
+            id: 2,
+            name: 'facility name',
+          },
+        },
       },
     ];
     state.dgcommon.allIds = [1];
@@ -58,6 +110,7 @@ describe('Dataset table component', () => {
 
   afterEach(() => {
     mount.cleanUp();
+    (handleICATError as jest.Mock).mockClear();
   });
 
   it('renders correctly', () => {
@@ -262,5 +315,211 @@ describe('Dataset table component', () => {
     expect(
       wrapper.find('[aria-colindex=3]').find('p').children()
     ).toMatchSnapshot();
+  });
+
+  // new tests
+
+  it('renders fine with incomplete data', () => {
+    // this can happen when navigating between tables and the previous table's state still exists
+    state.dgcommon.data = [
+      {
+        id: 1,
+        name: 'test',
+        size: 1,
+        modTime: '2019-07-23',
+        createTime: '2019-07-23',
+        investigation: {},
+      },
+    ];
+
+    expect(() =>
+      mount(
+        <Provider store={mockStore(state)}>
+          <MemoryRouter>
+            <DatasetSearchTable />
+          </MemoryRouter>
+        </Provider>
+      )
+    ).not.toThrowError();
+  });
+
+  it('renders generic link correctly', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable hierarchy="data" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
+      `/browse/investigation/1/dataset/2/datafile`
+    );
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual('Dataset test 1');
+  });
+
+  it('renders DLS link correctly', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable hierarchy="dls" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
+      '/browse/proposal/Investigation test name/investigation/1/dataset/2/datafile'
+    );
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Dataset test name'
+    );
+  });
+
+  it('throws an error if facility cycles could not be fetched', async () => {
+    (axios.get as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject({
+        message: 'Test error message',
+      })
+    );
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable hierarchy="isis" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(handleICATError).toHaveBeenCalled();
+    expect(handleICATError).toHaveBeenCalledWith({
+      message: 'Test error message',
+    });
+  });
+
+  it('renders ISIS link correctly', async () => {
+    (axios.get as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        data: [
+          {
+            id: 2,
+            name: 'facility cycle name',
+            startDate: '2000-06-10',
+            endDate: '2020-06-11',
+          },
+        ],
+      })
+    );
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable hierarchy="isis" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
+      `/browse/instrument/3/facilityCycle/2/investigation/1/dataset/2/datafile`
+    );
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Dataset test name'
+    );
+  });
+
+  it('does not render ISIS link when instrumentId cannot be found', async () => {
+    delete state.dgcommon.data[0].investigationInstruments;
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable hierarchy="isis" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.find('[aria-colindex=3]').find('a')).toHaveLength(0);
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Dataset test name'
+    );
+  });
+
+  it('does not render ISIS link when facilityCycleId cannot be found', async () => {
+    (axios.get as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        data: [],
+      })
+    );
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable hierarchy="isis" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.find('[aria-colindex=3]').find('a')).toHaveLength(0);
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Dataset test name'
+    );
+  });
+
+  it('does not render ISIS link when facilityCycleId has incompatible dates', async () => {
+    (axios.get as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        data: [
+          {
+            id: 2,
+            name: 'facility cycle name',
+            startDate: '2020-06-11',
+            endDate: '2000-06-10',
+          },
+        ],
+      })
+    );
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <DatasetSearchTable hierarchy="isis" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(wrapper.find('[aria-colindex=3]').find('a')).toHaveLength(0);
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Dataset test name'
+    );
   });
 });

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -356,7 +356,9 @@ describe('Dataset table component', () => {
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
       `/browse/investigation/1/dataset/2/datafile`
     );
-    expect(wrapper.find('[aria-colindex=3]').text()).toEqual('Dataset test 1');
+    expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
+      'Dataset test name'
+    );
   });
 
   it('renders DLS link correctly', () => {
@@ -463,11 +465,11 @@ describe('Dataset table component', () => {
   });
 
   it('does not render ISIS link when facilityCycleId cannot be found', async () => {
-    (axios.get as jest.Mock).mockImplementationOnce(() =>
-      Promise.resolve({
-        data: [],
-      })
-    );
+    // (axios.get as jest.Mock).mockImplementationOnce(() =>
+    //   Promise.resolve({
+    //     data: [],
+    //   })
+    // );
 
     const testStore = mockStore(state);
     const wrapper = mount(

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -49,7 +49,7 @@ describe('Dataset table component', () => {
     );
     state.dgcommon.data = [
       {
-        id: 2,
+        id: 1,
         name: 'Dataset test name',
         size: 1,
         modTime: '2019-07-23',
@@ -57,7 +57,7 @@ describe('Dataset table component', () => {
         startDate: '2019-07-24',
         endDate: '2019-07-25',
         investigation: {
-          id: 1,
+          id: 2,
           title: 'Investigation test title',
           name: 'Investigation test name',
           summary: 'foo bar',
@@ -67,18 +67,18 @@ describe('Dataset table component', () => {
           size: 1,
           investigationInstruments: [
             {
-              id: 1,
+              id: 3,
               instrument: {
-                id: 3,
+                id: 4,
                 name: 'LARMOR',
               },
             },
           ],
           studyInvestigations: [
             {
-              id: 6,
+              id: 5,
               study: {
-                id: 7,
+                id: 6,
                 pid: 'study pid',
                 name: 'study name',
                 modTime: '2019-06-10',
@@ -89,7 +89,7 @@ describe('Dataset table component', () => {
           startDate: '2019-06-10',
           endDate: '2019-06-11',
           facility: {
-            id: 2,
+            id: 7,
             name: 'facility name',
           },
         },
@@ -332,6 +332,8 @@ describe('Dataset table component', () => {
       },
     ];
 
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
     expect(() =>
       mount(
         <Provider store={mockStore(state)}>
@@ -341,6 +343,9 @@ describe('Dataset table component', () => {
         </Provider>
       )
     ).not.toThrowError();
+
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 
   it('renders generic link correctly', () => {
@@ -354,7 +359,7 @@ describe('Dataset table component', () => {
     );
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      `/browse/investigation/1/dataset/2/datafile`
+      `/browse/investigation/2/dataset/1/datafile`
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Dataset test name'
@@ -372,7 +377,7 @@ describe('Dataset table component', () => {
     );
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      '/browse/proposal/Investigation test name/investigation/1/dataset/2/datafile'
+      '/browse/proposal/Investigation test name/investigation/2/dataset/1/datafile'
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Dataset test name'
@@ -411,7 +416,7 @@ describe('Dataset table component', () => {
       Promise.resolve({
         data: [
           {
-            id: 2,
+            id: 6,
             name: 'facility cycle name',
             startDate: '2000-06-10',
             endDate: '2020-06-11',
@@ -435,7 +440,7 @@ describe('Dataset table component', () => {
     });
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      `/browse/instrument/3/facilityCycle/2/investigation/1/dataset/2`
+      `/browse/instrument/4/facilityCycle/6/investigation/2/dataset/1`
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Dataset test name'

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -435,7 +435,7 @@ describe('Dataset table component', () => {
     });
 
     expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
-      `/browse/instrument/3/facilityCycle/2/investigation/1/dataset/2/datafile`
+      `/browse/instrument/3/facilityCycle/2/investigation/1/dataset/2`
     );
     expect(wrapper.find('[aria-colindex=3]').text()).toEqual(
       'Dataset test name'
@@ -465,12 +465,6 @@ describe('Dataset table component', () => {
   });
 
   it('does not render ISIS link when facilityCycleId cannot be found', async () => {
-    // (axios.get as jest.Mock).mockImplementationOnce(() =>
-    //   Promise.resolve({
-    //     data: [],
-    //   })
-    // );
-
     const testStore = mockStore(state);
     const wrapper = mount(
       <Provider store={testStore}>

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -92,17 +92,19 @@ const DatasetSearchTable = (
   const dlsLink = (
     datasetData: Dataset,
     linkType = 'dataset'
-  ): React.ReactElement => {
-    if (linkType === 'investigation') {
-      return tableLink(
-        `/browse/proposal/${datasetData.investigation?.name}/investigation/${datasetData.investigation?.id}/dataset`,
-        datasetData.investigation?.title
-      );
+  ): React.ReactElement | string => {
+    if (datasetData.investigation) {
+      return linkType === 'investigation'
+        ? tableLink(
+            `/browse/proposal/${datasetData.investigation.name}/investigation/${datasetData.investigation.id}/dataset`,
+            datasetData.investigation.title
+          )
+        : tableLink(
+            `/browse/proposal/${datasetData.investigation.name}/investigation/${datasetData.investigation.id}/dataset/${datasetData.id}/datafile`,
+            datasetData.name
+          );
     }
-    return tableLink(
-      `/browse/proposal/${datasetData.investigation?.name}/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}/datafile`,
-      datasetData.name
-    );
+    return linkType === 'investigation' ? '' : datasetData.name;
   };
 
   const isisLink = React.useCallback(
@@ -113,7 +115,7 @@ const DatasetSearchTable = (
         instrumentId =
           datasetData.investigation?.investigationInstruments[0].instrument?.id;
       } else {
-        return datasetData.name;
+        return linkType === 'investigation' ? '' : datasetData.name;
       }
 
       if (datasetData.startDate && facilityCycles.length) {
@@ -131,19 +133,17 @@ const DatasetSearchTable = (
       }
 
       if (facilityCycleId) {
-        if (linkType === 'investigation') {
-          return tableLink(
-            `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation?.id}/dataset`,
-            datasetData.investigation?.title
-          );
-        }
-        return tableLink(
-          `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}`,
-          datasetData.name
-        );
-      } else {
-        return datasetData.name;
+        return linkType === 'investigation'
+          ? tableLink(
+              `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation.id}/dataset`,
+              datasetData.investigation.title
+            )
+          : tableLink(
+              `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation.id}/dataset/${datasetData.id}`,
+              datasetData.name
+            );
       }
+      return linkType === 'investigation' ? '' : datasetData.name;
     },
     [facilityCycles]
   );
@@ -151,19 +151,19 @@ const DatasetSearchTable = (
   const genericLink = (
     datasetData: Dataset,
     linkType = 'dataset'
-  ): React.ReactElement => {
-    // generic link for parent investigation
-    if (linkType === 'investigation') {
-      return tableLink(
-        `/browse/investigation/${datasetData.investigation?.id}/dataset`,
-        datasetData.investigation?.title
-      );
+  ): React.ReactElement | string => {
+    if (datasetData.investigation) {
+      return linkType === 'investigation'
+        ? tableLink(
+            `/browse/investigation/${datasetData.investigation.id}/dataset`,
+            datasetData.investigation.title
+          )
+        : tableLink(
+            `/browse/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}/datafile`,
+            datasetData.name
+          );
     }
-    // generic link for this dataset
-    return tableLink(
-      `/browse/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}/datafile`,
-      datasetData.name
-    );
+    return linkType === 'investigation' ? '' : datasetData.name;
   };
 
   const hierarchyLink = React.useMemo(() => {

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -280,7 +280,7 @@ const DatasetSearchTable = (
         },
         {
           label: t('datasets.investigation'),
-          dataKey: 'investigation',
+          dataKey: 'investigation.title',
           cellContentRenderer: (cellProps: TableCellProps) => {
             const datasetData = cellProps.rowData as Dataset;
             return hierarchyLink(datasetData, 'investigation');

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -17,14 +17,18 @@ import {
   sortTable,
   filterTable,
   clearTable,
+  tableLink,
+  handleICATError,
+  readSciGatewayToken,
+  FacilityCycle,
 } from 'datagateway-common';
-import { AnyAction } from 'redux';
 import { StateType } from '../state/app.types';
 import { ThunkDispatch } from 'redux-thunk';
-import { Action } from 'redux';
+import { Action, AnyAction } from 'redux';
 import { connect } from 'react-redux';
-import { IndexRange } from 'react-virtualized';
+import { TableCellProps, IndexRange } from 'react-virtualized';
 import { useTranslation } from 'react-i18next';
+import axios from 'axios';
 
 interface DatasetTableStoreProps {
   sort: {
@@ -40,6 +44,7 @@ interface DatasetTableStoreProps {
   cartItems: DownloadCartItem[];
   allIds: number[];
   luceneData: number[];
+  apiUrl: string;
 }
 
 interface DatasetTableDispatchProps {
@@ -54,7 +59,7 @@ interface DatasetTableDispatchProps {
 }
 
 type DatasetTableCombinedProps = DatasetTableStoreProps &
-  DatasetTableDispatchProps;
+  DatasetTableDispatchProps & { hierarchy: string };
 
 const DatasetSearchTable = (
   props: DatasetTableCombinedProps
@@ -76,9 +81,100 @@ const DatasetSearchTable = (
     fetchAllIds,
     loading,
     luceneData,
+    hierarchy,
+    apiUrl,
   } = props;
 
+  const [facilityCycles, setFacilityCycles] = React.useState([]);
+
   const [t] = useTranslation();
+
+  const dlsLink = (
+    datasetData: Dataset,
+    linkType = 'dataset'
+  ): React.ReactElement => {
+    if (linkType === 'investigation') {
+      return tableLink(
+        `/browse/proposal/${datasetData.investigation?.name}/investigation/${datasetData.investigation?.id}/dataset`,
+        datasetData.investigation?.title
+      );
+    }
+    return tableLink(
+      `/browse/proposal/${datasetData.investigation?.name}/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}/datafile`,
+      datasetData.name
+    );
+  };
+
+  const isisLink = React.useCallback(
+    (datasetData: Dataset, linkType = 'dataset') => {
+      let instrumentId;
+      let facilityCycleId;
+      if (datasetData.investigation?.investigationInstruments?.length) {
+        instrumentId =
+          datasetData.investigation?.investigationInstruments[0].instrument?.id;
+      } else {
+        return datasetData.name;
+      }
+
+      if (datasetData.startDate && facilityCycles.length) {
+        const filteredFacilityCycles: FacilityCycle[] = facilityCycles.filter(
+          (facilityCycle: FacilityCycle) =>
+            datasetData.startDate &&
+            facilityCycle.startDate &&
+            facilityCycle.endDate &&
+            datasetData.startDate >= facilityCycle.startDate &&
+            datasetData.startDate <= facilityCycle.endDate
+        );
+        if (filteredFacilityCycles.length) {
+          facilityCycleId = filteredFacilityCycles[0].id;
+        }
+      }
+
+      if (facilityCycleId) {
+        if (linkType === 'investigation') {
+          return tableLink(
+            `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation?.id}/dataset`,
+            datasetData.investigation?.title
+          );
+        }
+        return tableLink(
+          `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}`,
+          datasetData.name
+        );
+      } else {
+        return datasetData.name;
+      }
+    },
+    [facilityCycles]
+  );
+
+  const genericLink = (
+    datasetData: Dataset,
+    linkType = 'dataset'
+  ): React.ReactElement => {
+    // generic link for parent investigation
+    if (linkType === 'investigation') {
+      return tableLink(
+        `/browse/investigation/${datasetData.investigation?.id}/dataset`,
+        datasetData.investigation?.title
+      );
+    }
+    // generic link for this dataset
+    return tableLink(
+      `/browse/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}/datafile`,
+      datasetData.name
+    );
+  };
+
+  const hierarchyLink = React.useMemo(() => {
+    if (hierarchy === 'dls') {
+      return dlsLink;
+    } else if (hierarchy === 'isis') {
+      return isisLink;
+    } else {
+      return genericLink;
+    }
+  }, [hierarchy, isisLink]);
 
   const selectedRows = React.useMemo(
     () =>
@@ -91,19 +187,6 @@ const DatasetSearchTable = (
         .map((cartItem) => cartItem.entityId),
     [cartItems, allIds]
   );
-
-  React.useEffect(() => {
-    clearTable();
-  }, [clearTable, luceneData]);
-
-  React.useEffect(() => {
-    fetchCount(luceneData);
-    fetchAllIds(luceneData);
-  }, [fetchCount, fetchData, fetchAllIds, filters, luceneData]);
-
-  React.useEffect(() => {
-    fetchData(luceneData, { startIndex: 0, stopIndex: 49 });
-  }, [fetchCount, fetchData, fetchAllIds, sort, filters, luceneData]);
 
   const textFilter = (label: string, dataKey: string): React.ReactElement => (
     <TextColumnFilter
@@ -122,6 +205,38 @@ const DatasetSearchTable = (
       }
     />
   );
+
+  const fetchFacilityCycles = React.useCallback(() => {
+    axios
+      .get(`${apiUrl}/facilitycycles`, {
+        headers: {
+          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
+        },
+      })
+      .then((response) => {
+        setFacilityCycles(response.data);
+      })
+      .catch((error) => {
+        handleICATError(error);
+      });
+  }, [apiUrl]);
+
+  React.useEffect(() => {
+    if (hierarchy === 'isis') fetchFacilityCycles();
+  }, [fetchFacilityCycles, hierarchy]);
+
+  React.useEffect(() => {
+    clearTable();
+  }, [clearTable, luceneData]);
+
+  React.useEffect(() => {
+    fetchCount(luceneData);
+    fetchAllIds(luceneData);
+  }, [fetchCount, fetchData, fetchAllIds, filters, luceneData]);
+
+  React.useEffect(() => {
+    fetchData(luceneData, { startIndex: 0, stopIndex: 49 });
+  }, [fetchCount, fetchData, fetchAllIds, sort, filters, luceneData]);
 
   return (
     <Table
@@ -152,12 +267,25 @@ const DatasetSearchTable = (
         {
           label: t('datasets.name'),
           dataKey: 'name',
+          cellContentRenderer: (cellProps: TableCellProps) => {
+            const datasetData = cellProps.rowData as Dataset;
+            return hierarchyLink(datasetData);
+          },
           filterComponent: textFilter,
         },
         {
           label: t('datasets.datafile_count'),
           dataKey: 'datafileCount',
           disableSort: true,
+        },
+        {
+          label: t('datasets.investigation'),
+          dataKey: 'investigation',
+          cellContentRenderer: (cellProps: TableCellProps) => {
+            const datasetData = cellProps.rowData as Dataset;
+            return hierarchyLink(datasetData, 'investigation');
+          },
+          filterComponent: textFilter,
         },
         {
           label: t('datasets.create_time'),
@@ -194,6 +322,10 @@ const mapDispatchToProps = (
             filterValue: JSON.stringify({
               id: { in: luceneData },
             }),
+          },
+          {
+            filterType: 'include',
+            filterValue: 'investigation',
           },
         ],
       })
@@ -237,6 +369,7 @@ const mapStateToProps = (state: StateType): DatasetTableStoreProps => {
     cartItems: state.dgcommon.cartItems,
     allIds: state.dgcommon.allIds,
     luceneData: state.dgsearch.searchData.dataset,
+    apiUrl: state.dgcommon.urls.apiUrl,
   };
 };
 

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -118,14 +118,14 @@ const DatasetSearchTable = (
         return linkType === 'investigation' ? '' : datasetData.name;
       }
 
-      if (datasetData.startDate && facilityCycles.length) {
+      if (facilityCycles.length && datasetData.investigation?.startDate) {
         const filteredFacilityCycles: FacilityCycle[] = facilityCycles.filter(
           (facilityCycle: FacilityCycle) =>
-            datasetData.startDate &&
+            datasetData.investigation?.startDate &&
             facilityCycle.startDate &&
             facilityCycle.endDate &&
-            datasetData.startDate >= facilityCycle.startDate &&
-            datasetData.startDate <= facilityCycle.endDate
+            datasetData.investigation.startDate >= facilityCycle.startDate &&
+            datasetData.investigation.startDate <= facilityCycle.endDate
         );
         if (filteredFacilityCycles.length) {
           facilityCycleId = filteredFacilityCycles[0].id;
@@ -323,7 +323,9 @@ const mapDispatchToProps = (
           },
           {
             filterType: 'include',
-            filterValue: '"investigation"',
+            filterValue: JSON.stringify({
+              investigation: { investigationInstruments: 'instrument' },
+            }),
           },
         ],
       })

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -159,7 +159,7 @@ const DatasetSearchTable = (
             datasetData.investigation.title
           )
         : tableLink(
-            `/browse/investigation/${datasetData.investigation?.id}/dataset/${datasetData.id}/datafile`,
+            `/browse/investigation/${datasetData.investigation.id}/dataset/${datasetData.id}/datafile`,
             datasetData.name
           );
     }
@@ -325,7 +325,7 @@ const mapDispatchToProps = (
           },
           {
             filterType: 'include',
-            filterValue: 'investigation',
+            filterValue: '"investigation"',
           },
         ],
       })

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -135,7 +135,7 @@ const DatasetSearchTable = (
       if (facilityCycleId) {
         return linkType === 'investigation'
           ? tableLink(
-              `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation.id}/dataset`,
+              `/browse/instrument/${instrumentId}/facilityCycle/${facilityCycleId}/investigation/${datasetData.investigation.id}`,
               datasetData.investigation.title
             )
           : tableLink(


### PR DESCRIPTION
## Description
This branch is based on and builds on [Make DataGateway work with API's ICAT backend](https://github.com/ral-facilities/datagateway/pull/663) and [Fixing slow search queries on bugfix/casing-json-fields-#94](https://github.com/ral-facilities/datagateway/pull/700) PRs. 

This finishes off the issue that was originally addressed by Patrick but not completed. Investigation search results in DataGateway currently provide a link to the investigation itself but datasets and datafiles do not. This fix ensures that they now do, regardless of the facility being used (ISIS, DLS or a generic link).

## Testing instructions
Use the ISIS dev URLs for testing as the code makes use of alternative casing when referring to fields. Perform some test search queries in DataGateway search (e.g. "test", "dog", etc.) and experiment with filtering by investigation, dataset and datafile. _All_ results should have a link in their first column (corresponding to their name or title) that should take the user to the appropriate place. For example, if the link is for a DLS investigation, the user should be navigated to `/browse/proposal/...` and if the link is for an ISIS investigation, the user should be navigated to `/browse/investigation/...`. Datafiles also have a column for parent dataset (with a link) and datasets have a column for parent investigation (also with a link).

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [ ] Check investigations link to investigation pages, datasets to dataset pages and datafiles to datafile pages
- [ ] Check that DLS results link to DLS pages and ISIS results link to ISIS pages
- [ ] Check the ID numbers in the constructed links tally with data received from ICAT

## Agile board tracking
Closes #566