### PR TITLE
#717 - use date-fns-tz to parse date strings with tz info

### DIFF
--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -12,7 +12,6 @@
     "@types/single-spa-react": "^3.0.1",
     "axios": "^0.21.1",
     "datagateway-common": "0.1.0",
-    "date-fns": "^2.17.0",
     "date-fns-tz": "^1.1.4",
     "i18next": "^19.9.0",
     "i18next-browser-languagedetector": "^6.0.0",
@@ -26,8 +25,8 @@
     "react-scripts": "4.0.3",
     "react-virtualized": "^9.22.3",
     "single-spa-react": "^4.1.0",
-    "typescript": "4.2.2",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "typescript": "4.2.2"
   },
   "devDependencies": {
     "@craco/craco": "^6.1.1",

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -12,6 +12,8 @@
     "@types/single-spa-react": "^3.0.1",
     "axios": "^0.21.1",
     "datagateway-common": "0.1.0",
+    "date-fns": "^2.17.0",
+    "date-fns-tz": "^1.1.4",
     "i18next": "^19.9.0",
     "i18next-browser-languagedetector": "^6.0.0",
     "i18next-http-backend": "^1.1.1",

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -12,6 +12,7 @@
     "@types/single-spa-react": "^3.0.1",
     "axios": "^0.21.1",
     "datagateway-common": "0.1.0",
+    "date-fns": "^2.17.0",
     "date-fns-tz": "^1.1.4",
     "i18next": "^19.9.0",
     "i18next-browser-languagedetector": "^6.0.0",
@@ -25,8 +26,8 @@
     "react-scripts": "4.0.3",
     "react-virtualized": "^9.22.3",
     "single-spa-react": "^4.1.0",
-    "tslib": "^2.1.0",
-    "typescript": "4.2.2"
+    "typescript": "4.2.2",
+    "tslib": "^2.1.0"
   },
   "devDependencies": {
     "@craco/craco": "^6.1.1",

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -91,7 +91,7 @@ describe('Admin Download Status Table', () => {
       userName: 'test user',
     },
     {
-      createdAt: '2020-03-01T15:57:28Z',
+      createdAt: '2020-03-01T15:57:28Z[UTC]',
       downloadItems: [{ entityId: 5, entityType: 'investigation', id: 5 }],
       email: 'test5@email.com',
       facilityName: 'LILS',

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -39,7 +39,8 @@ import {
 } from '@material-ui/icons';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import BlackTooltip from '../tooltip.component';
-import { toDate, format } from 'date-fns-tz';
+import { toDate } from 'date-fns-tz';
+import { format } from 'date-fns';
 
 const paperStyles = (theme: Theme): StyleRules =>
   createStyles({

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -39,8 +39,7 @@ import {
 } from '@material-ui/icons';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import BlackTooltip from '../tooltip.component';
-import { toDate } from 'date-fns-tz';
-import { format } from 'date-fns';
+import { toDate, format } from 'date-fns-tz';
 
 const paperStyles = (theme: Theme): StyleRules =>
   createStyles({

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -39,6 +39,8 @@ import {
 } from '@material-ui/icons';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import BlackTooltip from '../tooltip.component';
+import { toDate } from 'date-fns-tz';
+import { format } from 'date-fns';
 
 const paperStyles = (theme: Theme): StyleRules =>
   createStyles({
@@ -370,8 +372,8 @@ const AdminDownloadStatusTable: React.FC = () => {
                       dataKey: 'createdAt',
                       cellContentRenderer: (props: TableCellProps) => {
                         if (props.cellData) {
-                          const date = new Date(props.cellData).toISOString();
-                          return `${date.slice(0, 10)} ${date.slice(11, 19)}`;
+                          const date = toDate(props.cellData);
+                          return format(date, 'yyyy-MM-dd HH:mm:ss');
                         }
                       },
                       filterComponent: dateFilter,

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -106,7 +106,7 @@ describe('Download Status Table', () => {
       userName: 'test user',
     },
     {
-      createdAt: '2020-03-01T15:57:28Z',
+      createdAt: '2020-03-01T15:57:28Z[UTC]',
       downloadItems: [{ entityId: 5, entityType: 'investigation', id: 5 }],
       email: 'test5@email.com',
       facilityName: 'LILS',

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -15,7 +15,8 @@ import { RemoveCircle, GetApp } from '@material-ui/icons';
 import BlackTooltip from '../tooltip.component';
 import { DownloadSettingsContext } from '../ConfigProvider';
 import { useTranslation } from 'react-i18next';
-import { toDate, format } from 'date-fns-tz';
+import { toDate } from 'date-fns-tz';
+import { format } from 'date-fns';
 
 interface DownloadStatusTableProps {
   refreshTable: boolean;

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -15,6 +15,8 @@ import { RemoveCircle, GetApp } from '@material-ui/icons';
 import BlackTooltip from '../tooltip.component';
 import { DownloadSettingsContext } from '../ConfigProvider';
 import { useTranslation } from 'react-i18next';
+import { toDate } from 'date-fns-tz';
+import { format } from 'date-fns';
 
 interface DownloadStatusTableProps {
   refreshTable: boolean;
@@ -176,8 +178,8 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
             value.startDate
           ) {
             // Check that the given date is in the range specified by the filter.
-            const tableTimestamp = new Date(tableValue).getTime();
-            const startTimestamp = new Date(value.startDate).getTime();
+            const tableTimestamp = toDate(tableValue).getTime();
+            const startTimestamp = toDate(value.startDate).getTime();
             const endTimestamp = value.endDate
               ? new Date(`${value.endDate} 23:59:59`).getTime()
               : Date.now();
@@ -267,8 +269,8 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                 dataKey: 'createdAt',
                 cellContentRenderer: (props: TableCellProps) => {
                   if (props.cellData) {
-                    const date = new Date(props.cellData).toISOString();
-                    return `${date.slice(0, 10)} ${date.slice(11, 19)}`;
+                    const date = toDate(props.cellData);
+                    return format(date, 'yyyy-MM-dd HH:mm:ss');
                   }
                 },
                 filterComponent: dateFilter,

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -15,8 +15,7 @@ import { RemoveCircle, GetApp } from '@material-ui/icons';
 import BlackTooltip from '../tooltip.component';
 import { DownloadSettingsContext } from '../ConfigProvider';
 import { useTranslation } from 'react-i18next';
-import { toDate } from 'date-fns-tz';
-import { format } from 'date-fns';
+import { toDate, format } from 'date-fns-tz';
 
 interface DownloadStatusTableProps {
   refreshTable: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13207,7 +13207,7 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-router-dom@^5.0.1, react-router-dom@^5.2.0:
+react-router-dom@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
   integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5900,6 +5900,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns-tz@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.1.4.tgz#38282c2bfab08946a4e9bb89d733451e5525048b"
+  integrity sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13207,7 +13207,7 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-router-dom@^5.0.1:
+react-router-dom@^5.0.1, react-router-dom@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
   integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==


### PR DESCRIPTION
## Description
TopCAT can return strings with timezones on the end when run in Payara 5 so we need to be able to parse these otherwise we get an error. We use a library to help with parsing a string with a potential timezone at the end.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] You can compare ISIS prod and ISIS dev - if you go to `/download` and go into the download tab, ISIS dev should throw an error and ISIS prod should be fine
 
## Agile board tracking
Closes #717 
