### PR TITLE
Fixing crashing study landing page #711

### DIFF
--- a/packages/datagateway-dataview/cypress/integration/landing/isis/study.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/landing/isis/study.spec.ts
@@ -28,7 +28,7 @@ describe('ISIS - Study Landing', () => {
     );
   });
 
-  it('should display a missing investigation label when investigation is null', () => {
+  it('should load correctly when investigation missing', () => {
     cy.intercept('/studyinvestigations', [
       {
         createId: 'uows/1050072',
@@ -43,8 +43,6 @@ describe('ISIS - Study Landing', () => {
       },
     ]);
     cy.visit('/browseStudyHierarchy/instrument/1/study/405');
-    cy.get('[aria-label="landing-study-part-label"').contains(
-      'Missing investigation'
-    );
+    cy.get('#datagateway-dataview').should('be.visible');
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/landing/isis/study.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/landing/isis/study.spec.ts
@@ -27,4 +27,24 @@ describe('ISIS - Study Landing', () => {
       '/browseStudyHierarchy/instrument/1/study/405/investigation/2'
     );
   });
+
+  it('should display a missing investigation label when investigation is null', () => {
+    cy.intercept('/studyinvestigations', [
+      {
+        createId: 'uows/1050072',
+        createTime: '2019-02-07 15:27:19.790000+00:00',
+        id: 101224981,
+        study: {
+          endDate: null,
+          id: 101224979,
+          pid: '10.5286/ISIS.E.RB1810842',
+          startDate: null,
+        },
+      },
+    ]);
+    cy.visit('/browseStudyHierarchy/instrument/1/study/405');
+    cy.get('[aria-label="landing-study-part-label"').contains(
+      'Missing investigation'
+    );
+  });
 });

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -104,8 +104,7 @@
     },
     "type": {
       "id": "Type ID"
-    },
-    "missing": "Missing investigation"
+    }
   },
   "datasets": {
     "dataset": "Dataset",

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -104,7 +104,8 @@
     },
     "type": {
       "id": "Type ID"
-    }
+    },
+    "missing": "Missing investigation",
   },
   "datasets": {
     "dataset": "Dataset",

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -105,7 +105,7 @@
     "type": {
       "id": "Type ID"
     },
-    "missing": "Missing investigation",
+    "missing": "Missing investigation"
   },
   "datasets": {
     "dataset": "Dataset",

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.test.tsx
@@ -366,7 +366,7 @@ describe('ISIS Study Landing page', () => {
     ).toEqual('Copied citation');
   });
 
