### PR TITLE
Fix useInstrumentsInfinite query key typo (#859)

### DIFF
--- a/packages/datagateway-common/src/api/instruments.tsx
+++ b/packages/datagateway-common/src/api/instruments.tsx
@@ -102,7 +102,7 @@ export const useInstrumentsInfinite = (): UseInfiniteQueryResult<
     Instrument[],
     [string, { sort: SortType; filters: FiltersType }]
   >(
-    ['investigation', { sort, filters }],
+    ['instrument', { sort, filters }],
     (params) => {
       const { sort, filters } = params.queryKey[1];
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };


### PR DESCRIPTION
## Description
Fix typo in 'useInstrumentsInfinite' by replacing 'investigations' with 'instruments'.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #859
