### PR TITLE
Revert icat-ansible to master #752

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: temp-icat-server-config-test
+          ref: master
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: temp-icat-server-config-test
+          ref: master
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
@@ -383,7 +383,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: temp-icat-server-config-test
+          ref: master
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt


### PR DESCRIPTION

## Description
This will close #752. Small PR to make ICAT Ansible use master as Lucene 1.1.1 has been released
 
## Testing instructions
Just a CI change.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
connect to #752 