-  it('displays missing investigation label when investigation is null', () => {
+  it('displays correctly when investigation missing', () => {
     const testStore = mockStore({
       ...state,
       dgcommon: {
@@ -387,7 +387,7 @@ describe('ISIS Study Landing page', () => {
     );
 
     expect(
-      wrapper.find('[aria-label="landing-study-part-label"]').first().text()
-    ).toEqual('investigations.missing');
+      wrapper.find('[aria-label="landing-study-citation"]').first().text()
+    ).toEqual('2019: doi_constants.publisher.name, https://doi.org/study pid');
   });
 });

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.test.tsx
@@ -316,4 +316,29 @@ describe('ISIS Study Landing page', () => {
       wrapper.find('[aria-label="landing-study-citation"]').first().text()
     ).toEqual('Title 1, doi_constants.publisher.name');
   });
+
+  it('displays missing investigation label when investigation is null', () => {
+    const testStore = mockStore({
+      ...state,
+      dgcommon: {
+        ...state.dgcommon,
+        data: [
+          {
+            study: study,
+          },
+        ],
+      },
+    });
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <ISISStudyLanding instrumentId="4" studyId="5" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find('[aria-label="landing-study-part-label"]').first().text()
+    ).toEqual('investigations.missing');
+  });
 });

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -501,7 +501,7 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
             {data.map((studyInvestigation, i) => (
               <div key={i} className={classes.shortInfoPart}>
                 <Divider />
-                {studyInvestigation.investigation ? (
+                {studyInvestigation.investigation && (
                   <LinkedInvestigation
                     studyInvestigation={
                       studyInvestigation as StudyInvestigation
@@ -509,16 +509,6 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
                     urlPrefix={urlPrefix}
                     view={view}
                   />
-                ) : (
-                  <Typography
-                    className={classes.subHeading}
-                    component="h6"
-                    variant="h6"
-                    align="center"
-                    aria-label="landing-study-part-label"
-                  >
-                    {t('investigations.missing')}
-                  </Typography>
                 )}
               </div>
             ))}

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -123,6 +123,8 @@ const LinkedInvestigation = (
   const [t] = useTranslation();
   const classes = useStyles();
 
+  const investigation = props.studyInvestigation.investigation as Investigation;
+
   const shortInvestigationInfo = [
     {
       content: (entity: Investigation) => entity.doi,
@@ -151,41 +153,28 @@ const LinkedInvestigation = (
         align="center"
         aria-label="landing-study-part-label"
       >
-        {props.studyInvestigation.investigation &&
-          tableLink(
-            `${props.urlPrefix}/investigation/${props.studyInvestigation.investigation.id}`,
-            `${t('investigations.visit_id')}: ${
-              props.studyInvestigation.investigation?.visitId
-            }`,
-            props.view
-          )}
+        {tableLink(
+          `${props.urlPrefix}/investigation/${investigation.id}`,
+          `${t('investigations.visit_id')}: ${investigation.visitId}`,
+          props.view
+        )}
       </Typography>
-      {shortInvestigationInfo.map(
-        (field, i) =>
-          // data[0]?.investigation &&
-          props.studyInvestigation.investigation &&
-          // field.content(data[0].investigation as Investigation) && (
-          field.content(
-            props.studyInvestigation.investigation as Investigation
-          ) && (
-            <div className={classes.shortInfoRow} key={i}>
-              <Typography className={classes.shortInfoLabel}>
-                {field.icon}
-                {field.label}:
-              </Typography>
-              <Typography className={classes.shortInfoValue}>
-                {field.content(
-                  props.studyInvestigation.investigation as Investigation
-                )}
-              </Typography>
-            </div>
-          )
-      )}
+      {shortInvestigationInfo.map((field, i) => (
+        <div className={classes.shortInfoRow} key={i}>
+          <Typography className={classes.shortInfoLabel}>
+            {field.icon}
+            {field.label}:
+          </Typography>
+          <Typography className={classes.shortInfoValue}>
+            {field.content(investigation)}
+          </Typography>
+        </div>
+      ))}
       <div className={classes.actionButtons}>
         <AddToCartButton
           entityType="investigation"
-          allIds={[props.studyInvestigation.investigation.id]}
-          entityId={props.studyInvestigation.investigation.id}
+          allIds={[investigation.id]}
+          entityId={investigation.id}
         />
       </div>
     </div>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -107,9 +107,90 @@ interface LandingPageProps {
   studyId: string;
 }
 
+interface LinkedInvestigationProps {
+  studyInvestigation: StudyInvestigation;
+  urlPrefix: string;
+  view: ViewsType;
+}
+
 type LandingPageCombinedProps = LandingPageDispatchProps &
   LandingPageStateProps &
   LandingPageProps;
+
+const LinkedInvestigation = (
+  props: LinkedInvestigationProps
+): React.ReactElement => {
+  const [t] = useTranslation();
+  const classes = useStyles();
+
+  const shortInvestigationInfo = [
+    {
+      content: (entity: Investigation) => entity.doi,
+      label: t('investigations.doi'),
+      icon: <Public className={classes.shortInfoIcon} />,
+    },
+    {
+      content: (entity: Investigation) =>
+        entity.investigationInstruments?.[0]?.instrument?.name,
+      label: t('investigations.instrument'),
+      icon: <Assessment className={classes.shortInfoIcon} />,
+    },
+    {
+      content: (entity: Investigation) => entity.releaseDate?.slice(0, 10),
+      label: t('investigations.release_date'),
+      icon: <CalendarToday className={classes.shortInfoIcon} />,
+    },
+  ];
+
+  return (
+    <div>
+      <Typography
+        className={classes.subHeading}
+        component="h6"
+        variant="h6"
+        align="center"
+        aria-label="landing-study-part-label"
+      >
+        {props.studyInvestigation.investigation &&
+          tableLink(
+            `${props.urlPrefix}/investigation/${props.studyInvestigation.investigation.id}`,
+            `${t('investigations.visit_id')}: ${
+              props.studyInvestigation.investigation?.visitId
+            }`,
+            props.view
+          )}
+      </Typography>
+      {shortInvestigationInfo.map(
+        (field, i) =>
+          // data[0]?.investigation &&
+          props.studyInvestigation.investigation &&
+          // field.content(data[0].investigation as Investigation) && (
+          field.content(
+            props.studyInvestigation.investigation as Investigation
+          ) && (
+            <div className={classes.shortInfoRow} key={i}>
+              <Typography className={classes.shortInfoLabel}>
+                {field.icon}
+                {field.label}:
+              </Typography>
+              <Typography className={classes.shortInfoValue}>
+                {field.content(
+                  props.studyInvestigation.investigation as Investigation
+                )}
+              </Typography>
+            </div>
+          )
+      )}
+      <div className={classes.actionButtons}>
+        <AddToCartButton
+          entityType="investigation"
+          allIds={[props.studyInvestigation.investigation.id]}
+          entityId={props.studyInvestigation.investigation.id}
+        />
+      </div>
+    </div>
+  );
+};
 
 const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
   const [t] = useTranslation();
@@ -136,6 +217,7 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
     const principals: FormattedUser[] = [];
     const contacts: FormattedUser[] = [];
     const experimenters: FormattedUser[] = [];
+
     if (data[0]?.investigation?.investigationUsers) {
       const investigationUsers = data[0].investigation
         .investigationUsers as InvestigationUser[];
@@ -264,25 +346,6 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
     },
   ];
 
-  const shortInvestigationInfo = [
-    {
-      content: (entity: Investigation) => entity.doi,
-      label: t('investigations.doi'),
-      icon: <Public className={classes.shortInfoIcon} />,
-    },
-    {
-      content: (entity: Investigation) =>
-        entity.investigationInstruments?.[0]?.instrument?.name,
-      label: t('investigations.instrument'),
-      icon: <Assessment className={classes.shortInfoIcon} />,
-    },
-    {
-      content: (entity: Investigation) => entity.releaseDate?.slice(0, 10),
-      label: t('investigations.release_date'),
-      icon: <CalendarToday className={classes.shortInfoIcon} />,
-    },
-  ];
-
   return (
     <Paper className={classes.paper}>
       <Grid container style={{ padding: 4 }}>
@@ -403,45 +466,25 @@ const LandingPage = (props: LandingPageCombinedProps): React.ReactElement => {
             {data.map((studyInvestigation, i) => (
               <div key={i} className={classes.shortInfoPart}>
                 <Divider />
-                <Typography
-                  className={classes.subHeading}
-                  component="h6"
-                  variant="h6"
-                  align="center"
-                  aria-label="landing-study-part-label"
-                >
-                  {tableLink(
-                    `${urlPrefix}/investigation/${studyInvestigation.investigation.id}`,
-                    `${t('investigations.visit_id')}: ${
-                      studyInvestigation.investigation?.visitId
-                    }`,
-                    view
-                  )}
-                </Typography>
-                {shortInvestigationInfo.map(
-                  (field, i) =>
-                    data[0]?.investigation &&
-                    field.content(data[0].investigation as Investigation) && (
-                      <div className={classes.shortInfoRow} key={i}>
-                        <Typography className={classes.shortInfoLabel}>
-                          {field.icon}
-                          {field.label}:
-                        </Typography>
-                        <Typography className={classes.shortInfoValue}>
-                          {field.content(
-                            studyInvestigation.investigation as Investigation
-                          )}
-                        </Typography>
-                      </div>
-                    )
-                )}
-                <div className={classes.actionButtons}>
-                  <AddToCartButton
-                    entityType="investigation"
-                    allIds={[parseInt(studyInvestigation.investigation.id)]}
-                    entityId={parseInt(studyInvestigation.investigation.id)}
+                {studyInvestigation.investigation ? (
+                  <LinkedInvestigation
+                    studyInvestigation={
+                      studyInvestigation as StudyInvestigation
+                    }
+                    urlPrefix={urlPrefix}
+                    view={view}
                   />
-                </div>
+                ) : (
+                  <Typography
+                    className={classes.subHeading}
+                    component="h6"
+                    variant="h6"
+                    align="center"
+                    aria-label="landing-study-part-label"
+                  >
+                    {t('investigations.missing')}
+                  </Typography>
+                )}
               </div>
             ))}
           </Grid>


### PR DESCRIPTION
## Description
This addresses a problem which caused the ISIS study landing page to completely crash DataGateway. It occurred when the associated study was missing all of its known investigations (the query to /studyInvestigations would return some information about the study back but not the attached investigation). According to the ICAT schema, the investigation is a required field, hence why the app was crashing. 

As to why an investigation doesn't return from the API, that is still a mystery, _however_ it doesn't cause the page to crash when navigating to the investigations tab on the landing page. This loads the ISIS Investigations table component, which runs a separate query to fetch all investigations matching this instrument and study ID. In this case, we wouldn't know about any missing investigations because they wouldn't return or be displayed. 

Currently, the issue is being looked into on the API side of things so this addresses the DataGateway side of things and prevents the crash. Instead, what happens now when we detect missing investigations is we show a simple message saying 'Missing investigation' in place of where the investigation would go on the right hand side of the page. I'm open to suggestions on changing this displayed text as it might not be the right wording. 

An example query that caused the page to crash can be seen when navigating to https://datagateway.isis.stfc.ac.uk/browseStudyHierarchy/instrument/2/study/101224979. With this query, **three** investigations are being found by the API but only **one** is being returned. The below screenshot shows what will now display instead:

![Capture](https://user-images.githubusercontent.com/71134574/125106938-1f712a80-e0d8-11eb-9345-495c1a74272d.PNG)

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Try navigating to a range of study landing pages to replicate the issue. Alternatively, you can mock the data being returned to the component but there is a unit and e2e test to demonstrate this

## Agile board tracking
Closes #711