### PR TITLE
Removing "tab" and "tabs" from aria labels #799

### DIFF
--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -22,7 +22,7 @@
     "type": "Type",
     "url": "URL",
     "details": {
-      "tabs_label": "Instrument Details Tabs",
+      "tabs_label": "Instrument Details",
       "label": "Instrument Details",
       "name": "Name",
       "description": "Description",
@@ -69,7 +69,7 @@
     "dataset_count": "Dataset Count",
     "release_date": "Public Release",
     "details": {
-      "tabs_label": "Investigation Details Tabs",
+      "tabs_label": "Investigation Details",
       "label": "Investigation Details",
       "title": "Title",
       "name": "Name",
@@ -122,7 +122,7 @@
       "id": "Type ID"
     },
     "details": {
-      "tabs_label": "Dataset Details Tabs",
+      "tabs_label": "Dataset Details",
       "label": "Dataset Details",
       "name": "Name",
       "description": "Description",
@@ -147,7 +147,7 @@
     "location": "Location",
     "size": "Size",
     "details": {
-      "tabs_label": "Datafile Details Tabs",
+      "tabs_label": "Datafile Details",
       "label": "Datafile Details",
       "name": "Name",
       "description": "Description",

--- a/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
@@ -25,13 +25,13 @@ describe('Download Cart', () => {
     // Ensure we can move away from the table and come back to it.
     cy.get('[aria-label="Download cart panel"]').should('exist');
     // Wait for the downloads to be fetched before moving back to the cart.
-    cy.get('[aria-label="Downloads tab"]')
+    cy.get('[aria-label="Downloads"]')
       .should('exist')
       .click()
       .wait('@fetchDownloads');
     cy.get('[aria-label="Download status panel"]').should('exist');
 
-    cy.get('[aria-label="Cart tab').click().wait('@fetchCart');
+    cy.get('[aria-label="Cart').click().wait('@fetchCart');
     cy.get('[aria-label="Download cart panel"]').should('exist');
 
     cy.get('[aria-rowcount=59]', { timeout: 10000 }).should('exist');

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -17,8 +17,8 @@ describe('Download Status', () => {
     cy.seedDownloads().then(() => {
       cy.visit('/download');
 
-      cy.get('[aria-label="Downloads tab"]').should('exist');
-      cy.get('[aria-label="Downloads tab"]')
+      cy.get('[aria-label="Downloads"]').should('exist');
+      cy.get('[aria-label="Downloads"]')
         .click()
         .then(() => {
           cy.wait('@fetchDownloads');

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -2,8 +2,8 @@
   "downloadTab": {
     "cart_tab": "Cart",
     "downloads_tab": "Downloads",
-    "cart_tab_arialabel": "Cart tab",
-    "downloads_tab_arialabel": "Downloads tab",
+    "cart_tab_arialabel": "Cart",
+    "downloads_tab_arialabel": "Downloads",
     "download_cart_panel_arialabel": "Download cart panel",
     "download_status_panel_arialabel": "Download status panel",
     "last_updated_time_arialabel": "Last updated time",

--- a/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
@@ -50,7 +50,7 @@ describe('Datafile search tab', () => {
         timeout: 10000,
       });
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Datafile')
       .contains('1')
       .click()
@@ -80,7 +80,7 @@ describe('Datafile search tab', () => {
 
     cy.get('[aria-label="Submit search button"]').click();
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Datafile')
       .contains('9')
       .click()
@@ -104,7 +104,7 @@ describe('Datafile search tab', () => {
 
     cy.get('[aria-rowcount="50"]').should('exist');
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Datafile')
       .should('not.exist');
   });
@@ -119,7 +119,7 @@ describe('Datafile search tab', () => {
       .wait(['@investigations', '@investigations', '@investigationsCount'], {
         timeout: 10000,
       });
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Datafile')
       .contains('1')
       .click()

--- a/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
@@ -50,7 +50,7 @@ describe('Dataset search tab', () => {
         timeout: 15000,
       });
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Dataset')
       .contains('10')
       .click()
@@ -84,7 +84,7 @@ describe('Dataset search tab', () => {
 
     cy.get('[aria-label="Submit search button"]').click();
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Dataset')
       .contains('4')
       .click();
@@ -105,7 +105,7 @@ describe('Dataset search tab', () => {
 
     cy.get('[aria-rowcount="50"]').should('exist');
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Dataset')
       .should('not.exist');
   });
@@ -119,7 +119,7 @@ describe('Dataset search tab', () => {
 
     cy.get('[aria-label="Submit search button"]').click();
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Dataset')
       .contains('1')
       .click();
@@ -136,7 +136,7 @@ describe('Dataset search tab', () => {
 
     cy.get('[aria-label="Submit search button"]').click();
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Dataset')
       .contains('1')
       .click();

--- a/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
@@ -84,7 +84,7 @@ describe('Investigation search tab', () => {
         timeout: 10000,
       });
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Investigation')
       .contains('19')
       .click();
@@ -100,7 +100,7 @@ describe('Investigation search tab', () => {
 
     cy.get('[aria-label="Submit search button"]').click();
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Investigation')
       .contains('12')
       .click();
@@ -121,7 +121,7 @@ describe('Investigation search tab', () => {
 
     cy.get('[aria-rowcount="50"]').should('exist');
 
-    cy.get('[aria-label="Search table tabs"]')
+    cy.get('[aria-label="Search table"]')
       .contains('Investigation')
       .should('not.exist');
   });

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -20,7 +20,7 @@
     "invalid_date_message": "Invalid date range"
   },
   "searchPageTable": {
-    "tabs_arialabel": "Search table tabs",
+    "tabs_arialabel": "Search table",
     "header": "Search",
     "text": "Fill out form to the left and then click search."
   },


### PR DESCRIPTION
## Description
The words "tab" or "tabs" are not needed in the aria labels for tab elements because a screen reader automatically recognises the element is a tab and says the word anyway. This fix prevents the repetition of the word "tab" or "tabs" when reading aloud the aria label of an element.

## Testing instructions
Either use a screen reader or use developer tools to manually check the aria labels of the following elements do not contain the words "tab" or "tabs":
- dataset details panel tablist
- investigation details panel tablist
- datafile details panel tablist
- instrument details panel tablist
- cart tab in DG Download
- downloads tab in DG Download
- tablist in DG Search (parent element of investigation, dataset and datafile tabs)

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #799