### PR TITLE
Disabling column header wrapping #722

### DIFF
--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`Data column header component renders correctly with filter but no sort 
   >
     <Styled(MuiBox)
       display="flex"
-      flexWrap="wrap"
     >
       <Styled(MuiBox)
         marginRight={1}
@@ -111,7 +110,6 @@ exports[`Data column header component renders correctly with sort and filter 1`]
   >
     <Styled(MuiBox)
       display="flex"
-      flexWrap="wrap"
     >
       <Styled(MuiBox)
         marginRight={1}
@@ -205,7 +203,6 @@ exports[`Data column header component renders correctly with sort but no filter 
   >
     <Styled(MuiBox)
       display="flex"
-      flexWrap="wrap"
     >
       <Styled(MuiBox)
         marginRight={1}
@@ -295,7 +292,6 @@ exports[`Data column header component renders correctly without sort or filter 1
   >
     <Styled(MuiBox)
       display="flex"
-      flexWrap="wrap"
     >
       <Styled(MuiBox)
         marginRight={1}

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -19,7 +19,6 @@ const DataHeader = (
     resizeColumn: (deltaX: number) => void;
     icon?: JSX.Element;
     filterComponent?: React.ReactElement;
-    disableHeaderWrap?: boolean;
   }
 ): React.ReactElement => {
   const {
@@ -32,7 +31,6 @@ const DataHeader = (
     resizeColumn,
     icon,
     filterComponent,
-    disableHeaderWrap,
   } = props;
 
   const currSortDirection = sort[dataKey];
@@ -80,7 +78,7 @@ const DataHeader = (
           flex: 1,
         }}
       >
-        <Box display="flex" flexWrap={disableHeaderWrap ? 'nowrap' : 'wrap'}>
+        <Box display="flex">
           <Box marginRight={1}>{icon}</Box>
           <Box>{inner}</Box>
         </Box>

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -76,7 +76,6 @@ export interface ColumnType {
   className?: string;
   disableSort?: boolean;
   filterComponent?: (label: string, dataKey: string) => React.ReactElement;
-  disableHeaderWrap?: boolean;
 }
 
 export interface DetailsPanelProps {
@@ -346,7 +345,6 @@ const VirtualizedTable = (
                     icon,
                     filterComponent,
                     disableSort,
-                    disableHeaderWrap,
                   }) => {
                     return (
                       <Column
@@ -381,7 +379,6 @@ const VirtualizedTable = (
                                 [dataKey]: thisColumn,
                               });
                             }}
-                            disableHeaderWrap={disableHeaderWrap}
                           />
                         )}
                         className={clsx(classes.flexContainer, className)}

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`Datafile table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "MOD_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datafiles.modified_time",

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
@@ -177,14 +177,12 @@ exports[`Dataset table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "CREATE_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datasets.create_time",
       },
       Object {
         "dataKey": "MOD_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datasets.modified_time",

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -50,7 +50,6 @@ exports[`Investigation table component renders correctly 1`] = `
       Object {
         "cellContentRenderer": [Function],
         "dataKey": "STARTDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.start_date",
@@ -58,7 +57,6 @@ exports[`Investigation table component renders correctly 1`] = `
       Object {
         "cellContentRenderer": [Function],
         "dataKey": "ENDDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.end_date",

--- a/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
@@ -248,7 +248,6 @@ const DatafileTable = (
           label: t('datafiles.modified_time'),
           dataKey: 'MOD_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
@@ -218,14 +218,12 @@ const DatasetTable = (props: DatasetTableCombinedProps): React.ReactElement => {
           label: t('datasets.create_time'),
           dataKey: 'CREATE_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
           label: t('datasets.modified_time'),
           dataKey: 'MOD_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatafilesTable.component.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`DLS datafiles table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "CREATE_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datafiles.create_time",

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
@@ -177,14 +177,12 @@ exports[`DLS Dataset table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "CREATE_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datasets.create_time",
       },
       Object {
         "dataKey": "MOD_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datasets.modified_time",

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsMyDataTable.component.test.tsx.snap
@@ -33,14 +33,12 @@ exports[`DLS Visits table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "STARTDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.start_date",
       },
       Object {
         "dataKey": "ENDDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.end_date",

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsVisitsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsVisitsTable.component.test.tsx.snap
@@ -26,14 +26,12 @@ exports[`DLS Visits table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "STARTDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.start_date",
       },
       Object {
         "dataKey": "ENDDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.end_date",

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -222,7 +222,6 @@ const DLSDatafilesTable = (
           label: t('datafiles.create_time'),
           dataKey: 'CREATE_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -186,7 +186,6 @@ const DLSDatasetsTable = (
           label: t('datasets.create_time'),
           dataKey: 'CREATE_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
@@ -194,7 +193,6 @@ const DLSDatasetsTable = (
           label: t('datasets.modified_time'),
           dataKey: 'MOD_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -216,7 +216,6 @@ const DLSMyDataTable = (
           label: t('investigations.start_date'),
           dataKey: 'STARTDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
@@ -224,7 +223,6 @@ const DLSMyDataTable = (
           label: t('investigations.end_date'),
           dataKey: 'ENDDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
@@ -174,14 +174,12 @@ const DLSVisitsTable = (
           label: t('investigations.start_date'),
           dataKey: 'STARTDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
           label: t('investigations.end_date'),
           dataKey: 'ENDDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -260,7 +260,6 @@ const InvestigationTable = (
               return cellProps.cellData.toString().split(' ')[0];
             }
           },
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
@@ -272,7 +271,6 @@ const InvestigationTable = (
               return cellProps.cellData.toString().split(' ')[0];
             }
           },
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`ISIS datafiles table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "MOD_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datafiles.modified_time",

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
@@ -30,14 +30,12 @@ exports[`ISIS Dataset table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "CREATE_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datasets.create_time",
       },
       Object {
         "dataKey": "MOD_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "datasets.modified_time",

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
@@ -19,14 +19,12 @@ exports[`ISIS FacilityCycles table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "STARTDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "facilitycycles.start_date",
       },
       Object {
         "dataKey": "ENDDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "facilitycycles.end_date",

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -53,14 +53,12 @@ exports[`ISIS Investigations table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "STARTDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.start_date",
       },
       Object {
         "dataKey": "ENDDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.end_date",

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
@@ -52,14 +52,12 @@ exports[`ISIS Investigations table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "STARTDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.start_date",
       },
       Object {
         "dataKey": "ENDDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.end_date",

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -208,7 +208,6 @@ const ISISDatafilesTable = (
           label: t('datafiles.modified_time'),
           dataKey: 'MOD_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -225,14 +225,12 @@ const ISISDatasetsTable = (
           label: t('datasets.create_time'),
           dataKey: 'CREATE_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
           label: t('datasets.modified_time'),
           dataKey: 'MOD_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -135,14 +135,12 @@ const ISISFacilityCyclesTable = (
           label: t('facilitycycles.start_date'),
           dataKey: 'STARTDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
           label: t('facilitycycles.end_date'),
           dataKey: 'ENDDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -298,7 +298,6 @@ const ISISInvestigationsTable = (
           label: t('investigations.start_date'),
           dataKey: 'STARTDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
@@ -306,7 +305,6 @@ const ISISInvestigationsTable = (
           label: t('investigations.end_date'),
           dataKey: 'ENDDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -312,14 +312,12 @@ const ISISMyDataTable = (
           label: t('investigations.start_date'),
           dataKey: 'STARTDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           icon: <CalendarTodayIcon />,
           label: t('investigations.end_date'),
           dataKey: 'ENDDATE',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -121,7 +121,6 @@ exports[`Admin Download Status Table renders correctly 1`] = `
                   Object {
                     "cellContentRenderer": [Function],
                     "dataKey": "createdAt",
-                    "disableHeaderWrap": true,
                     "filterComponent": [Function],
                     "label": "downloadStatus.createdAt",
                   },

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`Download Status Table renders correctly 1`] = `
             Object {
               "cellContentRenderer": [Function],
               "dataKey": "createdAt",
-              "disableHeaderWrap": true,
               "filterComponent": [Function],
               "label": "downloadStatus.createdAt",
             },

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -375,7 +375,6 @@ const AdminDownloadStatusTable: React.FC = () => {
                         }
                       },
                       filterComponent: dateFilter,
-                      disableHeaderWrap: true,
                     },
                     {
                       label: t('downloadStatus.deleted'),

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -272,7 +272,6 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                   }
                 },
                 filterComponent: dateFilter,
-                disableHeaderWrap: true,
               },
             ]}
             sort={sort}

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`Datafile search table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "MOD_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "label": "datafiles.modified_time",
       },

--- a/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
@@ -23,13 +23,11 @@ exports[`Dataset table component renders correctly 1`] = `
       },
       Object {
         "dataKey": "CREATE_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "label": "datasets.create_time",
       },
       Object {
         "dataKey": "MOD_TIME",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "label": "datasets.modified_time",
       },

--- a/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
@@ -44,14 +44,12 @@ exports[`Investigation Search Table component renders correctly 1`] = `
       Object {
         "cellContentRenderer": [Function],
         "dataKey": "STARTDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "label": "investigations.start_date",
       },
       Object {
         "cellContentRenderer": [Function],
         "dataKey": "ENDDATE",
-        "disableHeaderWrap": true,
         "filterComponent": [Function],
         "label": "investigations.end_date",
       },

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
@@ -177,7 +177,6 @@ const DatafileSearchTable = (
           label: t('datafiles.modified_time'),
           dataKey: 'MOD_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -163,13 +163,11 @@ const DatasetSearchTable = (
           label: t('datasets.create_time'),
           dataKey: 'CREATE_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
         {
           label: t('datasets.modified_time'),
           dataKey: 'MOD_TIME',
           filterComponent: dateFilter,
-          disableHeaderWrap: true,
         },
       ]}
     />

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.tsx
@@ -273,7 +273,6 @@ const InvestigationSearchTable = (
               return cellProps.cellData.toString().split(' ')[0];
             }
           },
-          disableHeaderWrap: true,
         },
         {
           label: t('investigations.end_date'),
@@ -284,7 +283,6 @@ const InvestigationSearchTable = (
               return cellProps.cellData.toString().split(' ')[0];
             }
           },
-          disableHeaderWrap: true,
         },
       ]}
     />


### PR DESCRIPTION
## Description
This makes wrapping behaviour of table column headers consistent. Previously, any header that wasn't a date wrapped onto 3 rows when its column width was shrunk. This changes tables so that no wrapping occurs for any columns anymore.

## Testing instructions
Navigate to a page which contains a tabular view of results, e.g. `/browse/investigation?view=table`. Compare [SciGateway pre-prod](https://scigateway-preprod.esc.rl.ac.uk/browse/investigation?view=table) and this version.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Resize columns in various pages to ensure text and dates aren't being wrapped (so shrinking their width to less than the length of the word hides part of the word rather than moving the word to the line below)
- [x] Test this across dataview, download, search and the admin download table

## Agile board tracking
Closes #722