### PR TITLE
Use Ubuntu 20 on CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: master
+          ref: ubuntu-20-work
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: master
+          ref: ubuntu-20-work
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
@@ -383,7 +383,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: master
+          ref: ubuntu-20-work
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint-and-unit-test:
     name: Lint & Unit Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
 
   dataview-e2e-tests:
     name: DataGateway DataView End to End Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -211,7 +211,7 @@ jobs:
 
   download-e2e-tests:
     name: DataGateway Download End to End Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -361,7 +361,7 @@ jobs:
 
   search-e2e-tests:
     name: DataGateway Search End to End Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
This will close #749.

This is a small PR on DataGateway's side to update the CI workflow to use Ubuntu 20.04 before 16.04 is dropped from GitHub Actions. The work in this involved changing ICAT Ansible so it became compatible with 20.04, as there were many instances when it broke using the new OS version. I have changed the branch of ICAT Ansible to use the one I've been working with and I know works on Ubuntu 20. Once the 'clean' changes for this solution have been pushed to master on ICAT Ansible, I will change the ICAT Ansible branch on the CI workflow back to master. 

## Testing instructions
I guess the test is whether the CI passes or not.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
connect to #749 
