### PR TITLE
Add browsing anonymously label #834

### DIFF
--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -3,6 +3,7 @@
     "results": "Results",
     "view_table": "Display as table",
     "view_cards": "Display as cards",
+    "view_open_data_warning" : "You are viewing open data",
     "max_results": "Max Results",
     "error": "Something went wrong..."
   },

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -10,7 +10,6 @@ import {
   Badge,
   makeStyles,
   Button,
-  Tooltip,
 } from '@material-ui/core';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 import SearchIcon from '@material-ui/icons/Search';
@@ -190,15 +189,13 @@ const NavBar = React.memo(
                 justify="center"
               >
                 <Grid item>
-                  <Tooltip title="Only open data is displayed when browsing anonymously">
-                    <IconButton>
-                      <InfoIcon color="primary" />
-                    </IconButton>
-                  </Tooltip>
+                  <IconButton disabled>
+                    <InfoIcon color="primary" />
+                  </IconButton>
                 </Grid>
                 <Grid item>
                   <Typography color="inherit" variant="h6" component="h3">
-                    <b>You are viewing open data</b>
+                    <b>{t('app.view_open_data_warning')}</b>
                   </Typography>
                 </Grid>
               </Grid>

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -10,9 +10,11 @@ import {
   Badge,
   makeStyles,
   Button,
+  Tooltip,
 } from '@material-ui/core';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 import SearchIcon from '@material-ui/icons/Search';
+import InfoIcon from '@material-ui/icons/Info';
 import { StyleRules } from '@material-ui/core/styles';
 import {
   DownloadCartItem,
@@ -149,6 +151,9 @@ const NavBar = React.memo(
   }): React.ReactElement => {
     const [t] = useTranslation();
 
+    //Determine whether logged in anonymously
+    const loggedInAnonymously = localStorage.getItem('autoLogin') === 'true';
+
     return (
       <Sticky>
         <StyledGrid container>
@@ -165,6 +170,40 @@ const NavBar = React.memo(
               component={PageBreadcrumbs}
             />
           </Grid>
+
+          {loggedInAnonymously ? (
+            <Paper
+              square
+              style={{
+                backgroundColor: '#00e676',
+                display: 'flex',
+                flexDirection: 'column',
+                paddingLeft: 6,
+                paddingRight: 20,
+                justifyContent: 'center',
+              }}
+            >
+              <Grid
+                container
+                direction="row"
+                alignItems="center"
+                justify="center"
+              >
+                <Grid item>
+                  <Tooltip title="Only open data is displayed when browsing anonymously">
+                    <IconButton>
+                      <InfoIcon color="primary" />
+                    </IconButton>
+                  </Tooltip>
+                </Grid>
+                <Grid item>
+                  <Typography color="inherit" variant="h6" component="h3">
+                    <b>You are viewing open data</b>
+                  </Typography>
+                </Grid>
+              </Grid>
+            </Paper>
+          ) : null}
 
           {/* The table entity count has a size of 2 (or 3 for xs screens); the
             breadcrumbs will take the remainder of the space. */}


### PR DESCRIPTION
## Description
This adds a label to the left of the results label in datagateway-dataview when the user is not logged in stating 'You are viewing open data'.

## Testing instructions
Still need to add tests.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #{834}
