### PR TITLE
Use `ilike` operator for case insensitive searching

### DIFF
--- a/packages/datagateway-common/src/api/datafiles.test.tsx
+++ b/packages/datagateway-common/src/api/datafiles.test.tsx
@@ -78,7 +78,7 @@ describe('datafile api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(20));
@@ -159,7 +159,7 @@ describe('datafile api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(0));
@@ -260,7 +260,7 @@ describe('datafile api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('distinct', JSON.stringify(['name', 'title']));

--- a/packages/datagateway-common/src/api/datasets.test.tsx
+++ b/packages/datagateway-common/src/api/datasets.test.tsx
@@ -147,7 +147,7 @@ describe('dataset api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(20));
@@ -228,7 +228,7 @@ describe('dataset api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(0));
@@ -706,7 +706,7 @@ describe('dataset api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('distinct', JSON.stringify(['name', 'title']));

--- a/packages/datagateway-common/src/api/facilityCycles.test.tsx
+++ b/packages/datagateway-common/src/api/facilityCycles.test.tsx
@@ -102,7 +102,7 @@ describe('facility cycle api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(20));
@@ -172,7 +172,7 @@ describe('facility cycle api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(0));
@@ -261,7 +261,7 @@ describe('facility cycle api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
 

--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -158,7 +158,7 @@ describe('generic api functions', () => {
       const params = new URLSearchParams();
       params.append('order', JSON.stringify('name asc'));
       params.append('order', JSON.stringify('id asc'));
-      params.append('where', JSON.stringify({ name: { like: 'test' } }));
+      params.append('where', JSON.stringify({ name: { ilike: 'test' } }));
       params.append('where', JSON.stringify({ title: { nlike: 'test' } }));
       params.append(
         'where',

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -191,7 +191,7 @@ export const getApiParams = (props: {
           if (filter.type === 'include') {
             searchParams.append(
               'where',
-              JSON.stringify({ [column]: { like: filter.value } })
+              JSON.stringify({ [column]: { ilike: filter.value } })
             );
           } else {
             searchParams.append(

--- a/packages/datagateway-common/src/api/instruments.test.tsx
+++ b/packages/datagateway-common/src/api/instruments.test.tsx
@@ -58,7 +58,7 @@ describe('instrument api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(20));
@@ -122,7 +122,7 @@ describe('instrument api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(0));
@@ -208,7 +208,7 @@ describe('instrument api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
 

--- a/packages/datagateway-common/src/api/investigations.test.tsx
+++ b/packages/datagateway-common/src/api/investigations.test.tsx
@@ -157,7 +157,7 @@ describe('investigation api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(20));
@@ -241,7 +241,7 @@ describe('investigation api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(0));
@@ -733,7 +733,7 @@ describe('investigation api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('distinct', JSON.stringify(['name', 'title']));
@@ -847,7 +847,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
         params.append('skip', JSON.stringify(20));
@@ -891,7 +891,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
         params.append('skip', JSON.stringify(20));
@@ -987,7 +987,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
         params.append('skip', JSON.stringify(0));
@@ -1059,7 +1059,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
         params.append('skip', JSON.stringify(0));
@@ -1177,7 +1177,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
 
@@ -1210,7 +1210,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
         params.append(
@@ -1283,7 +1283,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
 
@@ -1317,7 +1317,7 @@ describe('investigation api functions', () => {
         params.append(
           'where',
           JSON.stringify({
-            name: { like: 'test' },
+            name: { ilike: 'test' },
           })
         );
         params.append(

--- a/packages/datagateway-common/src/api/studies.test.tsx
+++ b/packages/datagateway-common/src/api/studies.test.tsx
@@ -77,7 +77,7 @@ describe('study api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(20));
@@ -162,7 +162,7 @@ describe('study api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append('skip', JSON.stringify(0));
@@ -358,7 +358,7 @@ describe('study api functions', () => {
       params.append(
         'where',
         JSON.stringify({
-          name: { like: 'test' },
+          name: { ilike: 'test' },
         })
       );
       params.append(


### PR DESCRIPTION
## Description
This PR will close #731 

This is just a search and replace PR to support case insensitive searching on ICAT instances that use Oracle DB (i.e. production). 

I will make this 'ready to review' once Python ICAT 0.20.0 has been released and https://github.com/ral-facilities/datagateway-api/pull/273 has been merged.

## Testing instructions
Check that all instances of the `like` operator have been changed to `ilike`. I could only find instances of this operator in datagateway-common.

Test that filters etc. haven't been broken by this change

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
connect to #731 
