### PR TITLE
Adding download button for ISIS investigations #802

### DIFF
--- a/packages/datagateway-common/src/api/investigations.test.tsx
+++ b/packages/datagateway-common/src/api/investigations.test.tsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 import handleICATError from '../handleICATError';
 import { createReactQueryWrapper } from '../setupTests';
 import {
+  downloadInvestigation,
   useInvestigation,
   useInvestigationCount,
   useInvestigationDetails,
@@ -1372,6 +1373,22 @@ describe('investigation api functions', () => {
 
         expect(handleICATError).toHaveBeenCalledWith({ message: 'Test error' });
       });
+    });
+  });
+
+  describe('downloadInvestigation', () => {
+    it('clicks on IDS link upon downloadInvestigation action', async () => {
+      jest.spyOn(document, 'createElement');
+      jest.spyOn(document.body, 'appendChild');
+
+      downloadInvestigation('https://www.example.com/ids', 1, 'test');
+
+      expect(document.createElement).toHaveBeenCalledWith('a');
+      const link = document.createElement('a');
+      link.href = `https://www.example.com/ids/getData?sessionId=${null}&investigationIds=${1}&compress=${false}&zip=${true}&outname=${'test'}`;
+      link.target = '_blank';
+      link.style.display = 'none';
+      expect(document.body.appendChild).toHaveBeenCalledWith(link);
     });
   });
 });

--- a/packages/datagateway-common/src/api/investigations.tsx
+++ b/packages/datagateway-common/src/api/investigations.tsx
@@ -823,3 +823,28 @@ export const useISISInvestigationIds = (
     }
   );
 };
+
+export const downloadInvestigation = (
+  idsUrl: string,
+  investigationId: number,
+  investigationName: string
+): void => {
+  const params = {
+    sessionId: readSciGatewayToken().sessionId,
+    investigationIds: investigationId,
+    compress: false,
+    zip: true,
+    outname: investigationName,
+  };
+
+  const link = document.createElement('a');
+  link.href = `${idsUrl}/getData?${Object.entries(params)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&')}`;
+
+  link.style.display = 'none';
+  link.target = '_blank';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+};

--- a/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
@@ -32,7 +32,7 @@ describe('ISIS - Investigations Table', () => {
       .then((window) => {
         const windowWidth = window.innerWidth;
         // Account for select and details column widths
-        columnWidth = (windowWidth - 40 - 40) / 7;
+        columnWidth = (windowWidth - 40 - 40 - 70) / 7;
         columnWidth = Math.floor(columnWidth * 10) / 10;
       })
       .then(() => expect(columnWidth).to.not.equal(0));

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
@@ -19,6 +19,7 @@ import { initialState as dgDataViewInitialState } from '../../../state/reducers/
 import ISISInvestigationsCardView from './isisInvestigationsCardView.component';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import AddToCartButton from '../../addToCartButton.component';
+import DownloadButton from '../../downloadButton.component';
 import InvestigationDetailsPanel from '../../detailsPanels/isis/investigationDetailsPanel.component';
 import { createMemoryHistory, History } from 'history';
 
@@ -202,6 +203,9 @@ describe('ISIS Investigations - Card View', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(AddToCartButton).exists()).toBeTruthy();
     expect(wrapper.find(AddToCartButton).text()).toEqual('buttons.add_to_cart');
+
+    expect(wrapper.find(DownloadButton).exists()).toBeTruthy();
+    expect(wrapper.find(DownloadButton).text()).toEqual('buttons.download');
   });
 
   it('displays details panel when more information is expanded and navigates to datasets view when tab clicked', () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -29,6 +29,21 @@ import { useTranslation } from 'react-i18next';
 import InvestigationDetailsPanel from '../../detailsPanels/isis/investigationDetailsPanel.component';
 import { useHistory, useLocation } from 'react-router';
 import AddToCartButton from '../../addToCartButton.component';
+import DownloadButton from '../../downloadButton.component';
+import { Theme, createStyles, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    actionButtons: {
+      display: 'flex',
+      flexDirection: 'column',
+      '& button': {
+        marginTop: theme.spacing(1),
+        margin: 'auto',
+      },
+    },
+  })
+);
 
 interface ISISInvestigationsCardViewProps {
   instrumentId: string;
@@ -159,17 +174,27 @@ const ISISInvestigationsCardView = (
     [data, dateFilter, sizeQueries, t, textFilter]
   );
 
+  const classes = useStyles();
+
   const buttons = React.useMemo(
     () => [
       (investigation: Investigation) => (
-        <AddToCartButton
-          entityType="investigation"
-          allIds={data?.map((investigation) => investigation.id) ?? []}
-          entityId={investigation.id}
-        />
+        <div className={classes.actionButtons}>
+          <AddToCartButton
+            entityType="investigation"
+            allIds={data?.map((investigation) => investigation.id) ?? []}
+            entityId={investigation.id}
+          />
+          <DownloadButton
+            entityType="investigation"
+            entityId={investigation.id}
+            entityName={investigation.name}
+            variant="outlined"
+          />
+        </div>
       ),
     ],
-    [data]
+    [classes.actionButtons, data]
   );
 
   const moreInformation = React.useCallback(

--- a/packages/datagateway-dataview/src/views/downloadButton.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/downloadButton.component.test.tsx
@@ -6,6 +6,7 @@ import DownloadButton, {
 import configureStore from 'redux-mock-store';
 import {
   dGCommonInitialState,
+  downloadInvestigation,
   downloadDataset,
   downloadDatafile,
   StateType,
@@ -23,6 +24,7 @@ jest.mock('datagateway-common', () => {
   return {
     __esModule: true,
     ...originalModule,
+    downloadInvestigation: jest.fn(),
     downloadDataset: jest.fn(),
     downloadDatafile: jest.fn(),
   };
@@ -83,6 +85,37 @@ describe('Generic download button', () => {
       variant: 'icon',
     });
     expect(iconButtonWrapper.find('button').text()).toBe('');
+  });
+
+  it('calls download investigation on button press for both text and icon buttons', () => {
+    let wrapper = createWrapper({
+      entityType: 'investigation',
+      entityName: 'test',
+      entityId: 1,
+    });
+
+    wrapper.find('#download-btn-1').first().simulate('click');
+    expect(downloadInvestigation).toHaveBeenCalledWith(
+      'https://www.example.com/ids',
+      1,
+      'test'
+    );
+
+    jest.clearAllMocks();
+
+    wrapper = createWrapper({
+      entityType: 'investigation',
+      entityName: 'test',
+      entityId: 1,
+      variant: 'icon',
+    });
+
+    wrapper.find('#download-btn-1').first().simulate('click');
+    expect(downloadInvestigation).toHaveBeenCalledWith(
+      'https://www.example.com/ids',
+      1,
+      'test'
+    );
   });
 
   it('calls download dataset on button press for both text and icon buttons', () => {

--- a/packages/datagateway-dataview/src/views/downloadButton.component.tsx
+++ b/packages/datagateway-dataview/src/views/downloadButton.component.tsx
@@ -3,6 +3,7 @@ import { GetApp } from '@material-ui/icons';
 import {
   downloadDatafile,
   downloadDataset,
+  downloadInvestigation,
   StateType,
 } from 'datagateway-common';
 import React from 'react';
@@ -10,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 export interface DownloadButtonProps {
-  entityType: 'dataset' | 'datafile';
+  entityType: 'investigation' | 'dataset' | 'datafile';
   entityId: number;
   entityName: string | undefined;
   variant?: 'text' | 'outlined' | 'contained' | 'icon';
@@ -24,11 +25,13 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
   const idsUrl = useSelector((state: StateType) => state.dgcommon.urls.idsUrl);
 
   const downloadData = (
-    entityType: 'dataset' | 'datafile',
+    entityType: 'investigation' | 'dataset' | 'datafile',
     entityId: number,
     entityName: string
   ): void => {
-    if (entityType === 'dataset') {
+    if (entityType === 'investigation') {
+      downloadInvestigation(idsUrl, entityId, entityName);
+    } else if (entityType === 'dataset') {
       downloadDataset(idsUrl, entityId, entityName);
     } else if (entityType === 'datafile') {
       downloadDatafile(idsUrl, entityId, entityName);

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`ISIS Investigations table component renders correctly 1`] = `
 Object {
+  "actions": Array [
+    [Function],
+  ],
   "allIds": Array [
     1,
   ],

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -23,6 +23,7 @@ import { Router } from 'react-router';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactWrapper } from 'enzyme';
 import { createMemoryHistory, History } from 'history';
+import DownloadButton from '../../downloadButton.component';
 
 jest.mock('datagateway-common', () => {
   const originalModule = jest.requireActual('datagateway-common');
@@ -438,5 +439,11 @@ describe('ISIS Investigations table component', () => {
     wrapper = createWrapper();
     expect(wrapper.find('[aria-colindex=5]').find('p').text()).toEqual('');
     expect(wrapper.find('[aria-colindex=7]').find('p').text()).toEqual('');
+  });
+
+  it('renders actions correctly', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.find(DownloadButton).exists()).toBeTruthy();
   });
 });

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -15,6 +15,7 @@ import {
   usePushSort,
   useRemoveFromCart,
   useTextFilter,
+  TableActionProps,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -30,6 +31,7 @@ import AssessmentIcon from '@material-ui/icons/Assessment';
 import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router';
+import DownloadButton from '../../downloadButton.component';
 
 interface ISISInvestigationsTableProps {
   instrumentId: string;
@@ -223,6 +225,16 @@ const ISISInvestigationsTable = (
       onUncheck={removeFromCart}
       disableSelectAll={!selectAllSetting}
       detailsPanel={detailsPanel}
+      actions={[
+        ({ rowData }: TableActionProps) => (
+          <DownloadButton
+            entityType="investigation"
+            entityId={rowData.id}
+            entityName={rowData.name}
+            variant="icon"
+          />
+        ),
+      ]}
       columns={columns}
     />
   );


### PR DESCRIPTION
## Description
This provides a download button below the add to cart button in card view and a download icon in an actions column in table view. With this, any ISIS investigation, dataset and datafile can be individually downloaded without having to be added to the cart first. 

This feature was not available in TopCAT. With this in mind, I will leave this as a draft PR for now until I know for certain that adding this feature won't cause any unintended side effects with the IDS.

## Testing instructions
Check that both views for ISIS investigations contain a download button. Also check that whatever address is redirected to contains the parameter `investigationIds` and the investigation name as the `outname` parameter.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #802