### PR TITLE
Added alt text to homepage images #826

### DIFF
--- a/packages/datagateway-common/src/homePage/__snapshots__/homePage.component.test.tsx.snap
+++ b/packages/datagateway-common/src/homePage/__snapshots__/homePage.component.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Home page component homepage renders correctly 1`] = `
       }
     >
       <img
-        alt="test-title"
         src="test-logo"
       />
     </div>
@@ -48,7 +47,7 @@ exports[`Home page component homepage renders correctly 1`] = `
           test-exploreLabel
         </WithStyles(ForwardRef(Typography))>
         <img
-          alt=""
+          alt="test-exploreLabel"
           className="HomePage-howItWorksGridItemImage-6"
           src="test-exploreImage"
         />
@@ -72,7 +71,7 @@ exports[`Home page component homepage renders correctly 1`] = `
           test-discoverLabel
         </WithStyles(ForwardRef(Typography))>
         <img
-          alt=""
+          alt="test-discoverLabel"
           className="HomePage-howItWorksGridItemImage-6"
           src="test-discoverImage"
         />
@@ -96,7 +95,7 @@ exports[`Home page component homepage renders correctly 1`] = `
           test-downloadLabel
         </WithStyles(ForwardRef(Typography))>
         <img
-          alt=""
+          alt="test-downloadLabel"
           className="HomePage-howItWorksGridItemImage-6"
           src="test-downloadImage"
         />

--- a/packages/datagateway-common/src/homePage/homePage.component.tsx
+++ b/packages/datagateway-common/src/homePage/homePage.component.tsx
@@ -12,6 +12,7 @@ import { StyleRules } from '@material-ui/core/styles';
 const styles = (theme: Theme): StyleRules =>
   createStyles({
     bigImage: {
+      alt: 'DataGateway Banner',
       height: 250,
       width: '100%',
       '& img': {
@@ -60,6 +61,7 @@ const styles = (theme: Theme): StyleRules =>
 
 export interface HomePageProps {
   title: string;
+  logoLabel: string;
   howLabel: string;
   exploreLabel: string;
   exploreDescription: string;
@@ -87,7 +89,7 @@ const HomePage = (props: CombinedHomePageProps): React.ReactElement => {
             height: 250,
           }}
         >
-          <img src={props.logo} alt={props.title} />
+          <img src={props.logo} alt={props.logoLabel} />
         </div>
       </div>
       <div className={props.classes.howItWorks}>
@@ -110,7 +112,7 @@ const HomePage = (props: CombinedHomePageProps): React.ReactElement => {
             </Typography>
             <img
               src={props.exploreImage}
-              alt=""
+              alt={props.exploreLabel}
               className={props.classes.howItWorksGridItemImage}
             />
             <Typography
@@ -134,7 +136,7 @@ const HomePage = (props: CombinedHomePageProps): React.ReactElement => {
             </Typography>
             <img
               src={props.discoverImage}
-              alt=""
+              alt={props.discoverLabel}
               className={props.classes.howItWorksGridItemImage}
             />
             <Typography
@@ -158,7 +160,7 @@ const HomePage = (props: CombinedHomePageProps): React.ReactElement => {
             </Typography>
             <img
               src={props.downloadImage}
-              alt=""
+              alt={props.downloadLabel}
               className={props.classes.howItWorksGridItemImage}
             />
             <Typography

--- a/packages/datagateway-common/src/homePage/homePage.component.tsx
+++ b/packages/datagateway-common/src/homePage/homePage.component.tsx
@@ -12,7 +12,6 @@ import { StyleRules } from '@material-ui/core/styles';
 const styles = (theme: Theme): StyleRules =>
   createStyles({
     bigImage: {
-      alt: 'DataGateway Banner',
       height: 250,
       width: '100%',
       '& img': {

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -195,6 +195,7 @@
   },
   "homePage": {
     "title": "DataGateway",
+    "logoLabel": "DataGateway Logo",
     "howLabel": "How it works...",
     "exploreLabel": "1. Explore",
     "exploreDescription": "Browse, explore and visualise the experimental data produced at the facility.",

--- a/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`HomePage translated homepage renders correctly 1`] = `
       }
     >
       <img
-        alt="homePage.title"
+        alt="homePage.logoLabel"
         src="testdatgateway-white-text-blue-mark-logo.svg"
       />
     </div>
@@ -48,7 +48,7 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           homePage.exploreLabel
         </WithStyles(ForwardRef(Typography))>
         <img
-          alt=""
+          alt="homePage.exploreLabel"
           className="HomePage-howItWorksGridItemImage-6"
           src="testexplore.jpg"
         />
@@ -72,7 +72,7 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           homePage.discoverLabel
         </WithStyles(ForwardRef(Typography))>
         <img
-          alt=""
+          alt="homePage.discoverLabel"
           className="HomePage-howItWorksGridItemImage-6"
           src="testdiscover.jpg"
         />
@@ -96,7 +96,7 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           homePage.downloadLabel
         </WithStyles(ForwardRef(Typography))>
         <img
-          alt=""
+          alt="homePage.downloadLabel"
           className="HomePage-howItWorksGridItemImage-6"
           src="testdownload.jpg"
         />

--- a/packages/datagateway-dataview/src/page/translatedHomePage.component.tsx
+++ b/packages/datagateway-dataview/src/page/translatedHomePage.component.tsx
@@ -21,6 +21,7 @@ export const TranslatedHomePage = React.memo(
     return (
       <TranslatedHomePage
         title={t('homePage.title')}
+        logoLabel={t('homePage.logoLabel')}
         howLabel={t('homePage.howLabel')}
         exploreLabel={t('homePage.exploreLabel')}
         exploreDescription={t('homePage.exploreDescription')}


### PR DESCRIPTION
## Description
Added the alt text for the homepage images for data gateway, the text is from `default.json`, where its stored as key-value pairs. This is seen in both `datagateway-common` and `datagateway-dataview` with the `homePage.component.tsx` and `translatedHomePage.component.tsx` files respectively.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #826 
