### PR TITLE
Fix sorting on instrument column for generic investigation table

### DIFF
--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -70,9 +70,15 @@ exports[`Investigation table component renders correctly 1`] = `
         "doi": "doi 1",
         "endDate": "2019-07-24",
         "id": 1,
-        "instrument": Object {
-          "name": "LARMOR",
-        },
+        "investigationInstruments": Array [
+          Object {
+            "id": 3,
+            "instrument": Object {
+              "id": 4,
+              "name": "LARMOR",
+            },
+          },
+        ],
         "name": "Test 1",
         "rbNumber": "1",
         "size": 1,

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -42,7 +42,8 @@ exports[`Investigation table component renders correctly 1`] = `
         "label": "investigations.dataset_count",
       },
       Object {
-        "dataKey": "instrument.name",
+        "cellContentRenderer": [Function],
+        "dataKey": "investigationInstruments.instrument.name",
         "filterComponent": [Function],
         "icon": <Memo />,
         "label": "investigations.instrument",

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
@@ -45,9 +45,15 @@ describe('Investigation table component', () => {
         rbNumber: '1',
         doi: 'doi 1',
         size: 1,
-        instrument: {
-          name: 'LARMOR',
-        },
+        investigationInstruments: [
+          {
+            id: 3,
+            instrument: {
+              id: 4,
+              name: 'LARMOR',
+            },
+          },
+        ],
         startDate: '2019-07-23',
         endDate: '2019-07-24',
       },

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -247,6 +247,15 @@ const InvestigationTable = (
           icon: <AssessmentIcon />,
           label: t('investigations.instrument'),
           dataKey: 'investigationInstruments.instrument.name',
+          cellContentRenderer: (cellProps: TableCellProps) => {
+            const investigationData = cellProps.rowData as Investigation;
+            if (investigationData?.investigationInstruments?.[0]?.instrument) {
+              return investigationData.investigationInstruments[0].instrument
+                .name;
+            } else {
+              return '';
+            }
+          },
           filterComponent: textFilter,
         },
         {
@@ -281,7 +290,19 @@ const mapDispatchToProps = (
   dispatch: ThunkDispatch<StateType, null, AnyAction>
 ): InvestigationTableDispatchProps => ({
   fetchData: (offsetParams: IndexRange) =>
-    dispatch(fetchInvestigations({ offsetParams })),
+    dispatch(
+      fetchInvestigations({
+        offsetParams,
+        additionalFilters: [
+          {
+            filterType: 'include',
+            filterValue: JSON.stringify({
+              investigationInstruments: 'instrument',
+            }),
+          },
+        ],
+      })
+    ),
   fetchCount: () => dispatch(fetchInvestigationCount()),
 
   addToCart: (entityIds: number[]) =>

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -246,7 +246,7 @@ const InvestigationTable = (
         {
           icon: <AssessmentIcon />,
           label: t('investigations.instrument'),
-          dataKey: 'instrument.name',
+          dataKey: 'investigationInstruments.instrument.name',
           filterComponent: textFilter,
         },
         {


### PR DESCRIPTION
## Description
Tiny PR to fix #767. This means sorting on that column will occur on a one-to-many relationship, **Python ICAT 0.19.0 is required**, ideally with the changes from DataGateway API issue #238 (the corresponding PR for that brings both. If you don't have that, you'll get a 400 from the API request saying you cannot sort on a one to many relationship.

Screenshot below shows this works - both ascending and descending requests now return 200:
![image](https://user-images.githubusercontent.com/32678030/126790861-3f333047-2ee3-45bc-9516-ef605f4cd3a8.png)

The second commit in this PR actually makes data present in that column, as proven when pointing at ISIS dev:
![image](https://user-images.githubusercontent.com/32678030/126795161-e935baba-5138-4887-8593-020bb0e239e4.png)



## Testing instructions
Discussed between Sam and I over Slack

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
connect to #767 
