### PR TITLE
Preventing 'null' from displaying in descriptions and summaries

### DIFF
--- a/packages/datagateway-common/src/card/entityCard.component.tsx
+++ b/packages/datagateway-common/src/card/entityCard.component.tsx
@@ -273,7 +273,7 @@ const EntityCard = (props: EntityCardProps): React.ReactElement => {
                     variant="body1"
                     paragraph
                   >
-                    {description
+                    {description && description !== 'null'
                       ? description
                       : t('entity_card.no_description')}
                   </Typography>

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -187,7 +187,7 @@
     }
   },
   "entity_card": {
-    "no_description": "Description not provided",
+    "no_description": "No description available",
     "show_more": "Show more",
     "show_less": "Show less"
   },

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -187,7 +187,7 @@
     }
   },
   "entity_card": {
-    "no_description": "No description available",
+    "no_description": "Description not provided",
     "show_more": "Show more",
     "show_less": "Show less"
   },

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -59,7 +59,9 @@ exports[`Dataset details panel component renders calculate size button when size
           datasets.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -175,7 +177,9 @@ exports[`Dataset details panel component renders correctly 1`] = `
           datasets.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -297,7 +301,9 @@ exports[`Dataset details panel component renders type tab when present in the da
           datasets.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Dataset details panel component Shows "No description provided" instead
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            datasets.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -74,7 +74,9 @@ exports[`Dataset details panel component Shows "No description provided" instead
           datasets.details.start_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.start_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -87,7 +89,9 @@ exports[`Dataset details panel component Shows "No description provided" instead
           datasets.details.end_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.end_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -192,7 +196,9 @@ exports[`Dataset details panel component renders calculate size button when size
           datasets.details.start_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.start_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -205,7 +211,9 @@ exports[`Dataset details panel component renders calculate size button when size
           datasets.details.end_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.end_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -310,7 +318,9 @@ exports[`Dataset details panel component renders correctly 1`] = `
           datasets.details.start_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.start_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -323,7 +333,9 @@ exports[`Dataset details panel component renders correctly 1`] = `
           datasets.details.end_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.end_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -434,7 +446,9 @@ exports[`Dataset details panel component renders type tab when present in the da
           datasets.details.start_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.start_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -447,7 +461,9 @@ exports[`Dataset details panel component renders type tab when present in the da
           datasets.details.end_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.end_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dataset details panel component renders calculate size button when size has not been calculated 1`] = `
+exports[`Dataset details panel component Shows "No description provided" instead of a null field 1`] = `
 <div
   id="details-panel"
   style={
@@ -118,6 +118,124 @@ exports[`Dataset details panel component renders calculate size button when size
 </div>
 `;
 
+exports[`Dataset details panel component renders calculate size button when size has not been calculated 1`] = `
+<div
+  id="details-panel"
+  style={
+    Object {
+      "minWidth": 0,
+    }
+  }
+>
+  <WithStyles(ForwardRef(Tabs))
+    aria-label="datasets.details.tabs_label"
+    onChange={[Function]}
+    scrollButtons="auto"
+    value="details"
+    variant="scrollable"
+  >
+    <WithStyles(ForwardRef(Tab))
+      aria-controls="dataset-details-panel"
+      id="dataset-details-tab"
+      label="datasets.details.label"
+      value="details"
+    />
+  </WithStyles(ForwardRef(Tabs))>
+  <div
+    aria-labelledby="dataset-details-tab"
+    hidden={false}
+    id="dataset-details-panel"
+    role="tabpanel"
+  >
+    <WithStyles(ForwardRef(Grid))
+      className="makeStyles-root-1"
+      container={true}
+      direction="column"
+    >
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="h6"
+        >
+          <b>
+            Test 1
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Divider))
+          className="makeStyles-divider-2"
+        />
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.description
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            Test description
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.start_date
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b />
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.end_date
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b />
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.size
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            <WithStyles(ForwardRef(Button))
+              color="secondary"
+              id="calculate-size-btn"
+              onClick={[Function]}
+              size="small"
+              variant="outlined"
+            >
+              datasets.details.calculate
+            </WithStyles(ForwardRef(Button))>
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(Grid))>
+  </div>
+</div>
+`;
+
 exports[`Dataset details panel component renders correctly 1`] = `
 <div
   id="details-panel"
@@ -178,7 +296,7 @@ exports[`Dataset details panel component renders correctly 1`] = `
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -302,7 +420,7 @@ exports[`Dataset details panel component renders type tab when present in the da
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dataset details panel component Shows "No description provided" instead of a null field 1`] = `
+exports[`Dataset details panel component Shows "No <field> provided" incase of a null field 1`] = `
 <div
   id="details-panel"
   style={
@@ -144,127 +144,11 @@ exports[`Dataset details panel component renders calculate size button when size
       label="datasets.details.label"
       value="details"
     />
-  </WithStyles(ForwardRef(Tabs))>
-  <div
-    aria-labelledby="dataset-details-tab"
-    hidden={false}
-    id="dataset-details-panel"
-    role="tabpanel"
-  >
-    <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-1"
-      container={true}
-      direction="column"
-    >
-      <WithStyles(ForwardRef(Grid))
-        item={true}
-        xs={true}
-      >
-        <WithStyles(ForwardRef(Typography))
-          variant="h6"
-        >
-          <b>
-            Test 1
-          </b>
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-2"
-        />
-      </WithStyles(ForwardRef(Grid))>
-      <WithStyles(ForwardRef(Grid))
-        item={true}
-        xs={true}
-      >
-        <WithStyles(ForwardRef(Typography))
-          variant="overline"
-        >
-          datasets.details.description
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))>
-          <b>
-            Test description
-          </b>
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Grid))>
-      <WithStyles(ForwardRef(Grid))
-        item={true}
-        xs={true}
-      >
-        <WithStyles(ForwardRef(Typography))
-          variant="overline"
-        >
-          datasets.details.start_date
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))>
-          <b>
-            datasets.details.start_date not provided
-          </b>
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Grid))>
-      <WithStyles(ForwardRef(Grid))
-        item={true}
-        xs={true}
-      >
-        <WithStyles(ForwardRef(Typography))
-          variant="overline"
-        >
-          datasets.details.end_date
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))>
-          <b>
-            datasets.details.end_date not provided
-          </b>
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Grid))>
-      <WithStyles(ForwardRef(Grid))
-        item={true}
-        xs={true}
-      >
-        <WithStyles(ForwardRef(Typography))
-          variant="overline"
-        >
-          datasets.details.size
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))>
-          <b>
-            <WithStyles(ForwardRef(Button))
-              color="secondary"
-              id="calculate-size-btn"
-              onClick={[Function]}
-              size="small"
-              variant="outlined"
-            >
-              datasets.details.calculate
-            </WithStyles(ForwardRef(Button))>
-          </b>
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Grid))>
-    </WithStyles(ForwardRef(Grid))>
-  </div>
-</div>
-`;
-
-exports[`Dataset details panel component renders correctly 1`] = `
-<div
-  id="details-panel"
-  style={
-    Object {
-      "minWidth": 0,
-    }
-  }
->
-  <WithStyles(ForwardRef(Tabs))
-    aria-label="datasets.details.tabs_label"
-    onChange={[Function]}
-    scrollButtons="auto"
-    value="details"
-    variant="scrollable"
-  >
     <WithStyles(ForwardRef(Tab))
-      aria-controls="dataset-details-panel"
-      id="dataset-details-tab"
-      label="datasets.details.label"
-      value="details"
+      aria-controls="dataset-type-panel"
+      id="dataset-type-tab"
+      label="datasets.details.type.label"
+      value="type"
     />
   </WithStyles(ForwardRef(Tabs))>
   <div
@@ -319,7 +203,7 @@ exports[`Dataset details panel component renders correctly 1`] = `
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            datasets.details.start_date not provided
+            2019-06-11
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -334,7 +218,7 @@ exports[`Dataset details panel component renders correctly 1`] = `
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            datasets.details.end_date not provided
+            2019-06-12
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -358,6 +242,220 @@ exports[`Dataset details panel component renders correctly 1`] = `
             >
               datasets.details.calculate
             </WithStyles(ForwardRef(Button))>
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(Grid))>
+  </div>
+  <div
+    aria-labelledby="dataset-type-tab"
+    hidden={true}
+    id="dataset-type-panel"
+    role="tabpanel"
+  >
+    <WithStyles(ForwardRef(Grid))
+      className="makeStyles-root-1"
+      container={true}
+      direction="column"
+    >
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="h6"
+        >
+          <b>
+            Test 2
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Divider))
+          className="makeStyles-divider-2"
+        />
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.type.description
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            datasets.details.type.description not provided
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(Grid))>
+  </div>
+</div>
+`;
+
+exports[`Dataset details panel component renders correctly 1`] = `
+<div
+  id="details-panel"
+  style={
+    Object {
+      "minWidth": 0,
+    }
+  }
+>
+  <WithStyles(ForwardRef(Tabs))
+    aria-label="datasets.details.tabs_label"
+    onChange={[Function]}
+    scrollButtons="auto"
+    value="details"
+    variant="scrollable"
+  >
+    <WithStyles(ForwardRef(Tab))
+      aria-controls="dataset-details-panel"
+      id="dataset-details-tab"
+      label="datasets.details.label"
+      value="details"
+    />
+    <WithStyles(ForwardRef(Tab))
+      aria-controls="dataset-type-panel"
+      id="dataset-type-tab"
+      label="datasets.details.type.label"
+      value="type"
+    />
+  </WithStyles(ForwardRef(Tabs))>
+  <div
+    aria-labelledby="dataset-details-tab"
+    hidden={false}
+    id="dataset-details-panel"
+    role="tabpanel"
+  >
+    <WithStyles(ForwardRef(Grid))
+      className="makeStyles-root-1"
+      container={true}
+      direction="column"
+    >
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="h6"
+        >
+          <b>
+            Test 1
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Divider))
+          className="makeStyles-divider-2"
+        />
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.description
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            Test description
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.start_date
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            2019-06-11
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.end_date
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            2019-06-12
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.size
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            <WithStyles(ForwardRef(Button))
+              color="secondary"
+              id="calculate-size-btn"
+              onClick={[Function]}
+              size="small"
+              variant="outlined"
+            >
+              datasets.details.calculate
+            </WithStyles(ForwardRef(Button))>
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(Grid))>
+  </div>
+  <div
+    aria-labelledby="dataset-type-tab"
+    hidden={true}
+    id="dataset-type-panel"
+    role="tabpanel"
+  >
+    <WithStyles(ForwardRef(Grid))
+      className="makeStyles-root-1"
+      container={true}
+      direction="column"
+    >
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="h6"
+        >
+          <b>
+            Test 2
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Divider))
+          className="makeStyles-divider-2"
+        />
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.type.description
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            datasets.details.type.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -447,7 +545,7 @@ exports[`Dataset details panel component renders type tab when present in the da
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            datasets.details.start_date not provided
+            2019-06-11
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -462,7 +560,7 @@ exports[`Dataset details panel component renders type tab when present in the da
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            datasets.details.end_date not provided
+            2019-06-12
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.test.tsx
@@ -19,6 +19,7 @@ describe('Dataset details panel component', () => {
       name: 'Test 1',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
+      description: 'Test description',
     };
   });
 
