### PR TITLE
Change ICAT Ansible back to master #843

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: ubuntu-20-work
+          ref: master
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: ubuntu-20-work
+          ref: master
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
@@ -383,7 +383,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: ubuntu-20-work
+          ref: master
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt


### PR DESCRIPTION
## Description
This closes #843. Just a simple branch reference change for ICAT Ansible. I've left the `ref: master` in because we seem to switch between branches of ICAT Ansible somewhat regularly so it just helps for next time if the `ref:` is left in place.

## Testing instructions
No functionality changes, just make sure the CI passes.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #843 
