### PR TITLE
Improve tooltips and fix lingering tooltips #878

### DIFF
--- a/packages/datagateway-common/src/arrowtooltip.component.test.tsx
+++ b/packages/datagateway-common/src/arrowtooltip.component.test.tsx
@@ -3,6 +3,8 @@ import { createMount } from '@material-ui/core/test-utils';
 import { ReactWrapper } from 'enzyme';
 import { ArrowTooltip } from '.';
 import { Tooltip } from '@material-ui/core';
+import { getTooltipText } from './arrowtooltip.component';
+import { act } from 'react-dom/test-utils';
 
 describe('ArrowTooltip component', () => {
   let mount;
@@ -25,6 +27,43 @@ describe('ArrowTooltip component', () => {
 
   beforeEach(() => {
     mount = createMount({});
+  });
+
+  describe('getTooltipText', () => {
+    it('returns empty string for anything null-ish', () => {
+      expect(getTooltipText(undefined)).toBe('');
+      expect(getTooltipText(null)).toBe('');
+      expect(getTooltipText({})).toBe('');
+    });
+
+    it('returns value for any primitives', () => {
+      expect(getTooltipText(1)).toBe('1');
+      expect(getTooltipText(false)).toBe('false');
+      expect(getTooltipText('test')).toBe('test');
+    });
+
+    it('returns nested value for any react nodes', () => {
+      expect(getTooltipText(<b>{'Test'}</b>)).toBe('Test');
+      expect(
+        getTooltipText(
+          <div>
+            <b>
+              <i>{'Test'}</i>
+            </b>
+          </div>
+        )
+      ).toBe('Test');
+    });
+    it('returns concatted nested values for any react node lists', () => {
+      expect(
+        getTooltipText(
+          <React.Fragment>
+            <b>{'Test'}</b>
+            <b>{1}</b>
+          </React.Fragment>
+        )
+      ).toBe('Test1');
+    });
   });
 
   // Note that disableHoverListener has the opposite value to isTooltipVisible
@@ -106,6 +145,43 @@ describe('ArrowTooltip component', () => {
     // From 'tooltip unchanged when offsetHeight < maxEnabledHeight' this is a case that should disable the
     // hover listener, but force it to be enabled
     const wrapper = createWrapper(-1, 1, true);
+    expect(wrapper.find(Tooltip).props().disableHoverListener).toEqual(true);
+  });
+
+  it('tooltip recalculates when resize or columnResize actions sent', () => {
+    // Mock the value of scrollWidth
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      value: 0,
+    });
+    const wrapper = createWrapper();
+    expect(wrapper.find(Tooltip).props().disableHoverListener).toEqual(true);
+
+    // Mock the value of scrollWidth
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      value: 1,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+      // need to use setProps to force enzyme to rerender
+      wrapper.setProps({});
+    });
+
+    expect(wrapper.find(Tooltip).props().disableHoverListener).toEqual(false);
+
+    // Mock the value of scrollWidth
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      value: 0,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('columnResize'));
+      wrapper.setProps({});
+    });
+
     expect(wrapper.find(Tooltip).props().disableHoverListener).toEqual(true);
   });
 });

