### PR TITLE
Modified the query parameters of dataview and search plugins to refetch selection #864

### DIFF
--- a/packages/datagateway-dataview/src/App.tsx
+++ b/packages/datagateway-dataview/src/App.tsx
@@ -113,7 +113,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: true,
-      staleTime: 5,
+      staleTime: 5000,
     },
   },
 });

--- a/packages/datagateway-dataview/src/App.tsx
+++ b/packages/datagateway-dataview/src/App.tsx
@@ -112,8 +112,8 @@ export const ConnectedPreloader = connect(mapPreloaderStateToProps)(Preloader);
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
-      staleTime: Infinity,
+      refetchOnWindowFocus: true,
+      staleTime: 5,
     },
   },
 });

--- a/packages/datagateway-search/src/App.tsx
+++ b/packages/datagateway-search/src/App.tsx
@@ -104,7 +104,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: true,
-      staleTime: 5,
+      staleTime: 5000,
     },
   },
 });

--- a/packages/datagateway-search/src/App.tsx
+++ b/packages/datagateway-search/src/App.tsx
@@ -103,8 +103,8 @@ export const ConnectedPreloader = connect(mapPreloaderStateToProps)(Preloader);
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
-      staleTime: Infinity,
+      refetchOnWindowFocus: true,
+      staleTime: 5,
     },
   },
 });


### PR DESCRIPTION
## Description
Set refetchOnWindowFocus to true and staleTime to 5 in App.tsx files of dataview and search plugins. This solved both the problems with incorrect selection shown between plugins and the [bug](https://github.com/ral-facilities/datagateway/issues/864#issuecomment-948671003) of cart icon showing items, even after they are removed.

## Testing instructions

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #864
