### PR TITLE
Fix crashing study table and card views

### DIFF
--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisStudiesCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisStudiesCardView.component.test.tsx.snap
@@ -4,14 +4,11 @@ exports[`ISIS Studies - Card View renders correctly 1`] = `
 Object {
   "data": Array [
     Object {
+      "createTime": "2000-01-01",
       "id": 1,
-      "study": Object {
-        "createTime": "2000-01-01",
-        "id": 1,
-        "modTime": "2000-01-01",
-        "name": "Test 1",
-        "pid": "doi",
-      },
+      "modTime": "2000-01-01",
+      "name": "Test 1",
+      "pid": "doi",
     },
   ],
   "description": Object {

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.test.tsx
@@ -55,13 +55,10 @@ describe('ISIS Studies - Card View', () => {
     cardData = [
       {
         id: 1,
-        study: {
-          id: 1,
-          pid: 'doi',
-          name: 'Test 1',
-          modTime: '2000-01-01',
-          createTime: '2000-01-01',
-        },
+        pid: 'doi',
+        name: 'Test 1',
+        modTime: '2000-01-01',
+        createTime: '2000-01-01',
       },
     ];
     history = createMemoryHistory();
@@ -180,56 +177,6 @@ describe('ISIS Studies - Card View', () => {
     expect(history.location.search).toBe('?');
   });
 
-  // it('pushFilters dispatched by date filter', () => {
-  //   const wrapper = createWrapper();
-  //   const advancedFilter = wrapper.find(AdvancedFilter);
-  //   advancedFilter.find(Link).simulate('click');
-  //   advancedFilter
-  //     .find('input')
-  //     .last()
-  //     .simulate('change', { target: { value: '2019-08-06' } });
-  //   expect(store.getActions().length).toEqual(3);
-  //   expect(store.getActions()[1]).toEqual(
-  //     filterTable('investigation.endDate', {
-  //       endDate: '2019-08-06',
-  //       startDate: undefined,
-  //     })
-  //   );
-
-  //   advancedFilter
-  //     .find('input')
-  //     .last()
-  //     .simulate('change', { target: { value: '' } });
-  //   expect(store.getActions().length).toEqual(5);
-  //   expect(store.getActions()[3]).toEqual(
-  //     filterTable('investigation.endDate', null)
-  //   );
-  //   expect(store.getActions()[4]).toEqual(push('?'));
-  // });
-
-  // it('pushFilters dispatched by text filter', () => {
-  //   const wrapper = createWrapper();
-  //   const advancedFilter = wrapper.find(AdvancedFilter);
-  //   advancedFilter.find(Link).simulate('click');
-  //   advancedFilter
-  //     .find('input')
-  //     .first()
-  //     .simulate('change', { target: { value: 'test' } });
-  //   expect(store.getActions().length).toEqual(3);
-  //   expect(store.getActions()[1]).toEqual(
-  //     filterTable('study.name', { value: 'test', type: 'include' })
-  //   );
-  //   expect(store.getActions()[2]).toEqual(push('?'));
-
-  //   advancedFilter
-  //     .find('input')
-  //     .first()
-  //     .simulate('change', { target: { value: '' } });
-  //   expect(store.getActions().length).toEqual(5);
-  //   expect(store.getActions()[3]).toEqual(filterTable('study.name', null));
-  //   expect(store.getActions()[4]).toEqual(push('?'));
-  // });
-
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 
@@ -243,9 +190,61 @@ describe('ISIS Studies - Card View', () => {
     );
   });
 
+  it('displays information from investigation when investigation present', () => {
+    cardData = [
+      {
+        ...cardData[0],
+        studyInvestigations: [
+          {
+            id: 2,
+            study: {
+              ...cardData[0],
+            },
+            investigation: {
+              id: 3,
+              name: 'Test',
+              title: 'Test investigation',
+              visitId: '3',
+              startDate: '2021-08-19',
+              endDate: '2021-08-20',
+            },
+          },
+        ],
+      },
+    ];
+    (useStudiesPaginated as jest.Mock).mockReturnValue({
+      data: cardData,
+    });
+
+    const wrapper = createWrapper();
+
+    expect(
+      wrapper.find('[aria-label="card-description"]').first().text()
+    ).toEqual('Test investigation');
+  });
+
   it('renders fine with incomplete data', () => {
     (useStudyCount as jest.Mock).mockReturnValueOnce({});
     (useStudiesPaginated as jest.Mock).mockReturnValueOnce({});
+
+    expect(() => createWrapper()).not.toThrowError();
+
+    cardData = [
+      {
+        ...cardData[0],
+        studyInvestigations: [
+          {
+            id: 2,
+            study: {
+              ...cardData[0],
+            },
+          },
+        ],
+      },
+    ];
+    (useStudiesPaginated as jest.Mock).mockReturnValue({
+      data: cardData,
+    });
 
     expect(() => createWrapper()).not.toThrowError();
   });

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
@@ -89,7 +89,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
       label: t('studies.title'),
       dataKey: 'studyInvestigations.investigation.title',
       content: (study: Study) => {
-        return study.studyInvestigations?.[0]?.investigation.title ?? '';
+        return study.studyInvestigations?.[0]?.investigation?.title ?? '';
       },
       filterComponent: textFilter,
     }),
@@ -109,7 +109,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
         label: t('studies.start_date'),
         dataKey: 'studyInvestigations.investigation.startDate',
         content: (study: Study) =>
-          study.studyInvestigations?.[0]?.investigation.startDate ?? '',
+          study.studyInvestigations?.[0]?.investigation?.startDate ?? '',
         filterComponent: dateFilter,
       },
       {
@@ -117,7 +117,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
         label: t('studies.end_date'),
         dataKey: 'studyInvestigations.investigation.endDate',
         content: (study: Study) =>
-          study.studyInvestigations?.[0]?.investigation.endDate ?? '',
+          study.studyInvestigations?.[0]?.investigation?.endDate ?? '',
         filterComponent: dateFilter,
       },
     ],

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
@@ -84,14 +84,11 @@ Object {
   ],
   "data": Array [
     Object {
+      "createTime": "2000-01-01",
       "id": 1,
-      "study": Object {
-        "createTime": "2000-01-01",
-        "id": 1,
-        "modTime": "2000-01-01",
-        "name": "Test 1",
-        "pid": "doi",
-      },
+      "modTime": "2000-01-01",
+      "name": "Test 1",
+      "pid": "doi",
     },
   ],
   "loadMoreRows": [Function],
@@ -243,7 +240,9 @@ exports[`ISIS Studies table component renders studies name as a link 1`] = `
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-            />
+            >
+              Test 1
+            </a>
           </LinkAnchor>
         </Link>
       </ForwardRef(Typography)>

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.test.tsx
@@ -51,16 +51,13 @@ describe('ISIS Studies table component', () => {
 
   beforeEach(() => {
     mount = createMount();
-    rowData = rowData = [
+    rowData = [
       {
         id: 1,
-        study: {
-          id: 1,
-          pid: 'doi',
-          name: 'Test 1',
-          modTime: '2000-01-01',
-          createTime: '2000-01-01',
-        },
+        pid: 'doi',
+        name: 'Test 1',
+        modTime: '2000-01-01',
+        createTime: '2000-01-01',
       },
     ];
     history = createMemoryHistory();
@@ -208,5 +205,61 @@ describe('ISIS Studies table component', () => {
     expect(
       wrapper.find('[aria-colindex=1]').find('p').children()
     ).toMatchSnapshot();
+  });
+
+  it('displays information from investigation when investigation present', () => {
+    rowData = [
+      {
+        ...rowData[0],
+        studyInvestigations: [
+          {
+            id: 2,
+            study: {
+              ...rowData[0],
+            },
+            investigation: {
+              id: 3,
+              name: 'Test',
+              title: 'Test investigation',
+              visitId: '3',
+              startDate: '2021-08-19',
+              endDate: '2021-08-20',
+            },
+          },
+        ],
+      },
+    ];
+    (useStudiesInfinite as jest.Mock).mockReturnValue({
+      data: { pages: [rowData] },
+      fetchNextPage: jest.fn(),
+    });
+
+    const wrapper = createWrapper();
+
+    expect(wrapper.find('[aria-colindex=2]').find('p').first().text()).toBe(
+      'Test investigation'
+    );
+  });
+
+  it('renders fine when investigation is undefined', () => {
+    rowData = [
+      {
+        ...rowData[0],
+        studyInvestigations: [
+          {
+            id: 2,
+            study: {
+              ...rowData[0],
+            },
+          },
+        ],
+      },
+    ];
+    (useStudiesInfinite as jest.Mock).mockReturnValue({
+      data: { pages: [rowData] },
+      fetchNextPage: jest.fn(),
+    });
+
+    expect(() => createWrapper()).not.toThrowError();
   });
 });

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -98,7 +98,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
         dataKey: 'studyInvestigations.investigation.title',
         cellContentRenderer: (cellProps: TableCellProps) =>
           (cellProps.rowData as Study)?.studyInvestigations?.[0]?.investigation
-            .title ?? '',
+            ?.title ?? '',
         filterComponent: textFilter,
       },
       {
@@ -113,7 +113,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
         dataKey: 'studyInvestigations.investigation.startDate',
         cellContentRenderer: (cellProps: TableCellProps) =>
           (cellProps.rowData as Study)?.studyInvestigations?.[0]?.investigation
-            .startDate ?? '',
+            ?.startDate ?? '',
         filterComponent: dateFilter,
       },
       {
@@ -122,7 +122,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
         dataKey: 'studyInvestigations.investigation.endDate',
         cellContentRenderer: (cellProps: TableCellProps) =>
           (cellProps.rowData as Study)?.studyInvestigations?.[0]?.investigation
-            .endDate ?? '',
+            ?.endDate ?? '',
         filterComponent: dateFilter,
       },
     ];


### PR DESCRIPTION
## Description
The react-query branch created an issue where investigations in the study views weren't being accessed via the nullish coalescing operator and this meant a crash when no investigation existed. Adding these in means we no longer crash and instead display nothing (as was intended by the original code). I have tested this against ISIS dev ICAT and this has fixed the issue found on ISIS dev datagateway.

I also fixed that the study view unit tests were being supplied mock data in the wrong format and so there's some snapshot changes to do with that as well.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #711 
