### PR TITLE
Add ID and Fullname Columns to Admin Download Table

### DIFF
--- a/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
@@ -116,13 +116,19 @@ describe('Admin Download Status', () => {
     });
 
     it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Username').click();
       cy.get('.react-draggable')
         .eq(4)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 600 })
+        .trigger('mousemove', { clientX: 550 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Access Method').click();
+
+      cy.get('.react-draggable')
+        .eq(2)
+        .trigger('mousedown')
+        .trigger('mousemove', { clientX: 400 })
+        .trigger('mouseup');
+      cy.contains('[role="button"]', 'Username').click();
 
       cy.get('[aria-rowindex="1"] [aria-colindex="5"]').should(
         'have.text',

--- a/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
@@ -38,7 +38,7 @@ describe('Admin Download Status', () => {
 
     // Typical `.should('match'...)`  doesn't work for text, tries to match the element,
     // hence a slightly different approach for doing regex on the actual text
-    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').find('p').should(($preparedId) => {
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').find('p').should(($preparedId) => {
       expect($preparedId[0].textContent).match(
         /[0-9a-zA-Z]{8}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{12}/
       );
@@ -46,7 +46,7 @@ describe('Admin Download Status', () => {
 
     cy.get('[aria-label="Refresh download status table"]').click();
 
-    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').find('p').should(($preparedId) => {
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').find('p').should(($preparedId) => {
       expect($preparedId[0].textContent).match(
         /[0-9a-zA-Z]{8}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{12}/
       );
@@ -56,15 +56,15 @@ describe('Admin Download Status', () => {
   describe('should be able to sort download items by', () => {
     it('ascending order', () => {
       cy.get('.react-draggable')
-        .eq(1)
+        .eq(3)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 300 })
+        .trigger('mousemove', { clientX: 500 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Prepared ID').click();
 
       cy.get('[aria-sort="ascending"]').should('exist');
       cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').find('p').should(($preparedId) => {
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').find('p').should(($preparedId) => {
         expect($preparedId[0].textContent).match(
           /[0-9a-zA-Z]{8}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{12}/
         );
@@ -73,9 +73,9 @@ describe('Admin Download Status', () => {
 
     it('descending order', () => {
       cy.get('.react-draggable')
-        .eq(1)
+        .eq(3)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 300 })
+        .trigger('mousemove', { clientX: 500 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Prepared ID').click();
       cy.contains('[role="button"]', 'Prepared ID').click();
@@ -86,7 +86,7 @@ describe('Admin Download Status', () => {
         'opacity',
         '0'
       );
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').find('p').should(($preparedId) => {
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').find('p').should(($preparedId) => {
         expect($preparedId[0].textContent).match(
           /[0-9a-zA-Z]{8}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{12}/
         );
@@ -95,9 +95,9 @@ describe('Admin Download Status', () => {
 
     it('no order', () => {
       cy.get('.react-draggable')
-        .eq(1)
+        .eq(3)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 300 })
+        .trigger('mousemove', { clientX: 500 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Prepared ID').click();
       cy.contains('[role="button"]', 'Prepared ID').click();
@@ -110,7 +110,7 @@ describe('Admin Download Status', () => {
         'opacity',
         '0'
       );
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').find('p').should(($preparedId) => {
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').find('p').should(($preparedId) => {
         expect($preparedId[0].textContent).match(
           /[0-9a-zA-Z]{8}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{12}/
         );
@@ -119,9 +119,9 @@ describe('Admin Download Status', () => {
 
     it('multiple columns', () => {
       cy.contains('[role="button"]', 'Username').click();
-      cy.contains('[role="button"]', 'Prepared ID').click();
+      cy.contains('[role="button"]', 'Prepared ID').click({ force: true });
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').find('p').should(($preparedId) => {
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').find('p').should(($preparedId) => {
         expect($preparedId[0].textContent).match(
           /[0-9a-zA-Z]{8}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{12}/
         );
@@ -134,9 +134,9 @@ describe('Admin Download Status', () => {
       cy.get('[aria-label="Filter by Availability"]')
         .find('input')
         .first()
-        .type('Available');
+        .type('Available', { force: true });
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
+      cy.get('[aria-rowindex="1"] [aria-colindex="6"]').should(
         'have.text',
         'Available'
       );
@@ -150,13 +150,13 @@ describe('Admin Download Status', () => {
       cy.get('[aria-label="Filter by Access Method')
         .find('input')
         .first()
-        .type('globus');
+        .type('globus', { force: true });
       cy.get('[aria-label="Filter by Availability"]')
         .find('input')
         .first()
-        .type('restoring');
+        .type('restoring', { force: true });
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').find('p').should(($preparedId) => {
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').find('p').should(($preparedId) => {
         expect($preparedId[0].textContent).match(
           /[0-9a-zA-Z]{8}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{4}\-[0-9a-zA-Z]{12}/
         );

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -12,7 +12,9 @@
     "refreshing_downloads": "Refreshing downloads..."
   },
   "downloadStatus": {
+    "id": "ID",
     "filename": "Download Name",
+    "fullname": "Full Name",
     "username": "Username",
     "preparedId": "Prepared ID",
     "transport": "Access Method",

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -93,6 +93,16 @@ exports[`Admin Download Status Table renders correctly 1`] = `
               columns={
                 Array [
                   Object {
+                    "dataKey": "id",
+                    "filterComponent": [Function],
+                    "label": "downloadStatus.id",
+                  },
+                  Object {
+                    "dataKey": "fullName",
+                    "filterComponent": [Function],
+                    "label": "downloadStatus.fullname",
+                  },
+                  Object {
                     "dataKey": "userName",
                     "filterComponent": [Function],
                     "label": "downloadStatus.username",

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -172,19 +172,19 @@ describe('Admin Download Status Table', () => {
     });
 
     expect(
-      wrapper.find('[aria-rowindex=1]').find('[aria-colindex=4]').text()
+      wrapper.find('[aria-rowindex=1]').find('[aria-colindex=6]').text()
     ).toEqual('downloadStatus.complete');
     expect(
-      wrapper.find('[aria-rowindex=2]').find('[aria-colindex=4]').text()
+      wrapper.find('[aria-rowindex=2]').find('[aria-colindex=6]').text()
     ).toEqual('downloadStatus.preparing');
     expect(
-      wrapper.find('[aria-rowindex=3]').find('[aria-colindex=4]').text()
+      wrapper.find('[aria-rowindex=3]').find('[aria-colindex=6]').text()
     ).toEqual('downloadStatus.restoring');
     expect(
-      wrapper.find('[aria-rowindex=4]').find('[aria-colindex=4]').text()
+      wrapper.find('[aria-rowindex=4]').find('[aria-colindex=6]').text()
     ).toEqual('downloadStatus.expired');
     expect(
-      wrapper.find('[aria-rowindex=5]').find('[aria-colindex=4]').text()
+      wrapper.find('[aria-rowindex=5]').find('[aria-colindex=6]').text()
     ).toEqual('downloadStatus.paused');
   });
 
@@ -233,7 +233,7 @@ describe('Admin Download Status Table', () => {
     // Get the Username sort header
     const usernameSortLabel = wrapper
       .find('[role="columnheader"] span[role="button"]')
-      .at(0);
+      .at(2);
     await act(async () => {
       usernameSortLabel.simulate('click');
       await flushPromises();
@@ -259,7 +259,7 @@ describe('Admin Download Status Table', () => {
     // Get the Access Method sort header.
     const accessMethodSortLabel = wrapper
       .find('[role="columnheader"] span[role="button"]')
-      .at(2);
+      .at(4);
     await act(async () => {
       accessMethodSortLabel.simulate('click');
       await flushPromises();
@@ -377,7 +377,7 @@ describe('Admin Download Status Table', () => {
     );
 
     // We simulate a change in the select from 'include' to 'exclude'.
-    const availabilityFilterSelect = wrapper.find(Select).at(3);
+    const availabilityFilterSelect = wrapper.find(Select).at(5);
     await act(async () => {
       availabilityFilterSelect
         .props()

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -338,6 +338,16 @@ const AdminDownloadStatusTable: React.FC = () => {
                 <Table
                   columns={[
                     {
+                      label: t('downloadStatus.id'),
+                      dataKey: 'id',
+                      filterComponent: textFilter,
+                    },
+                    {
+                      label: t('downloadStatus.fullname'),
+                      dataKey: 'fullName',
+                      filterComponent: textFilter,
+                    },
+                    {
                       label: t('downloadStatus.username'),
                       dataKey: 'userName',
                       filterComponent: textFilter,


### PR DESCRIPTION
## Description
This PR adds two columns to the admin download table, as specified in the original. I've added relevant JSON in `default.json`. In that file, I've specified the text to be "Full Name". I'm not sure if it should be one word or two, so this should probably be confirmed. 

I've also fixed the tests where they've broken due to the added columns. 

I've made these changes off my e2e test fixing branch (which is off my JSON casing branch). I've recently fixed the admin download tests on these set of branches so I just thought it made sense to come off this branch to reduce future merge conflicts. Since the CI for e2e tests won't work until the JSON casing stuff gets merged, here's the e2e tests passing on my machine:

![image](https://user-images.githubusercontent.com/32678030/123431877-a9da6a00-d5c1-11eb-8161-b169679e772d.png)

## Testing instructions
I guess just check the new columns display data which we expect and that they sort/filter as they should.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Confirm whether full name should be one or two words in `default.json`

## Agile board tracking
connect to #708 
