### PR TITLE
Allow tab access to advanced filters link (#762)

### DIFF
--- a/packages/datagateway-common/src/card/advancedFilter.component.tsx
+++ b/packages/datagateway-common/src/card/advancedFilter.component.tsx
@@ -189,6 +189,8 @@ const AdvancedFilter = (props: AdvancedFilterProps): React.ReactElement => {
       {/* Advanced filters link */}
       <div className={classes.link}>
         <Link
+          component="button"
+          variant="body1"
           aria-label="advanced-filters-link"
           onClick={() => setAdvSearchCollapsed((prev) => !prev)}
         >


### PR DESCRIPTION
## Description

Allows for tab access to the "Show Advanced Filters" link. The component used for the root node has been changed to `button` in order for this to be possible.

## Testing instructions

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking

Closes #762 
