### PR TITLE
Fix datafile search with Lucene 4.10.0 (#890)

### DIFF
--- a/packages/datagateway-common/src/api/lucene.test.tsx
+++ b/packages/datagateway-common/src/api/lucene.test.tsx
@@ -40,8 +40,6 @@ describe('Lucene actions', () => {
       sessionId: null,
       query: {
         target: 'Datafile',
-        lower: '0000001010000',
-        upper: '9000012312359',
       },
       maxCount: 300,
     };

--- a/packages/datagateway-common/src/api/lucene.test.tsx
+++ b/packages/datagateway-common/src/api/lucene.test.tsx
@@ -12,7 +12,7 @@ describe('Lucene actions', () => {
     (handleICATError as jest.Mock).mockClear();
   });
 
-  it('sends axios request to fetch lucene search results once refetch function is called and returns successful response with default params', async () => {
+  it('sends axios request to fetch lucene search results for datafiles once refetch function is called and returns successful response with default params', async () => {
     (axios.get as jest.Mock).mockResolvedValue({
       data: [{ id: 1 }],
     });
@@ -40,6 +40,48 @@ describe('Lucene actions', () => {
       sessionId: null,
       query: {
         target: 'Datafile',
+      },
+      maxCount: 300,
+    };
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: params,
+      }
+    );
+    expect(result.current.data).toEqual([1]);
+  });
+
+  it('sends axios request to fetch lucene search results for investigations once refetch function is called and returns successful response with default params', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({
+      data: [{ id: 1 }],
+    });
+
+    const luceneSearchParams = {
+      searchText: '',
+      startDate: null,
+      endDate: null,
+    };
+    const { result, waitFor } = renderHook(
+      () => useLuceneSearch('Investigation', luceneSearchParams),
+      {
+        wrapper: createReactQueryWrapper(),
+      }
+    );
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(result.current.isIdle).toBe(true);
+
+    result.current.refetch();
+
+    await waitFor(() => result.current.isSuccess);
+
+    const params = {
+      sessionId: null,
+      query: {
+        target: 'Investigation',
+        lower: '0000001010000',
+        upper: '9000012312359',
       },
       maxCount: 300,
     };

--- a/packages/datagateway-common/src/api/lucene.test.tsx
+++ b/packages/datagateway-common/src/api/lucene.test.tsx
@@ -12,47 +12,7 @@ describe('Lucene actions', () => {
     (handleICATError as jest.Mock).mockClear();
   });
 
-  it('sends axios request to fetch lucene search results for datafiles once refetch function is called and returns successful response with default params', async () => {
-    (axios.get as jest.Mock).mockResolvedValue({
-      data: [{ id: 1 }],
-    });
-
-    const luceneSearchParams = {
-      searchText: '',
-      startDate: null,
-      endDate: null,
-    };
-    const { result, waitFor } = renderHook(
-      () => useLuceneSearch('Datafile', luceneSearchParams),
-      {
-        wrapper: createReactQueryWrapper(),
-      }
-    );
-
-    expect(axios.get).not.toHaveBeenCalled();
-    expect(result.current.isIdle).toBe(true);
-
-    result.current.refetch();
-
-    await waitFor(() => result.current.isSuccess);
-
-    const params = {
-      sessionId: null,
-      query: {
-        target: 'Datafile',
-      },
-      maxCount: 300,
-    };
-    expect(axios.get).toHaveBeenCalledWith(
-      'https://example.com/icat/lucene/data',
-      {
-        params: params,
-      }
-    );
-    expect(result.current.data).toEqual([1]);
-  });
-
-  it('sends axios request to fetch lucene search results for investigations once refetch function is called and returns successful response with default params', async () => {
+  it('sends axios request to fetch lucene search results once refetch function is called and returns successful response with default params', async () => {
     (axios.get as jest.Mock).mockResolvedValue({
       data: [{ id: 1 }],
     });
@@ -134,6 +94,79 @@ describe('Lucene actions', () => {
       }
     );
     expect(result.current.data).toEqual([1]);
+  });
+
+  it('sends axios request to fetch lucene search results once refetch function is called and returns successful response with only one date set', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({
+      data: [{ id: 1 }],
+    });
+
+    const luceneSearchParams = {
+      searchText: 'test',
+      startDate: new Date(2000, 0, 1),
+      endDate: null,
+      maxCount: 100,
+    };
+    const startDateTest = renderHook(
+      () => useLuceneSearch('Datafile', luceneSearchParams),
+      {
+        wrapper: createReactQueryWrapper(),
+      }
+    );
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(startDateTest.result.current.isIdle).toBe(true);
+
+    startDateTest.result.current.refetch();
+
+    await startDateTest.waitFor(() => startDateTest.result.current.isSuccess);
+
+    const params = {
+      sessionId: null,
+      query: {
+        target: 'Datafile',
+        text: 'test',
+        lower: '200001010000',
+        upper: '9000012312359',
+      },
+      maxCount: 100,
+    };
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: params,
+      }
+    );
+    expect(startDateTest.result.current.data).toEqual([1]);
+
+    (axios.get as jest.Mock).mockClear();
+
+    luceneSearchParams.endDate = new Date(2020, 11, 31);
+    luceneSearchParams.startDate = null;
+
+    const endDateTest = renderHook(
+      () => useLuceneSearch('Datafile', luceneSearchParams),
+      {
+        wrapper: createReactQueryWrapper(),
+      }
+    );
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(endDateTest.result.current.isIdle).toBe(true);
+
+    endDateTest.result.current.refetch();
+
+    await endDateTest.waitFor(() => endDateTest.result.current.isSuccess);
+
+    params.query.upper = '202012312359';
+    params.query.lower = '0000001010000';
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: params,
+      }
+    );
+    expect(endDateTest.result.current.data).toEqual([1]);
   });
 
   it('sends axios request to fetch lucene search results once refetch function is called and calls handleICATError on failure', async () => {

--- a/packages/datagateway-common/src/api/lucene.test.tsx
+++ b/packages/datagateway-common/src/api/lucene.test.tsx
@@ -80,8 +80,6 @@ describe('Lucene actions', () => {
       sessionId: null,
       query: {
         target: 'Investigation',
-        lower: '0000001010000',
-        upper: '9000012312359',
       },
       maxCount: 300,
     };

--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -1,6 +1,6 @@
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import axios, { AxiosError } from 'axios';
-import { format } from 'date-fns';
+import { format, set } from 'date-fns';
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
 import { StateType } from '..';
@@ -34,24 +34,22 @@ const urlParamsBuilder = (
     target: datasearchtype,
   };
 
-  if (params.startDate !== null) {
-    const stringStartDate = format(params.startDate, 'yyyy-MM-dd');
-    const stringStartDateArray = stringStartDate.split('-');
+  if (params.startDate !== null || params.endDate !== null) {
     query.lower =
-      stringStartDateArray[0] +
-      stringStartDateArray[1] +
-      stringStartDateArray[2] +
-      '0000';
-  }
+      params.startDate !== null
+        ? format(
+            set(params.startDate, { hours: 0, minutes: 0 }),
+            'yyyyMMddHHmm'
+          )
+        : '0000001010000';
 
-  if (params.endDate !== null) {
-    const stringEndDate = format(params.endDate, 'yyyy-MM-dd');
-    const stringEndDateArray = stringEndDate.split('-');
     query.upper =
-      stringEndDateArray[0] +
-      stringEndDateArray[1] +
-      stringEndDateArray[2] +
-      '2359';
+      params.endDate !== null
+        ? format(
+            set(params.endDate, { hours: 23, minutes: 59 }),
+            'yyyyMMddHHmm'
+          )
+        : '9000012312359';
   }
 
   if (params.searchText.length > 0) {

--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -34,13 +34,8 @@ const urlParamsBuilder = (
     target: datasearchtype,
   };
 
-  //Do not assign query.lower for datafiles when there is no start date
-  //as this fixes issue when using lucene 4.10.0 instead of 4.11.1
-  if (datasearchtype !== 'Datafile' || params.startDate !== null) {
-    const stringStartDate =
-      params.startDate !== null
-        ? format(params.startDate, 'yyyy-MM-dd')
-        : '00000-01-01';
+  if (params.startDate !== null) {
+    const stringStartDate = format(params.startDate, 'yyyy-MM-dd');
     const stringStartDateArray = stringStartDate.split('-');
     query.lower =
       stringStartDateArray[0] +
@@ -49,13 +44,8 @@ const urlParamsBuilder = (
       '0000';
   }
 
-  //Do not assign query.upper for datafiles when there is no end date
-  //as this fixes issue when using lucene 4.10.0 instead of 4.11.1
-  if (datasearchtype !== 'Datafile' || params.endDate !== null) {
-    const stringEndDate =
-      params.endDate !== null
-        ? format(params.endDate, 'yyyy-MM-dd')
-        : '90000-12-31';
+  if (params.endDate !== null) {
+    const stringEndDate = format(params.endDate, 'yyyy-MM-dd');
     const stringEndDateArray = stringEndDate.split('-');
     query.upper =
       stringEndDateArray[0] +

--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -34,27 +34,35 @@ const urlParamsBuilder = (
     target: datasearchtype,
   };
 
-  const stringStartDate =
-    params.startDate !== null
-      ? format(params.startDate, 'yyyy-MM-dd')
-      : '00000-01-01';
-  const stringStartDateArray = stringStartDate.split('-');
-  query.lower =
-    stringStartDateArray[0] +
-    stringStartDateArray[1] +
-    stringStartDateArray[2] +
-    '0000';
+  //Do not assign query.lower for datafiles when there is no start date
+  //as this fixes issue when using lucene 4.10.0 instead of 4.11.1
+  if (datasearchtype !== 'Datafile' || params.startDate !== null) {
+    const stringStartDate =
+      params.startDate !== null
+        ? format(params.startDate, 'yyyy-MM-dd')
+        : '00000-01-01';
+    const stringStartDateArray = stringStartDate.split('-');
+    query.lower =
+      stringStartDateArray[0] +
+      stringStartDateArray[1] +
+      stringStartDateArray[2] +
+      '0000';
+  }
 
-  const stringEndDate =
-    params.endDate !== null
-      ? format(params.endDate, 'yyyy-MM-dd')
-      : '90000-12-31';
-  const stringEndDateArray = stringEndDate.split('-');
-  query.upper =
-    stringEndDateArray[0] +
-    stringEndDateArray[1] +
-    stringEndDateArray[2] +
-    '2359';
+  //Do not assign query.upper for datafiles when there is no end date
+  //as this fixes issue when using lucene 4.10.0 instead of 4.11.1
+  if (datasearchtype !== 'Datafile' || params.endDate !== null) {
+    const stringEndDate =
+      params.endDate !== null
+        ? format(params.endDate, 'yyyy-MM-dd')
+        : '90000-12-31';
+    const stringEndDateArray = stringEndDate.split('-');
+    query.upper =
+      stringEndDateArray[0] +
+      stringEndDateArray[1] +
+      stringEndDateArray[2] +
+      '2359';
+  }
 
   if (params.searchText.length > 0) {
     query.text = params.searchText;

--- a/packages/datagateway-search/src/searchPageContainer.component.test.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.test.tsx
@@ -301,6 +301,7 @@ describe('SearchPageContainer - Tests', () => {
           query: {
             target: 'Datafile',
             lower: '201311110000',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -336,6 +337,7 @@ describe('SearchPageContainer - Tests', () => {
           query: {
             target: 'Dataset',
             lower: '201311110000',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -371,6 +373,7 @@ describe('SearchPageContainer - Tests', () => {
           query: {
             target: 'Investigation',
             lower: '201311110000',
+            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -399,6 +402,7 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Datafile',
+            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -434,6 +438,7 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Dataset',
+            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -469,6 +474,7 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Investigation',
+            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,

--- a/packages/datagateway-search/src/searchPageContainer.component.test.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.test.tsx
@@ -336,7 +336,6 @@ describe('SearchPageContainer - Tests', () => {
           query: {
             target: 'Dataset',
             lower: '201311110000',
-            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -372,7 +371,6 @@ describe('SearchPageContainer - Tests', () => {
           query: {
             target: 'Investigation',
             lower: '201311110000',
-            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -436,7 +434,6 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Dataset',
-            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -472,7 +469,6 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Investigation',
-            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -524,8 +520,6 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Dataset',
-            lower: '0000001010000',
-            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -556,8 +550,6 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Investigation',
-            lower: '0000001010000',
-            upper: '9000012312359',
           },
           sessionId: null,
         },

--- a/packages/datagateway-search/src/searchPageContainer.component.test.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.test.tsx
@@ -301,7 +301,6 @@ describe('SearchPageContainer - Tests', () => {
           query: {
             target: 'Datafile',
             lower: '201311110000',
-            upper: '9000012312359',
           },
           sessionId: null,
         },
@@ -402,7 +401,6 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Datafile',
-            lower: '0000001010000',
             upper: '201611112359',
           },
           sessionId: null,
@@ -496,8 +494,6 @@ describe('SearchPageContainer - Tests', () => {
           maxCount: 300,
           query: {
             target: 'Datafile',
-            lower: '0000001010000',
-            upper: '9000012312359',
           },
           sessionId: null,
         },


### PR DESCRIPTION
## Description
Fix datafile search so it works with Lucene 4.10.0, by removing `upper` and `lower` from the query when no start/end date is defined.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #890 
