### PR TITLE
Fixed the unknown response when the data count is 0 #804

### DIFF
--- a/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.test.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.test.tsx
@@ -54,15 +54,25 @@ describe('Cell content renderers', () => {
     });
 
     it('Returns data if query is successful', () => {
-      expect(formatCountOrSize({ isFetching: false, data: 1 })).toEqual('1');
-      expect(formatCountOrSize({ data: 1 })).toEqual('1');
+      expect(
+        formatCountOrSize({ isFetching: false, isSuccess: true, data: 1 })
+      ).toEqual('1');
+      expect(formatCountOrSize({ data: 1, isSuccess: true })).toEqual('1');
     });
 
     it('Returns data formatted in bytes when byte flag is set', () => {
-      expect(formatCountOrSize({ isFetching: false, data: 1 }, true)).toEqual(
-        '1 B'
+      expect(
+        formatCountOrSize({ isFetching: false, isSuccess: true, data: 1 }, true)
+      ).toEqual('1 B');
+      expect(formatCountOrSize({ data: 10000, isSuccess: true }, true)).toEqual(
+        '9.77 KB'
       );
-      expect(formatCountOrSize({ data: 10000 }, true)).toEqual('9.77 KB');
+    });
+
+    it('Returns data if query is successful and result is zero', () => {
+      expect(
+        formatCountOrSize({ isFetching: false, isSuccess: true, data: 0 })
+      ).toEqual('0');
     });
   });
 

--- a/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
@@ -28,9 +28,9 @@ export function formatCountOrSize(
   formatAsBytes = false
 ): string {
   if (query?.isFetching) return 'Calculating...';
-  if (query?.data) {
+  if (query?.isSuccess) {
     if (formatAsBytes) return formatBytes(query.data);
-    return query.data?.toString();
+    return query.data.toString();
   }
   return 'Unknown';
 }

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -168,6 +168,7 @@ describe('Dataset table component', () => {
       ).map(() => ({
         data: 1,
         isFetching: false,
+        isSuccess: true,
       }))
     );
     (useDatasetSizes as jest.Mock).mockImplementation((datasets) =>
@@ -179,6 +180,7 @@ describe('Dataset table component', () => {
       ).map(() => ({
         data: 1,
         isFetching: false,
+        isSuccess: true,
       }))
     );
   });

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
@@ -163,6 +163,7 @@ describe('Investigation Search Table component', () => {
         ).map(() => ({
           data: 1,
           isFetching: false,
+          isSuccess: true,
         }))
     );
     (useInvestigationSizes as jest.Mock).mockImplementation((investigations) =>
@@ -174,6 +175,7 @@ describe('Investigation Search Table component', () => {
       ).map(() => ({
         data: 1,
         isFetching: false,
+        isSuccess: true,
       }))
     );
   });


### PR DESCRIPTION
## Description
This fixes #804. Have worked with Sam to fix the unknown response when the data count is 0. Caused due to query data being improperly read and fixed it by checking for the success status before reading the query data.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #804 
