### PR TITLE
Force Actions to use Python 3.9

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.9
           architecture: x64
 
       # ICAT Ansible clone and install dependencies
@@ -225,7 +225,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.9
           architecture: x64
 
       # ICAT Ansible clone and install dependencies
@@ -375,7 +375,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.9
           architecture: x64
 
       # ICAT Ansible clone and install dependencies


### PR DESCRIPTION
## Description
Short-term fix until the version of Ansible specified in ICAT Ansible is upgraded to support Python 3.10. Python 3.9 is used in DataGateway API's CI so this should work without issue. 

I will keep #876 open as we might choose to revert back to the default Python version chosen by GitHub Actions once I've upgraded ICAT Ansible. There's no real harm in keeping to Python 3.9 (I believe 3.6 is used in production for reference) but I guess keeping up to date with the new Python versions is probably a good thing :)

## Testing instructions
Just check that the CI passes

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #876 