@@ -147,5 +148,24 @@ describe('Dataset details panel component', () => {
 
     expect(fetchDetails).toHaveBeenCalled();
     expect(fetchDetails).toHaveBeenCalledWith(1);
+  });
+
+  it('Shows "No description provided" instead of a null field', () => {
+    rowData = {
+      id: 1,
+      name: 'Test 1',
+      modTime: '2019-06-10',
+      createTime: '2019-06-11',
+    };
+
+    const wrapper = shallow(
+      <DatasetDetailsPanel
+        rowData={rowData}
+        detailsPanelResize={detailsPanelResize}
+        fetchDetails={fetchDetails}
+        fetchSize={fetchSize}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import DatasetDetailsPanel from './datasetDetailsPanel.component';
-import { Dataset } from 'datagateway-common';
+import { Dataset, DatasetType } from 'datagateway-common';
 
 describe('Dataset details panel component', () => {
   let shallow;
   let mount;
   let rowData: Dataset;
+  let rowDatasetType: DatasetType;
   const detailsPanelResize = jest.fn();
   const fetchDetails = jest.fn();
   const fetchSize = jest.fn();
@@ -14,12 +15,19 @@ describe('Dataset details panel component', () => {
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'div' });
     mount = createMount();
+    rowDatasetType = {
+      id: 2,
+      name: 'Test 2',
+    };
     rowData = {
       id: 1,
       name: 'Test 1',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
       description: 'Test description',
+      startDate: '2019-06-11',
+      endDate: '2019-06-12',
+      type: rowDatasetType,
     };
   });
 
@@ -137,6 +145,16 @@ describe('Dataset details panel component', () => {
   });
 
   it('calls fetchDetails on load', () => {
+    rowData = {
+      id: 1,
+      name: 'Test 1',
+      modTime: '2019-06-10',
+      createTime: '2019-06-11',
+      description: 'Test description',
+      startDate: '2019-06-11',
+      endDate: '2019-06-12',
+    };
+
     mount(
       <DatasetDetailsPanel
         rowData={rowData}
@@ -150,7 +168,7 @@ describe('Dataset details panel component', () => {
     expect(fetchDetails).toHaveBeenCalledWith(1);
   });
 
-  it('Shows "No description provided" instead of a null field', () => {
+  it('Shows "No <field> provided" incase of a null field', () => {
     rowData = {
       id: 1,
       name: 'Test 1',

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
@@ -93,7 +93,11 @@ const DatasetDetailsPanel = (
               {t('datasets.details.description')}
             </Typography>
             <Typography>
-              <b>{datasetData.description}</b>
+              <b>
+                {datasetData.description
+                  ? datasetData.description
+                  : t('entity_card.no_description')}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
@@ -96,7 +96,7 @@ const DatasetDetailsPanel = (
               <b>
                 {datasetData.description && datasetData.description !== 'null'
                   ? datasetData.description
-                  : t('entity_card.no_description')}
+                  : `${t('datasets.details.description')} not provided`}
               </b>
             </Typography>
           </Grid>
@@ -105,7 +105,11 @@ const DatasetDetailsPanel = (
               {t('datasets.details.start_date')}
             </Typography>
             <Typography>
-              <b>{datasetData.startDate}</b>
+              <b>
+                {datasetData.startDate && datasetData.startDate !== 'null'
+                  ? datasetData.startDate
+                  : `${t('datasets.details.start_date')} not provided`}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>
@@ -113,7 +117,11 @@ const DatasetDetailsPanel = (
               {t('datasets.details.end_date')}
             </Typography>
             <Typography>
-              <b>{datasetData.endDate}</b>
+              <b>
+                {datasetData.endDate && datasetData.endDate !== 'null'
+                  ? datasetData.endDate
+                  : `${t('datasets.details.end_date')} not provided`}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>
@@ -161,7 +169,12 @@ const DatasetDetailsPanel = (
                 {t('datasets.details.type.description')}
               </Typography>
               <Typography>
-                <b>{datasetData.type.description}</b>
+                <b>
+                  {datasetData.type?.description &&
+                  datasetData.type?.description !== 'null'
+                    ? datasetData.type.description
+                    : `${t('datasets.details.type.description')} not provided`}
+                </b>
               </Typography>
             </Grid>
           </Grid>

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/datasetDetailsPanel.component.tsx
@@ -94,7 +94,7 @@ const DatasetDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {datasetData.description
+                {datasetData.description && datasetData.description !== 'null'
                   ? datasetData.description
                   : t('entity_card.no_description')}
               </b>

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -142,7 +142,7 @@ const VisitDetailsPanel = (
                 {investigationData.summary &&
                 investigationData.summary !== 'null'
                   ? investigationData.summary
-                  : t('entity_card.no_description')}
+                  : `${t('investigations.details.summary')} not provided`}
               </b>
             </Typography>
           </Grid>
@@ -151,7 +151,12 @@ const VisitDetailsPanel = (
               {t('investigations.details.start_date')}
             </Typography>
             <Typography>
-              <b>{investigationData.startDate}</b>
+              <b>
+                {investigationData.startDate &&
+                investigationData.startDate !== 'null'
+                  ? investigationData.startDate
+                  : `${t('investigations.details.start_date')} not provided`}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>
@@ -159,7 +164,12 @@ const VisitDetailsPanel = (
               {t('investigations.details.end_date')}
             </Typography>
             <Typography>
-              <b>{investigationData.endDate}</b>
+              <b>
+                {investigationData.endDate &&
+                investigationData.endDate !== 'null'
+                  ? investigationData.endDate
+                  : `${t('investigations.details.end_date')} not provided`}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -139,7 +139,8 @@ const VisitDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {investigationData.summary
+                {investigationData.summary &&
+                investigationData.summary !== 'null'
                   ? investigationData.summary
                   : t('entity_card.no_description')}
               </b>

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -138,7 +138,11 @@ const VisitDetailsPanel = (
               {t('investigations.details.summary')}
             </Typography>
             <Typography>
-              <b>{investigationData.summary}</b>
+              <b>
+                {investigationData.summary
+                  ? investigationData.summary
+                  : t('entity_card.no_description')}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Datafile details panel component Shows "No description provided" instea
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            datafiles.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Datafile details panel component renders correctly 1`] = `
+exports[`Datafile details panel component Shows "No description provided" instead of a null field 1`] = `
 <div
   id="details-panel"
   style={
@@ -61,6 +61,90 @@ exports[`Datafile details panel component renders correctly 1`] = `
         <WithStyles(ForwardRef(Typography))>
           <b>
             entity_card.no_description
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datafiles.details.location
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            /test/location
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(Grid))>
+  </div>
+</div>
+`;
+
+exports[`Datafile details panel component renders correctly 1`] = `
+<div
+  id="details-panel"
+  style={
+    Object {
+      "minWidth": 0,
+    }
+  }
+>
+  <WithStyles(ForwardRef(Tabs))
+    aria-label="datafiles.details.tabs_label"
+    onChange={[Function]}
+    scrollButtons="auto"
+    value="details"
+    variant="scrollable"
+  >
+    <WithStyles(ForwardRef(Tab))
+      aria-controls="datafile-details-panel"
+      id="datafile-details-tab"
+      label="datafiles.details.label"
+      value="details"
+    />
+  </WithStyles(ForwardRef(Tabs))>
+  <div
+    aria-labelledby="datafile-details-tab"
+    hidden={false}
+    id="datafile-details-panel"
+    role="tabpanel"
+  >
+    <WithStyles(ForwardRef(Grid))
+      className="makeStyles-root-1"
+      container={true}
+      direction="column"
+    >
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="h6"
+        >
+          <b>
+            Test 1
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Divider))
+          className="makeStyles-divider-2"
+        />
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datafiles.details.description
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -150,7 +234,7 @@ exports[`Datafile details panel component renders parameters tab when present in
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
@@ -59,7 +59,9 @@ exports[`Datafile details panel component renders correctly 1`] = `
           datafiles.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -147,7 +149,9 @@ exports[`Datafile details panel component renders parameters tab when present in
           datafiles.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Datafile details panel component Shows "No description provided" instead of a null field 1`] = `
+exports[`Datafile details panel component Shows "No <field> provided" incase of a null field 1`] = `
 <div
   id="details-panel"
   style={
@@ -75,7 +75,7 @@ exports[`Datafile details panel component Shows "No description provided" instea
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            /test/location
+            datafiles.details.location not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -144,7 +144,7 @@ exports[`Datafile details panel component renders correctly 1`] = `
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            Test description
+            datafiles.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -234,7 +234,7 @@ exports[`Datafile details panel component renders parameters tab when present in
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            Test description
+            datafiles.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datafileDetailsPanel.component.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`Datafile details panel component renders correctly 1`] = `
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            datafiles.details.description not provided
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -234,7 +234,7 @@ exports[`Datafile details panel component renders parameters tab when present in
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            datafiles.details.description not provided
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -59,7 +59,9 @@ exports[`Dataset details panel component renders correctly 1`] = `
           datasets.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
     </WithStyles(ForwardRef(Grid))>
@@ -132,7 +134,9 @@ exports[`Dataset details panel component renders type tab when present in the da
           datasets.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
     </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dataset details panel component Shows "No description provided" instead of a null field 1`] = `
+exports[`Dataset details panel component Shows "No <field> provided" incase of a null field 1`] = `
 <div
   id="details-panel"
   style={

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dataset details panel component renders correctly 1`] = `
+exports[`Dataset details panel component Shows "No description provided" instead of a null field 1`] = `
 <div
   id="details-panel"
   style={
@@ -61,6 +61,75 @@ exports[`Dataset details panel component renders correctly 1`] = `
         <WithStyles(ForwardRef(Typography))>
           <b>
             entity_card.no_description
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(Grid))>
+  </div>
+</div>
+`;
+
+exports[`Dataset details panel component renders correctly 1`] = `
+<div
+  id="details-panel"
+  style={
+    Object {
+      "minWidth": 0,
+    }
+  }
+>
+  <WithStyles(ForwardRef(Tabs))
+    aria-label="datasets.details.tabs_label"
+    onChange={[Function]}
+    scrollButtons="auto"
+    value="details"
+    variant="scrollable"
+  >
+    <WithStyles(ForwardRef(Tab))
+      aria-controls="dataset-details-panel"
+      id="dataset-details-tab"
+      label="datasets.details.label"
+      value="details"
+    />
+  </WithStyles(ForwardRef(Tabs))>
+  <div
+    aria-labelledby="dataset-details-tab"
+    hidden={false}
+    id="dataset-details-panel"
+    role="tabpanel"
+  >
+    <WithStyles(ForwardRef(Grid))
+      className="makeStyles-root-1"
+      container={true}
+      direction="column"
+    >
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="h6"
+        >
+          <b>
+            Test 1
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Divider))
+          className="makeStyles-divider-2"
+        />
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.description
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -135,7 +204,7 @@ exports[`Dataset details panel component renders type tab when present in the da
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            Test description
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Dataset details panel component Shows "No description provided" instead
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            datasets.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/__snapshots__/datasetDetailsPanel.component.test.tsx.snap
@@ -91,6 +91,12 @@ exports[`Dataset details panel component renders correctly 1`] = `
       label="datasets.details.label"
       value="details"
     />
+    <WithStyles(ForwardRef(Tab))
+      aria-controls="dataset-type-panel"
+      id="dataset-type-tab"
+      label="datasets.details.type.label"
+      value="type"
+    />
   </WithStyles(ForwardRef(Tabs))>
   <div
     aria-labelledby="dataset-details-tab"
@@ -130,6 +136,49 @@ exports[`Dataset details panel component renders correctly 1`] = `
         <WithStyles(ForwardRef(Typography))>
           <b>
             Test description
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(Grid))>
+  </div>
+  <div
+    aria-labelledby="dataset-type-tab"
+    hidden={true}
+    id="dataset-type-panel"
+    role="tabpanel"
+  >
+    <WithStyles(ForwardRef(Grid))
+      className="makeStyles-root-1"
+      container={true}
+      direction="column"
+    >
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="h6"
+        >
+          <b>
+            Test 2
+          </b>
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Divider))
+          className="makeStyles-divider-2"
+        />
+      </WithStyles(ForwardRef(Grid))>
+      <WithStyles(ForwardRef(Grid))
+        item={true}
+        xs={true}
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="overline"
+        >
+          datasets.details.type.description
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))>
+          <b>
+            datasets.details.type.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
@@ -19,7 +19,7 @@ describe('Datafile details panel component', () => {
       location: '/test/location',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
-      description: 'Test description',
+      // description: 'Test description',
     };
   });
 
@@ -140,11 +140,10 @@ describe('Datafile details panel component', () => {
     expect(fetchDetails).toHaveBeenCalledWith(1);
   });
 
-  it('Shows "No description provided" instead of a null field', () => {
+  it('Shows "No <field> provided" incase of a null field', () => {
     rowData = {
       id: 1,
       name: 'Test 1',
-      location: '/test/location',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
     };

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
@@ -19,7 +19,7 @@ describe('Datafile details panel component', () => {
       location: '/test/location',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
-      // description: 'Test description',
+      description: 'Test description',
     };
   });
 

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
@@ -19,6 +19,7 @@ describe('Datafile details panel component', () => {
       location: '/test/location',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
+      description: 'Test description',
     };
   });
 
@@ -137,5 +138,24 @@ describe('Datafile details panel component', () => {
 
     expect(fetchDetails).toHaveBeenCalled();
     expect(fetchDetails).toHaveBeenCalledWith(1);
+  });
+
+  it('Shows "No description provided" instead of a null field', () => {
+    rowData = {
+      id: 1,
+      name: 'Test 1',
+      location: '/test/location',
+      modTime: '2019-06-10',
+      createTime: '2019-06-11',
+    };
+
+    const wrapper = shallow(
+      <DatafilesDetailsPanel
+        rowData={rowData}
+        detailsPanelResize={detailsPanelResize}
+        fetchDetails={fetchDetails}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.tsx
@@ -92,7 +92,7 @@ const DatafileDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {datafileData.description
+                {datafileData.description && datafileData.description !== 'null'
                   ? datafileData.description
                   : t('entity_card.no_description')}
               </b>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.tsx
@@ -91,7 +91,11 @@ const DatafileDetailsPanel = (
               {t('datafiles.details.description')}
             </Typography>
             <Typography>
-              <b>{datafileData.description}</b>
+              <b>
+                {datafileData.description
+                  ? datafileData.description
+                  : t('entity_card.no_description')}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datafileDetailsPanel.component.tsx
@@ -94,7 +94,7 @@ const DatafileDetailsPanel = (
               <b>
                 {datafileData.description && datafileData.description !== 'null'
                   ? datafileData.description
-                  : t('entity_card.no_description')}
+                  : `${t('datafiles.details.description')} not provided`}
               </b>
             </Typography>
           </Grid>
@@ -103,7 +103,11 @@ const DatafileDetailsPanel = (
               {t('datafiles.details.location')}
             </Typography>
             <Typography>
-              <b>{datafileData.location}</b>
+              <b>
+                {datafileData.location && datafileData.location !== 'null'
+                  ? datafileData.location
+                  : `${t('datafiles.details.location')} not provided`}
+              </b>
             </Typography>
           </Grid>
         </Grid>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.test.tsx
@@ -123,7 +123,7 @@ describe('Dataset details panel component', () => {
     expect(fetchDetails).toHaveBeenCalledWith(1);
   });
 
-  it('Shows "No description provided" instead of a null field', () => {
+  it('Shows "No <field> provided" incase of a null field', () => {
     rowData = {
       id: 1,
       name: 'Test 1',

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.test.tsx
@@ -18,6 +18,7 @@ describe('Dataset details panel component', () => {
       name: 'Test 1',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
+      description: 'Test description',
     };
   });
 
@@ -106,5 +107,23 @@ describe('Dataset details panel component', () => {
 
     expect(fetchDetails).toHaveBeenCalled();
     expect(fetchDetails).toHaveBeenCalledWith(1);
+  });
+
+  it('Shows "No description provided" instead of a null field', () => {
+    rowData = {
+      id: 1,
+      name: 'Test 1',
+      modTime: '2019-06-10',
+      createTime: '2019-06-11',
+    };
+
+    const wrapper = shallow(
+      <DatasetsDetailsPanel
+        rowData={rowData}
+        detailsPanelResize={detailsPanelResize}
+        fetchDetails={fetchDetails}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.test.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import DatasetsDetailsPanel from './datasetDetailsPanel.component';
-import { Dataset } from 'datagateway-common';
+import { Dataset, DatasetType } from 'datagateway-common';
 
 describe('Dataset details panel component', () => {
   let shallow;
   let mount;
   let rowData: Dataset;
+  let rowDatasetType: DatasetType;
   const detailsPanelResize = jest.fn();
   const fetchDetails = jest.fn();
 
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'div' });
     mount = createMount();
+    rowDatasetType = {
+      id: 2,
+      name: 'Test 2',
+    };
     rowData = {
       id: 1,
       name: 'Test 1',
       modTime: '2019-06-10',
       createTime: '2019-06-11',
       description: 'Test description',
+      type: rowDatasetType,
     };
   });
 
@@ -97,6 +103,14 @@ describe('Dataset details panel component', () => {
   });
 
   it('calls fetchDetails on load', () => {
+    rowData = {
+      id: 1,
+      name: 'Test 1',
+      modTime: '2019-06-10',
+      createTime: '2019-06-11',
+      description: 'Test description',
+    };
+
     mount(
       <DatasetsDetailsPanel
         rowData={rowData}

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.tsx
@@ -101,7 +101,7 @@ const DatasetDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {datasetData.description
+                {datasetData.description && datasetData.description !== 'null'
                   ? datasetData.description
                   : t('entity_card.no_description')}
               </b>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.tsx
@@ -100,7 +100,11 @@ const DatasetDetailsPanel = (
               {t('datasets.details.description')}
             </Typography>
             <Typography>
-              <b>{datasetData.description}</b>
+              <b>
+                {datasetData.description
+                  ? datasetData.description
+                  : t('entity_card.no_description')}
+              </b>
             </Typography>
           </Grid>
         </Grid>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/datasetDetailsPanel.component.tsx
@@ -103,7 +103,7 @@ const DatasetDetailsPanel = (
               <b>
                 {datasetData.description && datasetData.description !== 'null'
                   ? datasetData.description
-                  : t('entity_card.no_description')}
+                  : `${t('datasets.details.description')} not provided`}
               </b>
             </Typography>
           </Grid>
@@ -128,7 +128,12 @@ const DatasetDetailsPanel = (
                 {t('datasets.details.type.description')}
               </Typography>
               <Typography>
-                <b>{datasetData.type.description}</b>
+                <b>
+                  {datasetData.type?.description &&
+                  datasetData.type?.description !== 'null'
+                    ? datasetData.type.description
+                    : `${t('datasets.details.type.description')} not provided`}
+                </b>
               </Typography>
             </Grid>
           </Grid>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
@@ -93,7 +93,11 @@ const InstrumentDetailsPanel = (
               {t('instruments.details.description')}
             </Typography>
             <Typography>
-              <b>{instrumentData.description}</b>
+              <b>
+                {instrumentData.description
+                  ? instrumentData.description
+                  : t('entity_card.no_description')}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
@@ -94,7 +94,8 @@ const InstrumentDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {instrumentData.description
+                {instrumentData.description &&
+                instrumentData.description !== 'null'
                   ? instrumentData.description
                   : t('entity_card.no_description')}
               </b>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
@@ -84,7 +84,7 @@ const InstrumentDetailsPanel = (
         <Grid container className={classes.root} direction="column">
           <Grid item xs>
             <Typography variant="h6">
-              <b>{instrumentData.fullName}</b>
+              <b>{instrumentData.fullName || instrumentData.name}</b>
             </Typography>
             <Divider className={classes.divider} />
           </Grid>
@@ -97,7 +97,7 @@ const InstrumentDetailsPanel = (
                 {instrumentData.description &&
                 instrumentData.description !== 'null'
                   ? instrumentData.description
-                  : t('entity_card.no_description')}
+                  : `${t('instruments.details.description')} not provided`}
               </b>
             </Typography>
           </Grid>
@@ -106,7 +106,11 @@ const InstrumentDetailsPanel = (
               {t('instruments.details.type')}
             </Typography>
             <Typography>
-              <b>{instrumentData.type}</b>
+              <b>
+                {instrumentData.type && instrumentData.type !== 'null'
+                  ? instrumentData.type
+                  : `${t('instruments.details.type')} not provided`}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>
@@ -115,7 +119,11 @@ const InstrumentDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                <Link href={instrumentData.url}>{instrumentData.url}</Link>
+                {instrumentData.url && instrumentData.url !== 'null' ? (
+                  <Link href={instrumentData.url}>{instrumentData.url}</Link>
+                ) : (
+                  `${t('instruments.details.url')} not provided`
+                )}
               </b>
             </Typography>
           </Grid>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
@@ -148,7 +148,8 @@ const InvestigationDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {investigationData.summary
+                {investigationData.summary &&
+                investigationData.summary !== 'null'
                   ? investigationData.summary
                   : t('entity_card.no_description')}
               </b>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
@@ -147,7 +147,11 @@ const InvestigationDetailsPanel = (
               {t('investigations.details.summary')}
             </Typography>
             <Typography>
-              <b>{investigationData.summary}</b>
+              <b>
+                {investigationData.summary
+                  ? investigationData.summary
+                  : t('entity_card.no_description')}
+              </b>
             </Typography>
           </Grid>
           {investigationData.studyInvestigations &&

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
@@ -151,7 +151,7 @@ const InvestigationDetailsPanel = (
                 {investigationData.summary &&
                 investigationData.summary !== 'null'
                   ? investigationData.summary
-                  : t('entity_card.no_description')}
+                  : `${t('investigations.details.summary')} not provided`}
               </b>
             </Typography>
           </Grid>
@@ -181,7 +181,11 @@ const InvestigationDetailsPanel = (
               {t('investigations.details.doi')}
             </Typography>
             <Typography>
-              <b>{investigationData.doi}</b>
+              <b>
+                {investigationData.doi && investigationData.doi !== 'null'
+                  ? investigationData.doi
+                  : `${t('investigations.details.doi')} not provided`}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>
@@ -189,7 +193,12 @@ const InvestigationDetailsPanel = (
               {t('investigations.details.start_date')}
             </Typography>
             <Typography>
-              <b>{investigationData.startDate}</b>
+              <b>
+                {investigationData.startDate &&
+                investigationData.startDate !== 'null'
+                  ? investigationData.startDate
+                  : `${t('investigations.details.start_date')} not provided`}
+              </b>
             </Typography>
           </Grid>
           <Grid item xs>
@@ -197,7 +206,12 @@ const InvestigationDetailsPanel = (
               {t('investigations.details.end_date')}
             </Typography>
             <Typography>
-              <b>{investigationData.endDate}</b>
+              <b>
+                {investigationData.endDate &&
+                investigationData.endDate !== 'null'
+                  ? investigationData.endDate
+                  : `${t('investigations.details.end_date')} not provided`}
+              </b>
             </Typography>
           </Grid>
         </Grid>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -330,7 +330,9 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
             </Typography>
 
             <Typography aria-label="landing-investigation-summary">
-              {data[0]?.summary}
+              {data[0]?.summary
+                ? data[0].summary
+                : t('entity_card.no_description')}
             </Typography>
 
             {formattedUsers.length > 0 && (

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -330,7 +330,7 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
             </Typography>
 
             <Typography aria-label="landing-investigation-summary">
-              {data[0]?.summary
+              {data[0]?.summary && data[0]?.summary !== 'null'
                 ? data[0].summary
                 : t('entity_card.no_description')}
             </Typography>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -332,7 +332,7 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
             <Typography aria-label="landing-investigation-summary">
               {data[0]?.summary && data[0]?.summary !== 'null'
                 ? data[0].summary
-                : t('entity_card.no_description')}
+                : 'Description not provided'}
             </Typography>
 
             {formattedUsers.length > 0 && (

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -130,7 +130,13 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
 
   const pid = React.useMemo(() => data[0]?.study?.pid, [data]);
   const title = React.useMemo(() => data[0]?.investigation?.title, [data]);
-  const summary = React.useMemo(() => data[0]?.investigation?.summary, [data]);
+  const summary = React.useMemo(
+    () =>
+      data[0]?.investigation?.summary
+        ? data[0].investigation.summary
+        : t('entity_card.no_description'),
+    [data, t]
+  );
 
   const formattedUsers = React.useMemo(() => {
     const principals: FormattedUser[] = [];

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -132,7 +132,8 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
   const title = React.useMemo(() => data[0]?.investigation?.title, [data]);
   const summary = React.useMemo(
     () =>
-      data[0]?.investigation?.summary
+      data[0]?.investigation?.summary &&
+      data[0]?.investigation?.summary !== 'null'
         ? data[0].investigation.summary
         : t('entity_card.no_description'),
     [data, t]

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -135,8 +135,8 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
       data[0]?.investigation?.summary &&
       data[0]?.investigation?.summary !== 'null'
         ? data[0].investigation.summary
-        : t('entity_card.no_description'),
-    [data, t]
+        : 'Description not provided',
+    [data]
   );
 
   const formattedUsers = React.useMemo(() => {

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`DLS Dataset table component renders details panel correctly and it send
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            datasets.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
@@ -287,7 +287,9 @@ exports[`DLS Dataset table component renders details panel correctly and it send
           datasets.details.start_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.start_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -300,7 +302,9 @@ exports[`DLS Dataset table component renders details panel correctly and it send
           datasets.details.end_date
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            datasets.details.end_date not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
@@ -272,7 +272,9 @@ exports[`DLS Dataset table component renders details panel correctly and it send
           datasets.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
@@ -125,7 +125,9 @@ exports[`ISIS datafiles table component renders details panel correctly and it s
           datafiles.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`ISIS datafiles table component renders details panel correctly and it s
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            datafiles.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
@@ -437,7 +437,7 @@ exports[`ISIS Dataset table component renders details panel correctly and it sen
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <b>
-            entity_card.no_description
+            datasets.details.description not provided
           </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
@@ -436,7 +436,9 @@ exports[`ISIS Dataset table component renders details panel correctly and it sen
           datasets.details.description
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            entity_card.no_description
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
     </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInstrumentsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInstrumentsTable.component.test.tsx.snap
@@ -114,7 +114,9 @@ exports[`ISIS Instruments table component renders details panel correctly and it
           instruments.details.type
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
-          <b />
+          <b>
+            instruments.details.type not provided
+          </b>
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))


### PR DESCRIPTION
## Description
This fixes an issue where 'null' would display on the page in cases where an investigation, dataset or datafile description was being displayed on the page but this variable wasn't actually set. Usually this means it was never provided with the data to begin with so we now show a more helpful message: 'Description not provided'.

## Testing instructions
Browse various investigations and datasets to find instances of 'Description not provided'. Expand the 'More Information' segment as well to ensure this message is displayed there too. It may help to manually edit the passed-in data so that no description value is provided but the snapshots test this themselves.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #715