### PR TITLE
Improving visibility of text on download confirm dialogue box #770

### DIFF
--- a/packages/datagateway-download/src/downloadConfirmation/downloadConfirmDialog.component.tsx
+++ b/packages/datagateway-download/src/downloadConfirmation/downloadConfirmDialog.component.tsx
@@ -810,7 +810,7 @@ const DownloadConfirmDialog: React.FC<DownloadConfirmDialogProps> = (
                 <Grid item xs>
                   <Button
                     id="download-confirmation-status-link"
-                    variant="outlined"
+                    variant="contained"
                     color="primary"
                     onClick={redirectToStatusTab}
                   >


### PR DESCRIPTION
## Description
Currently, the text on the datagateway download confirmation button is difficult to read in dark mode due to poor contrast. This makes the button and accompanying text clearer, using a white on blue design

## Testing instructions
Attempt to download something through Datagateway download. The confirmation box should contain a blue button with white text.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #770