### PR TITLE
Unskip previously failing e2e tests

### DIFF
--- a/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
@@ -97,8 +97,7 @@ describe('DLS - Datasets Cards', () => {
     cy.get('#card').should('not.exist');
   });
 
-  // TODO: Data mismatch issue (#782)
-  it.skip('should be able to expand "More Information"', () => {
+  it('should be able to expand "More Information"', () => {
     cy.get('#card').contains('More Information').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
@@ -106,7 +105,7 @@ describe('DLS - Datasets Cards', () => {
     cy.get('#calculate-size-btn').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('5.36 GB', { timeout: 10000 });
+      .contains('4.24 GB', { timeout: 10000 });
 
     cy.get('#dataset-type-tab').click({ force: true });
     cy.get('#card')

--- a/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
@@ -108,8 +108,7 @@ describe('DLS - Visits Cards', () => {
     cy.get('#card').should('not.exist');
   });
 
-  // TODO: Data mismatch issue (#782)
-  it.skip('should be able to expand "More Information"', () => {
+  it('should be able to expand "More Information"', () => {
     cy.get('#card').contains('More Information').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
@@ -117,7 +116,7 @@ describe('DLS - Visits Cards', () => {
     cy.get('#calculate-size-btn').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('10.8 GB', { timeout: 10000 });
+      .contains('10.25 GB', { timeout: 10000 });
     cy.get('#visit-users-tab').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')

--- a/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
@@ -27,8 +27,7 @@ describe('ISIS - Studies Cards', () => {
     );
   });
 
-  // TODO: Data mismatch issue (#782)
-  it.skip('should be able to sort by one field', () => {
+  it('should be able to sort by one field', () => {
     cy.contains('[role="button"]', 'Start Date')
       .click()
       .wait('@getStudiesOrder', {
@@ -36,7 +35,7 @@ describe('ISIS - Studies Cards', () => {
       });
     cy.contains('[role="button"]', 'asc').should('exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('STUDY 4');
+    cy.get('#card').contains('STUDY 325');
 
     cy.contains('[role="button"]', 'Start Date')
       .click()
@@ -57,8 +56,7 @@ describe('ISIS - Studies Cards', () => {
     cy.get('#card').contains('STUDY 4');
   });
 
-  // TODO: Data mismatch issue (#782)
-  it.skip('should be able to sort by multiple fields', () => {
+  it('should be able to sort by multiple fields', () => {
     cy.contains('[role="button"]', 'Start Date')
       .click()
       .wait('@getStudiesOrder', {
@@ -66,7 +64,7 @@ describe('ISIS - Studies Cards', () => {
       });
     cy.contains('[role="button"]', 'asc').should('exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('STUDY 4');
+    cy.get('#card').contains('STUDY 325');
 
     cy.contains('[role="button"]', 'End Date')
       .click()
@@ -75,7 +73,7 @@ describe('ISIS - Studies Cards', () => {
       });
     cy.contains('[role="button"]', 'asc').should('exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('STUDY 4');
+    cy.get('#card').contains('STUDY 325');
   });
 
   it('should be able to filter by multiple fields', () => {

--- a/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
@@ -239,8 +239,7 @@ describe('DLS - Datasets Table', () => {
         .should('be.visible');
     });
 
-    // TODO: Data mismatch issue (#782)
-    it.skip('and then calculate file size', () => {
+    it('and then calculate file size', () => {
       // need to wait for counts to finish, otherwise cypress might interact with the details panel
       // too quickly and it rerenders during the test
       cy.contains('[aria-rowindex="1"] [aria-colindex="4"]', '55').should(
@@ -255,7 +254,7 @@ describe('DLS - Datasets Table', () => {
       cy.contains('#calculate-size-btn', 'Calculate')
         .should('exist')
         .click({ force: true });
-      cy.contains('5.36 GB', { timeout: 10000 }).should('be.visible');
+      cy.contains('4.24 GB', { timeout: 10000 }).should('be.visible');
     });
 
     it('and view the dataset type panel', () => {

--- a/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
@@ -200,8 +200,7 @@ describe('DLS - Visits Table', () => {
       cy.get('[aria-label="Hide details"]').should('exist');
     });
 
-    // TODO: Data mismatch issue (#782)
-    it.skip('and then calculate file size', () => {
+    it('and then calculate file size', () => {
       // We need to wait for counts to finish, otherwise cypress
       // might interact with the details panel too quickly and
       // it re-renders during the test.
@@ -213,7 +212,7 @@ describe('DLS - Visits Table', () => {
       cy.contains('#calculate-size-btn', 'Calculate')
         .should('exist')
         .click({ force: true });
-      cy.contains('10.8 GB', { timeout: 10000 }).should('be.visible');
+      cy.contains('10.25 GB', { timeout: 10000 }).should('be.visible');
     });
 
     // TODO: Since we only have one investigation, we cannot test

--- a/packages/datagateway-dataview/cypress/integration/table/isis/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/datasets.spec.ts
@@ -220,16 +220,15 @@ describe('ISIS - Datasets Table', () => {
     });
   });
 
-  // TODO: Data mismatch issue (#782)
-  describe.skip('should be able to view details', () => {
+  describe('should be able to view details', () => {
     beforeEach(() => {
       // Check that we have received the size from the API as this will produce
       // a re-render which can prevent the click.
-      cy.contains('[aria-rowindex="1"] [aria-colindex="4"]', '4.79 GB').should(
+      cy.contains('[aria-rowindex="1"] [aria-colindex="4"]', '5.78 GB').should(
         'exist'
       );
 
-      cy.contains('[aria-rowindex="2"] [aria-colindex="4"]', '6.07 GB').should(
+      cy.contains('[aria-rowindex="2"] [aria-colindex="4"]', '5.15 GB').should(
         'exist'
       );
     });

--- a/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
@@ -90,15 +90,14 @@ describe('ISIS - FacilityCycles Table', () => {
     });
   });
 
-  // TODO: Data mismatch issue (#782)
-  describe.skip('should be able to sort by', () => {
+  describe('should be able to sort by', () => {
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Name').click();
 
       cy.get('[aria-sort="ascending"]').should('exist');
       cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
       cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        '2000-04-02 00:00:00+01:00'
+        '2000-04-02 00:00:00+00:00'
       );
     });
 
@@ -113,7 +112,7 @@ describe('ISIS - FacilityCycles Table', () => {
         '0'
       );
       cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        '2019-08-04 00:00:00+01:00'
+        '2019-08-04 00:00:00+00:00'
       );
     });
 
@@ -131,7 +130,7 @@ describe('ISIS - FacilityCycles Table', () => {
         '0'
       );
       cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        '2000-04-02 00:00:00+01:00'
+        '2000-04-02 00:00:00+00:00'
       );
     });
 
@@ -140,7 +139,7 @@ describe('ISIS - FacilityCycles Table', () => {
       cy.contains('[role="button"]', 'Name').click();
 
       cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        '2000-04-02 00:00:00+01:00'
+        '2000-04-02 00:00:00+00:00'
       );
     });
   });
@@ -154,7 +153,7 @@ describe('ISIS - FacilityCycles Table', () => {
 
       cy.get('[aria-rowcount="2"]').should('exist');
       cy.get('[aria-rowindex="2"] [aria-colindex="2"]').contains(
-        '2010-08-04 00:00:00+01:00'
+        '2010-08-04 00:00:00+00:00'
       );
     });
 
@@ -180,7 +179,7 @@ describe('ISIS - FacilityCycles Table', () => {
 
       cy.get('[aria-rowcount="19"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        '2010-06-03 00:00:00+01:00'
+        '2010-06-03 00:00:00+00:00'
       );
     });
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
@@ -191,12 +191,11 @@ describe('ISIS - Investigations Table', () => {
     });
   });
 
-  // TODO: Data mismatch issue (#782)
-  describe.skip('should be able to view details', () => {
+  describe('should be able to view details', () => {
     beforeEach(() => {
       // Check that we have received the size from the API as this will produce
       // a re-render which can prevent the click.
-      cy.contains('[aria-rowindex="1"] [aria-colindex="6"]', '10.27 GB').should(
+      cy.contains('[aria-rowindex="1"] [aria-colindex="6"]', '10.2 GB').should(
         'exist'
       );
     });


### PR DESCRIPTION
## Description
This fixes #782. I've just unskipped the tests and reverted them back to the old data where needed.

I'll keep this as a draft PR for now since preprod isn't up to date with #756 as of yet (reason for some of the e2e failures). 

## Testing instructions
Run the e2e tests against preprod once it has been redeployed with the ISIS recommended changes.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #782 
