### PR TITLE
#695 - add icatUrl option for lucene searches

### DIFF
--- a/packages/datagateway-common/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-common/src/state/actions/actions.types.tsx
@@ -253,6 +253,7 @@ export interface URLs {
   idsUrl: string;
   apiUrl: string;
   downloadApiUrl: string;
+  icatUrl: string;
 }
 
 export interface PluginRoute {

--- a/packages/datagateway-common/src/state/actions/lucene.test.tsx
+++ b/packages/datagateway-common/src/state/actions/lucene.test.tsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { dGCommonInitialState, StateType } from '../..';
 import handleICATError from '../../handleICATError';
 import { actions, resetActions, dispatch, getState } from '../../setupTests';
 import {
@@ -33,6 +34,15 @@ describe('Lucene actions', () => {
       startDate: null,
       endDate: null,
     };
+    const getState = (): Partial<StateType> => ({
+      dgcommon: {
+        ...dGCommonInitialState,
+        urls: {
+          ...dGCommonInitialState.urls,
+          icatUrl: 'https://example.com/icat',
+        },
+      },
+    });
     const asyncAction = fetchLuceneIds('Datafile', luceneSearchParams);
     await asyncAction(dispatch, getState, null);
 
@@ -48,9 +58,12 @@ describe('Lucene actions', () => {
       },
       maxCount: 300,
     };
-    expect(axios.get).toHaveBeenCalledWith('/icat/lucene/data', {
-      params: params,
-    });
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: params,
+      }
+    );
   });
 
   it('dispatches fetchLuceneIdsRequest and fetchLuceneIdsSuccess actions upon successful fetchLuceneIds action with arguments', async () => {
@@ -66,6 +79,15 @@ describe('Lucene actions', () => {
       endDate: new Date(2020, 11, 31),
       maxCount: 100,
     };
+    const getState = (): Partial<StateType> => ({
+      dgcommon: {
+        ...dGCommonInitialState,
+        urls: {
+          ...dGCommonInitialState.urls,
+          icatUrl: 'https://example.com/icat',
+        },
+      },
+    });
     const asyncAction = fetchLuceneIds('Datafile', luceneSearchParams);
     await asyncAction(dispatch, getState, null);
 
@@ -82,9 +104,12 @@ describe('Lucene actions', () => {
       },
       maxCount: 100,
     };
-    expect(axios.get).toHaveBeenCalledWith('/icat/lucene/data', {
-      params: params,
-    });
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: params,
+      }
+    );
   });
 
   it('dispatches fetchLuceneIdsRequest and fetchLuceneIdsFailure actions upon unsuccessful fetchLuceneIds action', async () => {

--- a/packages/datagateway-common/src/state/actions/lucene.tsx
+++ b/packages/datagateway-common/src/state/actions/lucene.tsx
@@ -74,13 +74,9 @@ export const fetchLuceneData = async (
   datasearchType: DatasearchType,
   params: LuceneSearchParams,
   settings: {
-    downloadApiUrl: string;
+    icatUrl: string;
   }
 ): Promise<number[]> => {
-  // Create ICAT url.
-  const splitUrl = settings.downloadApiUrl.split('/');
-  const icatUrl = `${splitUrl.slice(0, splitUrl.length - 1).join('/')}/icat`;
-
   // Query params.
   const queryParams = {
     sessionId: readSciGatewayToken().sessionId,
@@ -91,7 +87,7 @@ export const fetchLuceneData = async (
 
   let results = [];
   results = await axios
-    .get(`${icatUrl}/lucene/data`, {
+    .get(`${settings.icatUrl}/lucene/data`, {
       params: queryParams,
     })
     .then((response) => {
@@ -136,13 +132,13 @@ export const fetchLuceneIds = (
   params: LuceneSearchParams
 ): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
-    const { downloadApiUrl } = getState().dgcommon.urls;
+    const { icatUrl } = getState().dgcommon.urls;
 
     const timestamp = Date.now();
     dispatch(fetchLuceneIdsRequest(timestamp));
 
     await fetchLuceneData(datasearchType, params, {
-      downloadApiUrl,
+      icatUrl,
     })
       .then((results) => {
         dispatch(fetchLuceneIdsSuccess(results, timestamp));

--- a/packages/datagateway-common/src/state/reducers/dgcommon.reducer.tsx
+++ b/packages/datagateway-common/src/state/reducers/dgcommon.reducer.tsx
@@ -152,6 +152,7 @@ export const initialState: DGCommonState = {
     idsUrl: '',
     apiUrl: '',
     downloadApiUrl: '',
+    icatUrl: '',
   },
   cartItems: [],
   allIds: [],

--- a/packages/datagateway-dataview/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-dataview/src/state/actions/actions.test.tsx
@@ -133,6 +133,7 @@ describe('Actions', () => {
         idsUrl: 'ids',
         apiUrl: 'api',
         downloadApiUrl: 'download-api',
+        icatUrl: '',
       })
     );
     expect(actions).toContainEqual(
@@ -203,6 +204,7 @@ describe('Actions', () => {
         idsUrl: 'ids',
         apiUrl: 'api',
         downloadApiUrl: 'download-api',
+        icatUrl: '',
       })
     );
     expect(actions).toContainEqual(settingsLoaded());

--- a/packages/datagateway-dataview/src/state/actions/index.tsx
+++ b/packages/datagateway-dataview/src/state/actions/index.tsx
@@ -105,6 +105,7 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
               idsUrl: settings['idsUrl'],
               apiUrl: settings['apiUrl'],
               downloadApiUrl: settings['downloadApiUrl'],
+              icatUrl: '', // we currently don't need icatUrl in dataview so just pass empty string for now
             })
           );
         } else {

--- a/packages/datagateway-search/public/datagateway-search-settings.example.json
+++ b/packages/datagateway-search/public/datagateway-search-settings.example.json
@@ -3,6 +3,7 @@
   "idsUrl": "example.ids.url",
   "apiUrl": "example.api.url",
   "downloadApiUrl": "example.download.api.url",
+  "icatUrl": "example.icat.url",
   "helpSteps": [
     {
       "target": "#plugin-link--search-data",

--- a/packages/datagateway-search/server/e2e-settings.json
+++ b/packages/datagateway-search/server/e2e-settings.json
@@ -3,6 +3,7 @@
   "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
   "apiUrl": "http://scigateway-preprod.esc.rl.ac.uk:5000",
   "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",
+  "icatUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/icat",
   "helpSteps": [
     {
       "target": "#plugin-link--search-data",

--- a/packages/datagateway-search/src/search/searchButton.component.test.tsx
+++ b/packages/datagateway-search/src/search/searchButton.component.test.tsx
@@ -61,7 +61,7 @@ describe('Search Button component tests', () => {
         ...dGCommonInitialState,
         urls: {
           ...dGCommonInitialState.urls,
-          downloadApiUrl: 'https://scigateway-preprod.esc.rl.ac.uk:8181/topcat',
+          icatUrl: 'https://example.com/icat',
         },
       },
       dgsearch: dGSearchInitialState,
@@ -115,7 +115,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -160,7 +160,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -205,7 +205,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -243,7 +243,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -286,7 +286,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -329,7 +329,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -366,7 +366,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -409,7 +409,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -452,7 +452,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -481,7 +481,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -520,7 +520,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,
@@ -559,7 +559,7 @@ describe('Search Button component tests', () => {
       .find('button[aria-label="searchBox.search_button_arialabel"]')
       .simulate('click');
     expect(axios.get).toHaveBeenLastCalledWith(
-      'https://scigateway-preprod.esc.rl.ac.uk:8181/icat/lucene/data',
+      'https://example.com/icat/lucene/data',
       {
         params: {
           maxCount: 300,

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -41,6 +41,7 @@ describe('Actions', () => {
             idsUrl: 'ids',
             apiUrl: 'api',
             downloadApiUrl: 'download-api',
+            icatUrl: 'icat',
             routes: [
               {
                 section: 'section',
@@ -70,6 +71,7 @@ describe('Actions', () => {
         idsUrl: 'ids',
         apiUrl: 'api',
         downloadApiUrl: 'download-api',
+        icatUrl: 'icat',
       })
     );
 
@@ -172,6 +174,7 @@ describe('Actions', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
+          icatUrl: 'icat',
         },
       })
     );
@@ -201,7 +204,7 @@ describe('Actions', () => {
     expect(log.error).toHaveBeenCalled();
     const mockLog = (log.error as jest.Mock).mock;
     expect(mockLog.calls[0][0]).toEqual(
-      'Error loading /datagateway-search-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
+      'Error loading /datagateway-search-settings.json: One of the URL options (idsUrl, apiUrl, downloadApiUrl, icatUrl) is undefined in settings'
     );
   });
 
@@ -213,6 +216,7 @@ describe('Actions', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
+          icatUrl: 'icat',
         },
       })
     );
@@ -235,6 +239,7 @@ describe('Actions', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
+          icatUrl: 'icat',
           routes: [
             {
               section: 'section',

--- a/packages/datagateway-search/src/state/actions/actions.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.tsx
@@ -145,10 +145,10 @@ export const fetchLuceneInvestigations = (
   params: LuceneSearchParams
 ): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
-    const { downloadApiUrl } = getState().dgcommon.urls;
+    const { icatUrl } = getState().dgcommon.urls;
 
     await fetchLuceneData('Investigation', params, {
-      downloadApiUrl,
+      icatUrl,
     }).then((results) => {
       dispatch(storeInvestigationLucene(results));
       dispatch(toggleLuceneRequestReceived(true));
@@ -160,10 +160,10 @@ export const fetchLuceneDatasets = (
   params: LuceneSearchParams
 ): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
-    const { downloadApiUrl } = getState().dgcommon.urls;
+    const { icatUrl } = getState().dgcommon.urls;
 
     await fetchLuceneData('Dataset', params, {
-      downloadApiUrl,
+      icatUrl,
     }).then((results) => {
       dispatch(storeDatasetLucene(results));
       dispatch(toggleLuceneRequestReceived(true));
@@ -175,10 +175,10 @@ export const fetchLuceneDatafiles = (
   params: LuceneSearchParams
 ): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
-    const { downloadApiUrl } = getState().dgcommon.urls;
+    const { icatUrl } = getState().dgcommon.urls;
 
     await fetchLuceneData('Datafile', params, {
-      downloadApiUrl,
+      icatUrl,
     }).then((results) => {
       dispatch(storeDatafileLucene(results));
       dispatch(toggleLuceneRequestReceived(true));

--- a/packages/datagateway-search/src/state/actions/index.tsx
+++ b/packages/datagateway-search/src/state/actions/index.tsx
@@ -51,11 +51,12 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
               idsUrl: settings['idsUrl'],
               apiUrl: settings['apiUrl'],
               downloadApiUrl: settings['downloadApiUrl'],
+              icatUrl: settings['icatUrl'],
             })
           );
         } else {
           throw new Error(
-            'One of the URL options (idsUrl, apiUrl, downloadApiUrl) is undefined in settings'
+            'One of the URL options (idsUrl, apiUrl, downloadApiUrl, icatUrl) is undefined in settings'
           );
         }
 
@@ -105,13 +106,9 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
         /* istanbul ignore if */
         if (process.env.NODE_ENV === `development`) {
           const apiUrl = settings.apiUrl;
-          const splitUrl = settings.downloadApiUrl.split('/');
-          const icatUrl = `${splitUrl
-            .slice(0, splitUrl.length - 1)
-            .join('/')}/icat`;
           axios
             .post(
-              `${icatUrl}/session`,
+              `${settings.icatUrl}/session`,
               `json=${JSON.stringify({
                 plugin: 'simple',
                 credentials: [{ username: 'root' }, { password: 'pw' }],


### PR DESCRIPTION
## Description
Previously, the ICAT url was "inferred" from the TopCAT url (using the assumption that TopCAT and ICAT run on the same machine). This assumption is incorrect and so a separate `icatUrl` option is needed. I made it so the URL is required, but that datagateway-dataview just passes a string since it doesn't require it and added a comment saying this.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Specifying an `icatUrl` changes where the lucene requests go to

## Agile board tracking
Fixes #695 