--- a/packages/datagateway-common/src/card/entityCard.component.test.tsx
+++ b/packages/datagateway-common/src/card/entityCard.component.test.tsx
@@ -61,6 +61,7 @@ describe('Card', () => {
     expect(wrapper.find('[aria-label="card-title"]').text()).toEqual(
       'Test Title'
     );
+    expect(wrapper.find('ArrowTooltip').prop('title')).toEqual('Test Title');
   });
 
   it('renders with a description', () => {
@@ -143,11 +144,12 @@ describe('Card', () => {
         information={[
           {
             dataKey: 'visitId',
-            content: () => '1',
+            content: function Test() {
+              return <b>{'1'}</b>;
+            },
             icon: function Icon() {
               return <strong>ICON - </strong>;
             },
-            noTooltip: true,
           },
         ]}
       />
@@ -158,7 +160,13 @@ describe('Card', () => {
     );
     expect(wrapper.exists("[aria-label='card-info-data-visitId']")).toBe(true);
     expect(
-      wrapper.find("[aria-label='card-info-data-visitId']").text()
+      wrapper.find("[aria-label='card-info-data-visitId']").find('b').text()
+    ).toEqual('1');
+    expect(
+      wrapper
+        .find("[aria-label='card-info-data-visitId']")
+        .find('ArrowTooltip')
+        .prop('title')
     ).toEqual('1');
   });
 

--- a/packages/datagateway-common/src/card/entityCard.component.tsx
+++ b/packages/datagateway-common/src/card/entityCard.component.tsx
@@ -13,7 +13,7 @@ import {
 } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import ArrowTooltip from '../arrowtooltip.component';
+import ArrowTooltip, { getTooltipText } from '../arrowtooltip.component';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import hexToRbga from 'hex-to-rgba';
@@ -225,7 +225,7 @@ const EntityCard = React.memo(
         ...details,
         // If we use custom content we can choose to not show a tooltip.
         content: !details.noTooltip ? (
-          <ArrowTooltip title={nestedValue(entity, details.dataKey)}>
+          <ArrowTooltip title={getTooltipText(details.content)}>
             <Typography>{details.content}</Typography>
           </ArrowTooltip>
         ) : (
@@ -307,7 +307,9 @@ const EntityCard = React.memo(
             */}
               <div aria-label="main-content" ref={mainContentRef}>
                 <ArrowTooltip
-                  title={title.label}
+                  title={
+                    title.content ? getTooltipText(title.content) : title.label
+                  }
                   enterDelay={500}
                   percentageWidth={30}
                   maxEnabledHeight={32}

--- a/packages/datagateway-common/src/table/cellRenderers/__snapshots__/dataCell.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/cellRenderers/__snapshots__/dataCell.component.test.tsx.snap
@@ -66,13 +66,15 @@ exports[`Data cell component renders provided cell data correctly 1`] = `
 >
   <ArrowTooltip
     enterDelay={500}
-    title="non nested property"
+    title="provided test"
   >
     <WithStyles(ForwardRef(Typography))
       noWrap={true}
       variant="body2"
     >
-      provided test
+      <b>
+        provided test
+      </b>
     </WithStyles(ForwardRef(Typography))>
   </ArrowTooltip>
 </div>

--- a/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
@@ -84,7 +84,7 @@ export function externalSiteLink(
   view?: ViewsType
 ): React.ReactElement {
   return (
-    <Link href={linkUrl} data-testId="table-study-doi-link">
+    <Link href={linkUrl} data-test-id="table-study-doi-link">
       {linkText}
     </Link>
   );

--- a/packages/datagateway-common/src/table/cellRenderers/dataCell.component.test.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/dataCell.component.test.tsx
@@ -29,7 +29,7 @@ describe('Data cell component', () => {
     const wrapper = shallow(
       <DataCell
         {...dataCellProps}
-        cellContentRenderer={() => 'provided test'}
+        cellContentRenderer={() => <b>{'provided test'}</b>}
       />
     );
     expect(wrapper).toMatchSnapshot();

--- a/packages/datagateway-common/src/table/cellRenderers/dataCell.component.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/dataCell.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TableCellProps, TableCellRenderer } from 'react-virtualized';
 import { TableCell, Typography, useMediaQuery } from '@material-ui/core';
-import ArrowTooltip from '../../arrowtooltip.component';
+import ArrowTooltip, { getTooltipText } from '../../arrowtooltip.component';
 
 type CellRendererProps = TableCellProps & {
   className: string;
@@ -13,9 +13,12 @@ const DataCell = React.memo(
     const { className, dataKey, rowData, cellContentRenderer } = props;
 
     // use . in dataKey name to drill down into nested row data
-    const cellValue = dataKey.split('.').reduce(function (prev, curr) {
-      return prev ? prev[curr] : null;
-    }, rowData);
+    // if cellContentRenderer not provided
+    const cellContent = cellContentRenderer
+      ? cellContentRenderer(props)
+      : dataKey.split('.').reduce(function (prev, curr) {
+          return prev ? prev[curr] : null;
+        }, rowData);
 
     const smWindow = !useMediaQuery('(min-width: 960px)');
     return (
@@ -26,9 +29,9 @@ const DataCell = React.memo(
         variant="body"
         style={smWindow ? { paddingLeft: 8, paddingRight: 8 } : {}}
       >
-        <ArrowTooltip title={cellValue} enterDelay={500}>
+        <ArrowTooltip title={getTooltipText(cellContent)} enterDelay={500}>
           <Typography variant="body2" noWrap>
-            {cellContentRenderer ? cellContentRenderer(props) : cellValue}
+            {cellContent}
           </Typography>
         </ArrowTooltip>
       </TableCell>

--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Data column header component renders correctly with filter but no sort 
       </Styled(MuiBox)>
     </Styled(MuiBox)>
     <TextColumnFilter
+      label="Test"
       onChange={[MockFunction]}
     />
   </div>
@@ -134,6 +135,7 @@ exports[`Data column header component renders correctly with sort and filter 1`]
       </Styled(MuiBox)>
     </Styled(MuiBox)>
     <TextColumnFilter
+      label="Test"
       onChange={[MockFunction]}
     />
   </div>

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
@@ -10,6 +10,7 @@ describe('Data column header component', () => {
   const resizeColumn = jest.fn();
   const dataHeaderProps = {
     label: 'Test',
+    labelString: 'Test',
     dataKey: 'test',
     className: 'test-class',
     sort: {},
@@ -100,5 +101,18 @@ describe('Data column header component', () => {
     wrapper.find('Draggable').prop('onDrag')(null, { deltaX: 50 });
 
     expect(resizeColumn).toHaveBeenCalledWith('test', 50);
+  });
+
+  it('sends a columnResize event when column resizer is finished dragging', () => {
+    const mockDispatchEvent = jest
+      .spyOn(window, 'dispatchEvent')
+      .mockImplementationOnce(() => true);
+
+    const wrapper = shallow(<DataHeader {...dataHeaderProps} />);
+
+    wrapper.find('Draggable').prop('onStop')();
+
+    expect(mockDispatchEvent).toHaveBeenCalledWith(expect.any(Event));
+    expect(mockDispatchEvent.mock.calls[0][0].type).toBe('columnResize');
   });
 });

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -95,6 +95,10 @@ const DataHeader = React.memo(
         <Draggable
           axis="none"
           onDrag={(event, { deltaX }) => resizeColumn(dataKey, deltaX)}
+          onStop={() => {
+            const event = new Event('columnResize');
+            window.dispatchEvent(event);
+          }}
         >
           <DragIndicator
             fontSize="small"

--- a/packages/datagateway-dataview/src/page/__snapshots__/breadcrumbs.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/breadcrumbs.component.test.tsx.snap
@@ -246,51 +246,22 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                         title="breadcrumbs.home"
                                       >
                                         <WithStyles(ForwardRef(Tooltip))
-                                          PopperProps={
-                                            Object {
-                                              "popperOptions": Object {
-                                                "modifiers": Object {
-                                                  "arrow": Object {
-                                                    "element": null,
-                                                    "enabled": false,
-                                                  },
-                                                },
-                                              },
-                                            }
-                                          }
+                                          arrow={true}
                                           classes={
                                             Object {
-                                              "popper": "makeStyles-popper-3",
+                                              "arrow": "makeStyles-arrow-3",
                                               "tooltip": "makeStyles-tooltip-2",
                                             }
                                           }
                                           disableHoverListener={true}
-                                          title={
-                                            <React.Fragment>
-                                              breadcrumbs.home
-                                              <span
-                                                className="makeStyles-arrow-4"
-                                              />
-                                            </React.Fragment>
-                                          }
+                                          title="breadcrumbs.home"
                                         >
                                           <ForwardRef(Tooltip)
-                                            PopperProps={
-                                              Object {
-                                                "popperOptions": Object {
-                                                  "modifiers": Object {
-                                                    "arrow": Object {
-                                                      "element": null,
-                                                      "enabled": false,
-                                                    },
-                                                  },
-                                                },
-                                              }
-                                            }
+                                            arrow={true}
                                             classes={
                                               Object {
-                                                "arrow": "MuiTooltip-arrow",
-                                                "popper": "MuiTooltip-popper makeStyles-popper-3",
+                                                "arrow": "MuiTooltip-arrow makeStyles-arrow-3",
+                                                "popper": "MuiTooltip-popper",
                                                 "popperArrow": "MuiTooltip-popperArrow",
                                                 "popperInteractive": "MuiTooltip-popperInteractive",
                                                 "tooltip": "MuiTooltip-tooltip makeStyles-tooltip-2",
@@ -303,14 +274,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               }
                                             }
                                             disableHoverListener={true}
-                                            title={
-                                              <React.Fragment>
-                                                breadcrumbs.home
-                                                <span
-                                                  className="makeStyles-arrow-4"
-                                                />
-                                              </React.Fragment>
-                                            }
+                                            title="breadcrumbs.home"
                                           >
                                             <div
                                               aria-describedby={null}
@@ -389,7 +353,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   </p>
                                                 </div>
                                               }
-                                              className="MuiTooltip-popper makeStyles-popper-3"
+                                              className="MuiTooltip-popper MuiTooltip-popperArrow"
                                               id={null}
                                               open={false}
                                               placement="bottom"
@@ -430,51 +394,22 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                         title="breadcrumbs.investigation {count:100}"
                                       >
                                         <WithStyles(ForwardRef(Tooltip))
-                                          PopperProps={
-                                            Object {
-                                              "popperOptions": Object {
-                                                "modifiers": Object {
-                                                  "arrow": Object {
-                                                    "element": null,
-                                                    "enabled": false,
-                                                  },
-                                                },
-                                              },
-                                            }
-                                          }
+                                          arrow={true}
                                           classes={
                                             Object {
-                                              "popper": "makeStyles-popper-3",
+                                              "arrow": "makeStyles-arrow-3",
                                               "tooltip": "makeStyles-tooltip-2",
                                             }
                                           }
                                           disableHoverListener={true}
-                                          title={
-                                            <React.Fragment>
-                                              breadcrumbs.investigation {count:100}
-                                              <span
-                                                className="makeStyles-arrow-4"
-                                              />
-                                            </React.Fragment>
-                                          }
+                                          title="breadcrumbs.investigation {count:100}"
                                         >
                                           <ForwardRef(Tooltip)
-                                            PopperProps={
-                                              Object {
-                                                "popperOptions": Object {
-                                                  "modifiers": Object {
-                                                    "arrow": Object {
-                                                      "element": null,
-                                                      "enabled": false,
-                                                    },
-                                                  },
-                                                },
-                                              }
-                                            }
+                                            arrow={true}
                                             classes={
                                               Object {
-                                                "arrow": "MuiTooltip-arrow",
-                                                "popper": "MuiTooltip-popper makeStyles-popper-3",
+                                                "arrow": "MuiTooltip-arrow makeStyles-arrow-3",
+                                                "popper": "MuiTooltip-popper",
                                                 "popperArrow": "MuiTooltip-popperArrow",
                                                 "popperInteractive": "MuiTooltip-popperInteractive",
                                                 "tooltip": "MuiTooltip-tooltip makeStyles-tooltip-2",
@@ -487,14 +422,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               }
                                             }
                                             disableHoverListener={true}
-                                            title={
-                                              <React.Fragment>
-                                                breadcrumbs.investigation {count:100}
-                                                <span
-                                                  className="makeStyles-arrow-4"
-                                                />
-                                              </React.Fragment>
-                                            }
+                                            title="breadcrumbs.investigation {count:100}"
                                           >
                                             <div
                                               aria-describedby={null}
@@ -681,7 +609,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   </a>
                                                 </div>
                                               }
-                                              className="MuiTooltip-popper makeStyles-popper-3"
+                                              className="MuiTooltip-popper MuiTooltip-popperArrow"
                                               id={null}
                                               open={false}
                                               placement="bottom"
@@ -722,51 +650,22 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                         title="Test 1"
                                       >
                                         <WithStyles(ForwardRef(Tooltip))
-                                          PopperProps={
-                                            Object {
-                                              "popperOptions": Object {
-                                                "modifiers": Object {
-                                                  "arrow": Object {
-                                                    "element": null,
-                                                    "enabled": false,
-                                                  },
-                                                },
-                                              },
-                                            }
-                                          }
+                                          arrow={true}
                                           classes={
                                             Object {
-                                              "popper": "makeStyles-popper-3",
+                                              "arrow": "makeStyles-arrow-3",
                                               "tooltip": "makeStyles-tooltip-2",
                                             }
                                           }
                                           disableHoverListener={true}
-                                          title={
-                                            <React.Fragment>
-                                              Test 1
-                                              <span
-                                                className="makeStyles-arrow-4"
-                                              />
-                                            </React.Fragment>
-                                          }
+                                          title="Test 1"
                                         >
                                           <ForwardRef(Tooltip)
-                                            PopperProps={
-                                              Object {
-                                                "popperOptions": Object {
-                                                  "modifiers": Object {
-                                                    "arrow": Object {
-                                                      "element": null,
-                                                      "enabled": false,
-                                                    },
-                                                  },
-                                                },
-                                              }
-                                            }
+                                            arrow={true}
                                             classes={
                                               Object {
-                                                "arrow": "MuiTooltip-arrow",
-                                                "popper": "MuiTooltip-popper makeStyles-popper-3",
+                                                "arrow": "MuiTooltip-arrow makeStyles-arrow-3",
+                                                "popper": "MuiTooltip-popper",
                                                 "popperArrow": "MuiTooltip-popperArrow",
                                                 "popperInteractive": "MuiTooltip-popperInteractive",
                                                 "tooltip": "MuiTooltip-tooltip makeStyles-tooltip-2",
@@ -779,14 +678,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               }
                                             }
                                             disableHoverListener={true}
-                                            title={
-                                              <React.Fragment>
-                                                Test 1
-                                                <span
-                                                  className="makeStyles-arrow-4"
-                                                />
-                                              </React.Fragment>
-                                            }
+                                            title="Test 1"
                                           >
                                             <div
                                               aria-describedby={null}
@@ -973,7 +865,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   </a>
                                                 </div>
                                               }
-                                              className="MuiTooltip-popper makeStyles-popper-3"
+                                              className="MuiTooltip-popper MuiTooltip-popperArrow"
                                               id={null}
                                               open={false}
                                               placement="bottom"
@@ -1013,51 +905,22 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                         title="INVESTIGATION 1"
                                       >
                                         <WithStyles(ForwardRef(Tooltip))
-                                          PopperProps={
-                                            Object {
-                                              "popperOptions": Object {
-                                                "modifiers": Object {
-                                                  "arrow": Object {
-                                                    "element": null,
-                                                    "enabled": false,
-                                                  },
-                                                },
-                                              },
-                                            }
-                                          }
+                                          arrow={true}
                                           classes={
                                             Object {
-                                              "popper": "makeStyles-popper-3",
+                                              "arrow": "makeStyles-arrow-3",
                                               "tooltip": "makeStyles-tooltip-2",
                                             }
                                           }
                                           disableHoverListener={true}
-                                          title={
-                                            <React.Fragment>
-                                              INVESTIGATION 1
-                                              <span
-                                                className="makeStyles-arrow-4"
-                                              />
-                                            </React.Fragment>
-                                          }
+                                          title="INVESTIGATION 1"
                                         >
                                           <ForwardRef(Tooltip)
-                                            PopperProps={
-                                              Object {
-                                                "popperOptions": Object {
-                                                  "modifiers": Object {
-                                                    "arrow": Object {
-                                                      "element": null,
-                                                      "enabled": false,
-                                                    },
-                                                  },
-                                                },
-                                              }
-                                            }
+                                            arrow={true}
                                             classes={
                                               Object {
-                                                "arrow": "MuiTooltip-arrow",
-                                                "popper": "MuiTooltip-popper makeStyles-popper-3",
+                                                "arrow": "MuiTooltip-arrow makeStyles-arrow-3",
+                                                "popper": "MuiTooltip-popper",
                                                 "popperArrow": "MuiTooltip-popperArrow",
                                                 "popperInteractive": "MuiTooltip-popperInteractive",
                                                 "tooltip": "MuiTooltip-tooltip makeStyles-tooltip-2",
@@ -1070,14 +933,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               }
                                             }
                                             disableHoverListener={true}
-                                            title={
-                                              <React.Fragment>
-                                                INVESTIGATION 1
-                                                <span
-                                                  className="makeStyles-arrow-4"
-                                                />
-                                              </React.Fragment>
-                                            }
+                                            title="INVESTIGATION 1"
                                           >
                                             <div
                                               aria-describedby={null}
@@ -1156,7 +1012,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   </p>
                                                 </div>
                                               }
-                                              className="MuiTooltip-popper makeStyles-popper-3"
+                                              className="MuiTooltip-popper MuiTooltip-popperArrow"
                                               id={null}
                                               open={false}
                                               placement="bottom"
@@ -1197,51 +1053,22 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                         title="breadcrumbs.datafile {count:100}"
                                       >
                                         <WithStyles(ForwardRef(Tooltip))
-                                          PopperProps={
-                                            Object {
-                                              "popperOptions": Object {
-                                                "modifiers": Object {
-                                                  "arrow": Object {
-                                                    "element": null,
-                                                    "enabled": false,
-                                                  },
-                                                },
-                                              },
-                                            }
-                                          }
+                                          arrow={true}
                                           classes={
                                             Object {
-                                              "popper": "makeStyles-popper-3",
+                                              "arrow": "makeStyles-arrow-3",
                                               "tooltip": "makeStyles-tooltip-2",
                                             }
                                           }
                                           disableHoverListener={true}
-                                          title={
-                                            <React.Fragment>
-                                              breadcrumbs.datafile {count:100}
-                                              <span
-                                                className="makeStyles-arrow-4"
-                                              />
-                                            </React.Fragment>
-                                          }
+                                          title="breadcrumbs.datafile {count:100}"
                                         >
                                           <ForwardRef(Tooltip)
-                                            PopperProps={
-                                              Object {
-                                                "popperOptions": Object {
-                                                  "modifiers": Object {
-                                                    "arrow": Object {
-                                                      "element": null,
-                                                      "enabled": false,
-                                                    },
-                                                  },
-                                                },
-                                              }
-                                            }
+                                            arrow={true}
                                             classes={
                                               Object {
-                                                "arrow": "MuiTooltip-arrow",
-                                                "popper": "MuiTooltip-popper makeStyles-popper-3",
+                                                "arrow": "MuiTooltip-arrow makeStyles-arrow-3",
+                                                "popper": "MuiTooltip-popper",
                                                 "popperArrow": "MuiTooltip-popperArrow",
                                                 "popperInteractive": "MuiTooltip-popperInteractive",
                                                 "tooltip": "MuiTooltip-tooltip makeStyles-tooltip-2",
@@ -1254,14 +1081,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               }
                                             }
                                             disableHoverListener={true}
-                                            title={
-                                              <React.Fragment>
-                                                breadcrumbs.datafile {count:100}
-                                                <span
-                                                  className="makeStyles-arrow-4"
-                                                />
-                                              </React.Fragment>
-                                            }
+                                            title="breadcrumbs.datafile {count:100}"
                                           >
                                             <div
                                               aria-describedby={null}
@@ -1344,7 +1164,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   </p>
                                                 </div>
                                               }
-                                              className="MuiTooltip-popper makeStyles-popper-3"
+                                              className="MuiTooltip-popper MuiTooltip-popperArrow"
                                               id={null}
                                               open={false}
                                               placement="bottom"

--- a/packages/datagateway-dataview/src/page/idCheckFunctions.ts
+++ b/packages/datagateway-dataview/src/page/idCheckFunctions.ts
@@ -64,7 +64,6 @@ const unmemoizedCheckInstrumentAndFacilityCycleId = (
   facilityCycleId: number,
   investigationId: number
 ): Promise<boolean> => {
-  console.log('performing instrument and facility cycle check');
   return axios
     .get(
       `${apiUrl}/instruments/${instrumentId}/facilitycycles/${facilityCycleId}/investigations/`,
@@ -161,7 +160,6 @@ const unmemoizedCheckInstrumentId = (
       },
     })
     .then((response: AxiosResponse<Investigation[]>) => {
-      console.log('instrument study check', response.data.length);
       return response.data.length > 0;
     })
     .catch((error) => {

--- a/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
@@ -232,7 +232,7 @@ describe('PageContainer - Tests', () => {
     expect(wrapper.exists('[aria-label="filter-message"]')).toBeFalsy();
   });
 
-  it('do not use StyledRouting component on landing pages', () => {
+  it('do not use StyledRouting component on landing pages', async () => {
     (checkInstrumentId as jest.Mock).mockResolvedValueOnce(true);
     (useQueryClient as jest.Mock).mockReturnValue({
       getQueryData: jest.fn(),
@@ -240,6 +240,11 @@ describe('PageContainer - Tests', () => {
     history.replace(`${paths.studyHierarchy.landing.isisStudyLanding}`);
 
     const wrapper = createWrapper();
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
 
     expect(wrapper.exists('StyledRouting')).toBeFalsy();
   });

--- a/packages/datagateway-dataview/src/views/card/investigationCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/investigationCardView.component.test.tsx
@@ -161,12 +161,15 @@ describe('Investigation - Card View', () => {
   it('displays DOI and renders the expected Link ', () => {
     const wrapper = createWrapper();
     expect(
-      wrapper.find('[data-testId="investigation-card-doi-link"]').first().text()
+      wrapper
+        .find('[data-test-id="investigation-card-doi-link"]')
+        .first()
+        .text()
     ).toEqual('doi 1');
 
     expect(
       wrapper
-        .find('[data-testId="investigation-card-doi-link"]')
+        .find('[data-test-id="investigation-card-doi-link"]')
         .first()
         .prop('href')
     ).toEqual('https://doi.org/doi 1');

--- a/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
@@ -106,7 +106,7 @@ const InvestigationCardView = (): React.ReactElement => {
             entity?.doi && (
               <MuiLink
                 href={`https://doi.org/${entity.doi}`}
-                data-testId="investigation-card-doi-link"
+                data-test-id="investigation-card-doi-link"
               >
                 {entity.doi}
               </MuiLink>

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
@@ -189,14 +189,14 @@ describe('ISIS Investigations - Card View', () => {
     const wrapper = createWrapper();
     expect(
       wrapper
-        .find('[data-testId="isis-investigations-card-doi-link"]')
+        .find('[data-test-id="isis-investigations-card-doi-link"]')
         .first()
         .text()
     ).toEqual('study pid');
 
     expect(
       wrapper
-        .find('[data-testId="isis-investigations-card-doi-link"]')
+        .find('[data-test-id="isis-investigations-card-doi-link"]')
         .first()
         .prop('href')
     ).toEqual('https://doi.org/study pid');

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -129,7 +129,7 @@ const ISISInvestigationsCardView = (
             entity?.studyInvestigations?.[0]?.study.pid && (
               <MuiLink
                 href={`https://doi.org/${entity.studyInvestigations[0].study.pid}`}
-                data-testId="isis-investigations-card-doi-link"
+                data-test-id="isis-investigations-card-doi-link"
               >
                 {entity.studyInvestigations[0].study.pid}
               </MuiLink>

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
@@ -171,13 +171,13 @@ describe('Investigation details panel component', () => {
     const wrapper = createWrapper();
     expect(
       wrapper
-        .find('[data-testId="investigation-details-panel-doi-link"]')
+        .find('[data-test-id="investigation-details-panel-doi-link"]')
         .first()
         .text()
     ).toEqual('doi 1');
     expect(
       wrapper
-        .find('[data-testId="investigation-details-panel-doi-link"]')
+        .find('[data-test-id="investigation-details-panel-doi-link"]')
         .first()
         .prop('href')
     ).toEqual('https://doi.org/doi 1');

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
@@ -175,7 +175,7 @@ const InvestigationDetailsPanel = (
               {investigationData.doi && investigationData.doi !== 'null' ? (
                 <MuiLink
                   href={`https://doi.org/${investigationData.doi}`}
-                  data-testId="investigation-details-panel-doi-link"
+                  data-test-id="investigation-details-panel-doi-link"
                 >
                   {investigationData.doi}
                 </MuiLink>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.test.tsx
@@ -129,14 +129,14 @@ describe('ISIS Dataset Landing page', () => {
 
     expect(
       wrapper
-        .find('[data-testId="isis-dataset-landing-doi-link"]')
+        .find('[data-test-id="isis-dataset-landing-doi-link"]')
         .first()
         .text()
     ).toEqual('doi 1');
 
     expect(
       wrapper
-        .find('[data-testId="isis-dataset-landing-doi-link"]')
+        .find('[data-test-id="isis-dataset-landing-doi-link"]')
         .first()
         .prop('href')
     ).toEqual('https://doi.org/doi 1');

--- a/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.tsx
@@ -111,7 +111,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
           entity?.doi && (
             <MuiLink
               href={`https://doi.org/${entity.doi}`}
-              data-testId="isis-dataset-landing-doi-link"
+              data-test-id="isis-dataset-landing-doi-link"
             >
               {entity.doi}
             </MuiLink>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
@@ -368,14 +368,14 @@ describe('ISIS Investigation Landing page', () => {
     const wrapper = createWrapper();
     expect(
       wrapper
-        .find('[data-testId="isis-investigation-landing-doi-link"]')
+        .find('[data-test-id="isis-investigation-landing-doi-link"]')
         .first()
         .text()
     ).toEqual('doi 1');
 
     expect(
       wrapper
-        .find('[data-testId="isis-investigation-landing-doi-link"]')
+        .find('[data-test-id="isis-investigation-landing-doi-link"]')
         .first()
         .prop('href')
     ).toEqual('https://doi.org/doi 1');

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -213,7 +213,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
           entity?.doi && (
             <MuiLink
               href={`https://doi.org/${entity.doi}`}
-              data-testId="isis-investigation-landing-doi-link"
+              data-test-id="isis-investigation-landing-doi-link"
             >
               {entity.doi}
             </MuiLink>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.test.tsx
@@ -274,13 +274,13 @@ describe('ISIS Study Landing page', () => {
     const wrapper = createWrapper();
     expect(
       wrapper
-        .find('[data-testId="landing-study-doi-link"]')
+        .find('[data-test-id="landing-study-doi-link"]')
         .first()
         .prop('href')
     ).toEqual('https://doi.org/doi 1');
 
     expect(
-      wrapper.find('[data-testId="landing-study-doi-link"]').first().text()
+      wrapper.find('[data-test-id="landing-study-doi-link"]').first().text()
     ).toEqual('doi 1');
   });
 

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -116,7 +116,7 @@ const LinkedInvestigation = (
           entity?.doi && (
             <MuiLink
               href={`https://doi.org/${entity.doi}`}
-              data-testId="landing-study-doi-link"
+              data-test-id="landing-study-doi-link"
             >
               {entity.doi}
             </MuiLink>

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
@@ -96,7 +96,7 @@ Object {
 
 exports[`Datafile table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-261"
+  className="makeStyles-root-251"
   container={true}
   direction="column"
   id="details-panel"
@@ -113,7 +113,7 @@ exports[`Datafile table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-262"
+      className="makeStyles-divider-252"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
@@ -247,7 +247,7 @@ Object {
 
 exports[`Dataset table component renders details panel correctly 1`] = `
 <div
-  className="MuiGrid-root makeStyles-root-235 MuiGrid-container MuiGrid-direction-xs-column"
+  className="MuiGrid-root makeStyles-root-226 MuiGrid-container MuiGrid-direction-xs-column"
   id="details-panel"
 >
   <WithStyles(ForwardRef(Grid))
@@ -262,7 +262,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-236"
+      className="makeStyles-divider-227"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -162,7 +162,7 @@ Object {
 
 exports[`Investigation table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-343"
+  className="makeStyles-root-334"
   container={true}
   direction="column"
   id="details-panel"
@@ -179,7 +179,7 @@ exports[`Investigation table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-344"
+      className="makeStyles-divider-335"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -163,7 +163,7 @@ Object {
 
 exports[`Investigation table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-381"
+  className="makeStyles-root-371"
   container={true}
   direction="column"
   id="details-panel"
@@ -180,7 +180,7 @@ exports[`Investigation table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-382"
+      className="makeStyles-divider-372"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
@@ -171,11 +171,11 @@ describe('Investigation table component', () => {
   it('displays DOI and renders the expected Link ', () => {
     const wrapper = createWrapper();
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().text()
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().text()
     ).toEqual('doi 1');
 
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().prop('href')
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().prop('href')
     ).toEqual('https://doi.org/doi 1');
   });
 
@@ -286,7 +286,6 @@ describe('Investigation table component', () => {
           entityType: 'investigation',
           id: 1,
           name: 'test',
-          doi: 'Test 1',
           parentEntities: [],
         },
         {
@@ -294,7 +293,6 @@ describe('Investigation table component', () => {
           entityType: 'dataset',
           id: 2,
           name: 'test',
-          doi: 'Test 2',
           parentEntities: [],
         },
       ],
@@ -347,6 +345,7 @@ describe('Investigation table component', () => {
         id: 1,
         name: 'test',
         title: 'test',
+        doi: 'Test 1',
       },
     ];
     (useInvestigationsInfinite as jest.Mock).mockReturnValueOnce({

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-351"
+      className="makeStyles-root-341"
       container={true}
       direction="column"
     >
@@ -210,7 +210,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-352"
+          className="makeStyles-divider-342"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-386"
+      className="makeStyles-root-375"
       container={true}
       direction="column"
     >
@@ -209,7 +209,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-387"
+          className="makeStyles-divider-376"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
@@ -286,7 +286,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <WithStyles(ForwardRef(Link))
-            data-testId="investigation-details-panel-doi-link"
+            data-test-id="investigation-details-panel-doi-link"
             href="https://doi.org/doi 1"
           >
             doi 1
@@ -486,7 +486,7 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
 
 exports[`ISIS Investigations table component renders title, name and DOI as links 3`] = `
 <WithStyles(ForwardRef(Link))
-  data-testId="table-study-doi-link"
+  data-test-id="table-study-doi-link"
   href="https://doi.org/study pid"
 >
   <ForwardRef(Link)
@@ -500,14 +500,14 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
         "underlineNone": "MuiLink-underlineNone",
       }
     }
-    data-testId="table-study-doi-link"
+    data-test-id="table-study-doi-link"
     href="https://doi.org/study pid"
   >
     <WithStyles(ForwardRef(Typography))
       className="MuiLink-root MuiLink-underlineHover"
       color="primary"
       component="a"
-      data-testId="table-study-doi-link"
+      data-test-id="table-study-doi-link"
       href="https://doi.org/study pid"
       onBlur={[Function]}
       onFocus={[Function]}
@@ -551,7 +551,7 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
         }
         color="primary"
         component="a"
-        data-testId="table-study-doi-link"
+        data-test-id="table-study-doi-link"
         href="https://doi.org/study pid"
         onBlur={[Function]}
         onFocus={[Function]}
@@ -559,7 +559,7 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
       >
         <a
           className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-          data-testId="table-study-doi-link"
+          data-test-id="table-study-doi-link"
           href="https://doi.org/study pid"
           onBlur={[Function]}
           onFocus={[Function]}
@@ -729,7 +729,7 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
 
 exports[`ISIS Investigations table component renders title, name and DOI as links in StudyHierarchy 3`] = `
 <WithStyles(ForwardRef(Link))
-  data-testId="table-study-doi-link"
+  data-test-id="table-study-doi-link"
   href="https://doi.org/study pid"
 >
   <ForwardRef(Link)
@@ -743,14 +743,14 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
         "underlineNone": "MuiLink-underlineNone",
       }
     }
-    data-testId="table-study-doi-link"
+    data-test-id="table-study-doi-link"
     href="https://doi.org/study pid"
   >
     <WithStyles(ForwardRef(Typography))
       className="MuiLink-root MuiLink-underlineHover"
       color="primary"
       component="a"
-      data-testId="table-study-doi-link"
+      data-test-id="table-study-doi-link"
       href="https://doi.org/study pid"
       onBlur={[Function]}
       onFocus={[Function]}
@@ -794,7 +794,7 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
         }
         color="primary"
         component="a"
-        data-testId="table-study-doi-link"
+        data-test-id="table-study-doi-link"
         href="https://doi.org/study pid"
         onBlur={[Function]}
         onFocus={[Function]}
@@ -802,7 +802,7 @@ exports[`ISIS Investigations table component renders title, name and DOI as link
       >
         <a
           className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-          data-testId="table-study-doi-link"
+          data-test-id="table-study-doi-link"
           href="https://doi.org/study pid"
           onBlur={[Function]}
           onFocus={[Function]}

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
@@ -214,7 +214,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-419"
+      className="makeStyles-root-408"
       container={true}
       direction="column"
     >
@@ -230,7 +230,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-420"
+          className="makeStyles-divider-409"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))>
           <WithStyles(ForwardRef(Link))
-            data-testId="investigation-details-panel-doi-link"
+            data-test-id="investigation-details-panel-doi-link"
             href="https://doi.org/doi 1"
           >
             doi 1

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -201,11 +201,11 @@ describe('ISIS Investigations table component', () => {
   it('displays DOI and renders the expected Link ', () => {
     const wrapper = createWrapper();
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().text()
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().text()
     ).toEqual('study pid');
 
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().prop('href')
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().prop('href')
     ).toEqual('https://doi.org/study pid');
   });
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
@@ -410,11 +410,11 @@ describe('ISIS MyData table component', () => {
   it('displays DOI and renders the expected Link ', () => {
     const wrapper = createWrapper();
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().text()
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().text()
     ).toEqual('study pid');
 
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().prop('href')
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().prop('href')
     ).toEqual('https://doi.org/study pid');
   });
 

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
@@ -340,14 +340,14 @@ describe('Investigation - Card View', () => {
     const wrapper = createWrapper();
     expect(
       wrapper
-        .find('[data-testId="investigation-search-card-doi-link"]')
+        .find('[data-test-id="investigation-search-card-doi-link"]')
         .first()
         .text()
     ).toEqual('doi 1');
 
     expect(
       wrapper
-        .find('[data-testId="investigation-search-card-doi-link"]')
+        .find('[data-test-id="investigation-search-card-doi-link"]')
         .first()
         .prop('href')
     ).toEqual('https://doi.org/doi 1');

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
@@ -217,7 +217,7 @@ const InvestigationCardView = (
             entity?.doi && (
               <MuiLink
                 href={`https://doi.org/${entity.doi}`}
-                data-testId="investigation-search-card-doi-link"
+                data-test-id="investigation-search-card-doi-link"
               >
                 {entity.doi}
               </MuiLink>

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -118,7 +118,7 @@ Object {
 
 exports[`Datafile search table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-262"
+  className="makeStyles-root-253"
   container={true}
   direction="column"
   id="details-panel"
@@ -135,7 +135,7 @@ exports[`Datafile search table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-263"
+      className="makeStyles-divider-254"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
@@ -264,7 +264,7 @@ Object {
 
 exports[`Dataset table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-262"
+  className="makeStyles-root-253"
   container={true}
   direction="column"
   id="details-panel"
@@ -281,7 +281,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-263"
+      className="makeStyles-divider-254"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
@@ -119,7 +119,7 @@ Object {
 
 exports[`Investigation Search Table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-343"
+  className="makeStyles-root-334"
   container={true}
   direction="column"
   id="details-panel"
@@ -136,7 +136,7 @@ exports[`Investigation Search Table component renders details panel correctly 1`
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-344"
+      className="makeStyles-divider-335"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
@@ -120,7 +120,7 @@ Object {
 
 exports[`Investigation Search Table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-381"
+  className="makeStyles-root-371"
   container={true}
   direction="column"
   id="details-panel"
@@ -137,7 +137,7 @@ exports[`Investigation Search Table component renders details panel correctly 1`
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-382"
+      className="makeStyles-divider-372"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))
@@ -347,7 +347,7 @@ exports[`Investigation Search Table component renders title, visit ID, Name and 
 
 exports[`Investigation Search Table component renders title, visit ID, Name and DOI as links 4`] = `
 <WithStyles(ForwardRef(Link))
-  data-testId="table-study-doi-link"
+  data-test-id="table-study-doi-link"
   href="https://doi.org/doi 1"
 >
   <ForwardRef(Link)
@@ -361,14 +361,14 @@ exports[`Investigation Search Table component renders title, visit ID, Name and 
         "underlineNone": "MuiLink-underlineNone",
       }
     }
-    data-testId="table-study-doi-link"
+    data-test-id="table-study-doi-link"
     href="https://doi.org/doi 1"
   >
     <WithStyles(ForwardRef(Typography))
       className="MuiLink-root MuiLink-underlineHover"
       color="primary"
       component="a"
-      data-testId="table-study-doi-link"
+      data-test-id="table-study-doi-link"
       href="https://doi.org/doi 1"
       onBlur={[Function]}
       onFocus={[Function]}
@@ -412,7 +412,7 @@ exports[`Investigation Search Table component renders title, visit ID, Name and 
         }
         color="primary"
         component="a"
-        data-testId="table-study-doi-link"
+        data-test-id="table-study-doi-link"
         href="https://doi.org/doi 1"
         onBlur={[Function]}
         onFocus={[Function]}
@@ -420,7 +420,7 @@ exports[`Investigation Search Table component renders title, visit ID, Name and 
       >
         <a
           className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
-          data-testId="table-study-doi-link"
+          data-test-id="table-study-doi-link"
           href="https://doi.org/doi 1"
           onBlur={[Function]}
           onFocus={[Function]}

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
@@ -274,11 +274,11 @@ describe('Investigation Search Table component', () => {
   it('displays DOI and renders the expected Link ', () => {
     const wrapper = createWrapper();
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().text()
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().text()
     ).toEqual('doi 1');
 
     expect(
-      wrapper.find('[data-testId="table-study-doi-link"]').first().prop('href')
+      wrapper.find('[data-test-id="table-study-doi-link"]').first().prop('href')
     ).toEqual('https://doi.org/doi 1');
   });
 
@@ -449,6 +449,7 @@ describe('Investigation Search Table component', () => {
         name: 'test',
         title: 'test',
         visitId: '1',
+        doi: 'Test 1',
         investigationInstruments: [],
       },
     ];


### PR DESCRIPTION
## Description
I noticed the study table tooltips weren't great as they weren't rendering the investigation title text, and that if you made a column smaller the tooltips wouldn't recalculate whether they needed to be active. So I fixed these problems, and as a side effect fixed #878 as that is effectively the opposite - that tooltips weren't recalculating when a column grew too big. I also simplified the tooltip component as the arrow styling was eventually made a prop in material ui and so I removed it here and added the prop instead.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Verify that issue #878 no longer occurs, as well as better resizing behaviour and that the study view displays tooltips for investigation title

## Agile board tracking
Fixes #878
