### PR TITLE
WIP: Fix aria-labels

### DIFF
--- a/packages/datagateway-dataview/cypress/integration/breadcrumbs.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/breadcrumbs.spec.ts
@@ -4,17 +4,18 @@ describe('Breadcrumbs Component', () => {
     cy.login();
 
     // Create route and aliases.
-    cy.intercept('/investigations/').as('getInvestigation');
-    cy.intercept('/datasets/').as('getDataset');
+    cy.intercept('/investigations/').as('getInvestigations');
+    cy.intercept(/\/investigations\/[0-9]+/).as('getInvestigation');
+    cy.intercept(/\/datasets\/[0-9]+/).as('getDataset');
 
-    cy.visit('/browse/investigation').wait('@getInvestigation');
+    cy.visit('/browse/investigation').wait('@getInvestigations');
   });
 
   it('should load correctly and display current breadcrumb', () => {
     cy.title().should('equal', 'DataGateway DataView');
 
     // Check that the base Investigations breadcrumb exists.
-    cy.get('[aria-label="Breadcrumb-base"]').contains('Investigations');
+    cy.get('[aria-label="Breadcrumbs"]').contains('Investigations');
   });
 
   it('should click on investigation and add breadcrumbs correctly', () => {
@@ -27,19 +28,15 @@ describe('Breadcrumbs Component', () => {
     // Check to see if the breadcrumbs have been added correctly.
     // Get the first link on the page which is a link to
     // /browse/investigations in the breadcrumb trail.
-    cy.get('[aria-label="Breadcrumb-base"]')
-      .should('have.text', 'Investigations')
+    cy.get('[aria-label="Breadcrumbs"]')
+      .contains('Investigations')
       .should('have.attr', 'href', '/browse/investigation');
 
     // Get the investigation name.
-    cy.get('[aria-label="Breadcrumb-hierarchy-1"]').should(
-      'have.text',
-      'Including spend increase ability music skill former. Agreement director concern once technology sometimes someone staff.' +
-        '\nSuccess pull bar. Laugh senior example.'
-    );
+    cy.get('[aria-label="Breadcrumbs"]').contains('Including spend');
 
     // Ensure current page is datasets.
-    cy.get('[aria-label="Breadcrumb-last"]').should('have.text', 'Datasets');
+    cy.get('[aria-label="Breadcrumbs"] li').last().contains('Datasets');
   });
 
   it('loads the breadcrumb trail when visiting a page directly', () => {
@@ -49,29 +46,20 @@ describe('Breadcrumbs Component', () => {
       .wait('@getDataset');
 
     // Get Investigations table breadcrumb link.
-    cy.get('[aria-label="Breadcrumb-base"]')
-      .should('have.text', 'Investigations')
+    cy.get('[aria-label="Breadcrumbs"]')
+      .contains('Investigations')
       .should('have.attr', 'href', '/browse/investigation');
 
     // Get investigation datasets table breadcrumb.
-    cy.get('[aria-label="Breadcrumb-hierarchy-1"]')
-      .should(
-        'have.text',
-        'Including spend increase ability music skill former. Agreement director ' +
-          'concern once technology sometimes someone staff.\nSuccess pull bar. Laugh senior example.'
-      )
+    cy.get('[aria-label="Breadcrumbs"]')
+      .contains('Including spend')
       .should('have.attr', 'href', '/browse/investigation/1/dataset');
 
     // Get current dataset page breadcrumb.
-    cy.get('[aria-label="Breadcrumb-hierarchy-2"]').should(
-      'have.text',
-      'DATASET 1'
-    );
+    cy.get('[aria-label="Breadcrumbs"]').contains('DATASET 1');
 
     // Get page contents breadcrumb.
-    cy.get('[aria-label="Breadcrumb-last"]')
-      .first()
-      .should('have.text', 'Datafiles');
+    cy.get('[aria-label="Breadcrumbs"] li').last().contains('Datafiles');
   });
 
   it('loads breadcrumb trail correctly after pressing back browser key', () => {
@@ -88,36 +76,28 @@ describe('Breadcrumbs Component', () => {
     );
 
     // Check the first breadcrumb loaded on the current page.
-    cy.get('[aria-label="Breadcrumb-base"]')
-      .should('have.text', 'Investigations')
+    cy.get('[aria-label="Breadcrumbs"]')
+      .contains('Investigations')
       .should('have.attr', 'href', '/browse/investigation');
 
-    cy.get('[aria-label="Breadcrumb-hierarchy-1"]')
-      .should(
-        'have.text',
-        'Including spend increase ability music skill former. Agreement director ' +
-          'concern once technology sometimes someone staff.\nSuccess pull bar. Laugh senior example.'
-      )
+    cy.get('[aria-label="Breadcrumbs"]')
+      .contains('Including spend')
       .should('have.attr', 'href', '/browse/investigation/1/dataset');
 
-    cy.get('[aria-label="Breadcrumb-hierarchy-2"]').contains('DATASET 1');
+    cy.get('[aria-label="Breadcrumbs"]').contains('DATASET 1');
 
-    cy.get('[aria-label="Breadcrumb-last"]').contains('Datafiles');
+    cy.get('[aria-label="Breadcrumbs"] li').last().contains('Datafiles');
 
     // Press back.
     cy.go('back');
 
     // Check the breadcrumb trail on the previous page.
-    cy.get('[aria-label="Breadcrumb-base"]')
-      .should('have.text', 'Investigations')
+    cy.get('[aria-label="Breadcrumbs"]')
+      .contains('Investigations')
       .should('have.attr', 'href', '/browse/investigation');
 
-    cy.get('[aria-label="Breadcrumb-hierarchy-1"]').should(
-      'have.text',
-      'Including spend increase ability music skill former. Agreement director ' +
-        'concern once technology sometimes someone staff.\nSuccess pull bar. Laugh senior example.'
-    );
+    cy.get('[aria-label="Breadcrumbs"]').contains('Including spend');
 
-    cy.get('[aria-label="Breadcrumb-last"]').contains('Datasets');
+    cy.get('[aria-label="Breadcrumbs"] li').last().contains('Datasets');
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/datasets.spec.ts
@@ -7,11 +7,9 @@ describe('Datasets Cards', () => {
       ['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]')
-      .click()
-      .wait(['@getDatasetsOrder'], {
-        timeout: 10000,
-      });
+    cy.contains('Display as cards').click().wait(['@getDatasetsOrder'], {
+      timeout: 10000,
+    });
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
@@ -9,11 +9,9 @@ describe('DLS - Datasets Cards', () => {
         timeout: 10000,
       }
     );
-    cy.get('[aria-label="page-view Display as cards"]')
-      .click()
-      .wait(['@getDatasetsOrder'], {
-        timeout: 10000,
-      });
+    cy.contains('Display as cards').click().wait(['@getDatasetsOrder'], {
+      timeout: 10000,
+    });
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
@@ -7,11 +7,9 @@ describe('DLS - Proposals Cards', () => {
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]')
-      .click()
-      .wait(['@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
+    cy.contains('Display as cards').click().wait(['@getInvestigationsOrder'], {
+      timeout: 10000,
+    });
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
@@ -7,11 +7,9 @@ describe('DLS - Visits Cards', () => {
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]')
-      .click()
-      .wait(['@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
+    cy.contains('Display as cards').click().wait(['@getInvestigationsOrder'], {
+      timeout: 10000,
+    });
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/investigations.spec.ts
@@ -11,7 +11,7 @@ describe('Investigations Cards', () => {
       ],
       { timeout: 15000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]').click();
+    cy.contains('Display as cards').click();
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/isis/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/datasets.spec.ts
@@ -8,11 +8,9 @@ describe('ISIS - Datasets Cards', () => {
     ).wait(['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'], {
       timeout: 10000,
     });
-    cy.get('[aria-label="page-view Display as cards"]')
-      .click()
-      .wait(['@getDatasetsOrder'], {
-        timeout: 10000,
-      });
+    cy.contains('Display as cards').click().wait(['@getDatasetsOrder'], {
+      timeout: 10000,
+    });
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/isis/instruments.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/instruments.spec.ts
@@ -7,7 +7,7 @@ describe('ISIS - Instruments Cards', () => {
       ['@getInstrumentsCount', '@getInstrumentsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]').click();
+    cy.contains('Display as cards').click();
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
@@ -7,7 +7,7 @@ describe('ISIS - Investigations Cards', () => {
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]').click();
+    cy.contains('Display as cards').click();
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
@@ -7,7 +7,7 @@ describe('ISIS - Studies Cards', () => {
       ['@getStudiesCount', '@getStudiesOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]').click();
+    cy.contains('Display as cards').click();
   });
 
   it('should load correctly', () => {

--- a/packages/datagateway-dataview/cypress/integration/card/pageContainer.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/pageContainer.spec.ts
@@ -11,29 +11,27 @@ describe('PageContainer Component', () => {
       ],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page-view Display as cards"]').click();
+    cy.contains('Display as cards').click();
     cy.clearDownloadCart();
   });
 
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
 
-    cy.get('[aria-label="page-breadcrumbs"]').should('exist');
+    cy.get('[aria-label="Breadcrumbs"]').should('exist');
 
-    cy.get('[aria-label="view-count"]').should('exist');
+    cy.contains('Results: ');
 
-    cy.get('[aria-label="view-search"]').should('exist');
+    cy.get('[aria-label="Go to search"]').should('exist');
 
-    cy.get('[aria-label="view-cart"]').should('exist');
+    cy.get('[aria-label="Go to selections"]').should('exist');
 
-    cy.get('[aria-label="page-view Display as table"]').should('exist');
+    cy.contains('Display as table');
   });
 
   it('should display correct entity count', () => {
     // Check that the entity count has displayed correctly.
-    cy.get('[aria-label="view-count"]')
-      .should('be.visible')
-      .contains('Results: 239');
+    cy.contains('Results: 239').should('be.visible');
   });
 
   it('Should default to 10 when the results value is not a vaild result ([10,20,30]) when manually changed in the url ', () => {
@@ -88,23 +86,18 @@ describe('PageContainer Component', () => {
 
   it('should display number of items in cart correctly', () => {
     // Check that the download cart has displayed correctly.
-    cy.get('[aria-label="view-cart-badge"]', { timeout: 10000 })
-      .children()
-      .should('be.hidden');
+    cy.get('[aria-label="Go to selections"]', { timeout: 10000 }).contains(
+      // matches empty string i.e. no badge
+      /^$/
+    );
 
     cy.get('[aria-label="card-button-1"]', { timeout: 10000 }).eq(0).click();
 
-    cy.get('[aria-label="view-cart-badge"]', { timeout: 10000 })
-      .children()
-      .should('not.be.hidden')
-      .contains('1');
+    cy.get('[aria-label="Go to selections"]', { timeout: 10000 }).contains('1');
 
     cy.get('[aria-label="card-button-1"]', { timeout: 10000 }).eq(1).click();
 
-    cy.get('[aria-label="view-cart-badge"]', { timeout: 10000 })
-      .children()
-      .should('not.be.hidden')
-      .contains('2');
+    cy.get('[aria-label="Go to selections"]', { timeout: 10000 }).contains('2');
   });
 
   it('should be able to choose number of results to display', () => {

--- a/packages/datagateway-dataview/cypress/integration/table/pageContainer.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/pageContainer.spec.ts
@@ -5,8 +5,8 @@ describe('PageContainer Component', () => {
       password: 'pw',
       mechanism: 'simple',
     });
-    cy.get('[aria-label="page-breadcrumbs"]').should('exist');
-    cy.get('[aria-label="open-data-warning"]').should('not.exist');
+    cy.get('[aria-label="Breadcrumbs"]').should('exist');
+    cy.contains('Open data').should('not.exist');
   });
 
   beforeEach(() => {
@@ -16,54 +16,47 @@ describe('PageContainer Component', () => {
   });
 
   it('should display the open data warning when not logged in', () => {
-    cy.get('[aria-label="open-data-warning"]').should('exist');
+    cy.contains('Open data');
   });
 
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
 
-    cy.get('[aria-label="page-breadcrumbs"]').should('exist');
+    cy.get('[aria-label="Breadcrumbs"]').should('exist');
 
-    cy.get('[aria-label="view-count"]').should('exist');
+    cy.contains('Results: ');
 
-    cy.get('[aria-label="view-search"]').should('exist');
+    cy.get('[aria-label="Go to search"]').should('exist');
 
-    cy.get('[aria-label="view-cart"]').should('exist');
+    cy.get('[aria-label="Go to selections"]').should('exist');
 
-    cy.get('[aria-label="page-view Display as cards"]').should('exist');
+    cy.contains('Display as cards');
   });
 
   it('should display correct entity count', () => {
     // Check that the entity count has displayed correctly.
-    cy.get('[aria-label="view-count"]')
-      .should('be.visible')
-      .contains('Results: 239');
+    cy.contains('Results: 239').should('be.visible');
   });
 
   it('should display number of items in cart correctly', () => {
-    cy.get('[aria-label="view-cart-badge"]', { timeout: 10000 })
-      .children()
-      .should('be.hidden');
+    cy.get('[aria-label="Go to selections"]', { timeout: 10000 }).contains(
+      // matches empty string i.e. no badge
+      /^$/
+    );
 
     cy.get('[aria-label="select row 0"]', { timeout: 10000 }).check();
     cy.get('[aria-label="select row 0"]', { timeout: 10000 }).should(
       'be.checked'
     );
 
-    cy.get('[aria-label="view-cart-badge"]', { timeout: 10000 })
-      .children()
-      .should('not.be.hidden')
-      .contains('1');
+    cy.get('[aria-label="Go to selections"]', { timeout: 10000 }).contains('1');
 
     cy.get('[aria-label="select row 1"]', { timeout: 10000 }).check();
     cy.get('[aria-label="select row 1"]', { timeout: 10000 }).should(
       'be.checked'
     );
 
-    cy.get('[aria-label="view-cart-badge"]', { timeout: 10000 })
-      .children()
-      .should('not.be.hidden')
-      .contains('2');
+    cy.get('[aria-label="Go to selections"]', { timeout: 10000 }).contains('2');
   });
 
   it('should display selection alert banner correctly', () => {

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -7,11 +7,13 @@
     "error": "Something went wrong...",
     "open_data_warning": {
       "message": "Open data",
+      "tooltip_aria_label": "Open data information tooltip",
       "tooltip": "Only open data is displayed when browsing anonymously. Please login to see embargoed data.",
       "tooltip_link": "Click here to learn more about our data policy."
     }
   },
   "breadcrumbs": {
+    "aria_label": "Breadcrumbs",
     "home": "Home",
     "instrument_plural": "Instruments",
     "facilityCycle_plural": "Facility Cycles",
@@ -174,6 +176,8 @@
     "filter_message": "No results found with current filters applied, please modify filter settings and try again."
   },
   "buttons": {
+    "search": "Go to search",
+    "cart": "Go to selections",
     "add_to_cart": "Add to selections",
     "remove_from_cart": "Remove from selections",
     "download": "Download"
@@ -182,21 +186,45 @@
     "show": "Show Advanced Filters",
     "hide": "Hide Advanced Filters",
     "icons": {
-      "title": ["Title", "Name", "Type"],
-      "fingerprint": ["Visit ID", "Name"],
-      "public": ["DOI"],
-      "confirmation_number": ["Dataset Count", " Datafile Count"],
-      "assessment": ["Instrument", "Beamline"],
+      "title": [
+        "Title",
+        "Name",
+        "Type"
+      ],
+      "fingerprint": [
+        "Visit ID",
+        "Name"
+      ],
+      "public": [
+        "DOI"
+      ],
+      "confirmation_number": [
+        "Dataset Count",
+        " Datafile Count"
+      ],
+      "assessment": [
+        "Instrument",
+        "Beamline"
+      ],
       "calendar_today": [
         "Start Date",
         "End Date",
         "Create Time",
         "Modified Time"
       ],
-      "explore": ["Location"],
-      "save": ["Size"],
-      "description": ["Description", "Summary"],
-      "link": ["URL"]
+      "explore": [
+        "Location"
+      ],
+      "save": [
+        "Size"
+      ],
+      "description": [
+        "Description",
+        "Summary"
+      ],
+      "link": [
+        "URL"
+      ]
     }
   },
   "entity_card": {

--- a/packages/datagateway-dataview/src/page/__snapshots__/breadcrumbs.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/breadcrumbs.component.test.tsx.snap
@@ -7,31 +7,26 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) Includes view in 
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.investigation {count:100}"
         url="/browse/investigation?view=card"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="Test 1"
         key="breadcrumb-1"
         url="/browse/investigation/1/dataset?view=card"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-2"
         displayName="INVESTIGATION 1"
         key="breadcrumb-2"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.datafile {count:100}"
         isLast={true}
       />
@@ -155,11 +150,11 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                     className="MuiPaper-root MuiPaper-elevation0"
                   >
                     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-                      aria-label="breadcrumb"
+                      aria-label="breadcrumbs.aria_label"
                       separator=""
                     >
                       <WithStyles(ForwardRef(Breadcrumbs))
-                        aria-label="breadcrumb"
+                        aria-label="breadcrumbs.aria_label"
                         classes={
                           Object {
                             "root": "WithStyles(ForwardRef(Breadcrumbs))-root-1",
@@ -168,7 +163,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                         separator=""
                       >
                         <ForwardRef(Breadcrumbs)
-                          aria-label="breadcrumb"
+                          aria-label="breadcrumbs.aria_label"
                           classes={
                             Object {
                               "li": "MuiBreadcrumbs-li",
@@ -180,13 +175,13 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                           separator=""
                         >
                           <WithStyles(ForwardRef(Typography))
-                            aria-label="breadcrumb"
+                            aria-label="breadcrumbs.aria_label"
                             className="MuiBreadcrumbs-root WithStyles(ForwardRef(Breadcrumbs))-root-1"
                             color="textSecondary"
                             component="nav"
                           >
                             <ForwardRef(Typography)
-                              aria-label="breadcrumb"
+                              aria-label="breadcrumbs.aria_label"
                               className="MuiBreadcrumbs-root WithStyles(ForwardRef(Breadcrumbs))-root-1"
                               classes={
                                 Object {
@@ -226,7 +221,7 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                               component="nav"
                             >
                               <nav
-                                aria-label="breadcrumb"
+                                aria-label="breadcrumbs.aria_label"
                                 className="MuiTypography-root MuiBreadcrumbs-root WithStyles(ForwardRef(Breadcrumbs))-root-1 MuiTypography-body1 MuiTypography-colorTextSecondary"
                               >
                                 <ol
@@ -237,7 +232,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                     key="child-0"
                                   >
                                     <WrappedBreadcrumb
-                                      ariaLabel="Breadcrumb-home"
                                       displayName="breadcrumbs.home"
                                       key=".0"
                                     >
@@ -322,11 +316,9 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               title={null}
                                             >
                                               <WithStyles(ForwardRef(Typography))
-                                                aria-label="Breadcrumb-home"
                                                 color="textPrimary"
                                               >
                                                 <ForwardRef(Typography)
-                                                  aria-label="Breadcrumb-home"
                                                   classes={
                                                     Object {
                                                       "alignCenter": "MuiTypography-alignCenter",
@@ -364,7 +356,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   color="textPrimary"
                                                 >
                                                   <p
-                                                    aria-label="Breadcrumb-home"
                                                     className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
                                                   >
                                                     <span>
@@ -380,7 +371,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   class=""
                                                 >
                                                   <p
-                                                    aria-label="Breadcrumb-home"
                                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
                                                   >
                                                     <span>
@@ -420,7 +410,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                     key="child-1"
                                   >
                                     <WrappedBreadcrumb
-                                      ariaLabel="Breadcrumb-base"
                                       displayName="breadcrumbs.investigation {count:100}"
                                       key=".1"
                                       url="/browse/investigation"
@@ -506,7 +495,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               title={null}
                                             >
                                               <WithStyles(ForwardRef(Link))
-                                                aria-label="Breadcrumb-base"
                                                 component={
                                                   Object {
                                                     "$$typeof": Symbol(react.forward_ref),
@@ -524,7 +512,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                 to="/browse/investigation"
                                               >
                                                 <ForwardRef(Link)
-                                                  aria-label="Breadcrumb-base"
                                                   classes={
                                                     Object {
                                                       "button": "MuiLink-button",
@@ -552,7 +539,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   to="/browse/investigation"
                                                 >
                                                   <WithStyles(ForwardRef(Typography))
-                                                    aria-label="Breadcrumb-base"
                                                     className="MuiLink-root MuiLink-underlineHover"
                                                     color="primary"
                                                     component={
@@ -575,7 +561,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                     variant="inherit"
                                                   >
                                                     <ForwardRef(Typography)
-                                                      aria-label="Breadcrumb-base"
                                                       className="MuiLink-root MuiLink-underlineHover"
                                                       classes={
                                                         Object {
@@ -632,14 +617,12 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                       variant="inherit"
                                                     >
                                                       <Link
-                                                        aria-label="Breadcrumb-base"
                                                         className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                         onBlur={[Function]}
                                                         onFocus={[Function]}
                                                         to="/browse/investigation"
                                                       >
                                                         <LinkAnchor
-                                                          aria-label="Breadcrumb-base"
                                                           className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                           href="/browse/investigation"
                                                           navigate={[Function]}
@@ -647,7 +630,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                           onFocus={[Function]}
                                                         >
                                                           <a
-                                                            aria-label="Breadcrumb-base"
                                                             className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                             href="/browse/investigation"
                                                             onBlur={[Function]}
@@ -671,7 +653,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   class=""
                                                 >
                                                   <a
-                                                    aria-label="Breadcrumb-base"
                                                     class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                     href="/browse/investigation"
                                                   >
@@ -712,7 +693,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                     key="child-2"
                                   >
                                     <WrappedBreadcrumb
-                                      ariaLabel="Breadcrumb-hierarchy-1"
                                       displayName="Test 1"
                                       key=".2:$breadcrumb-1"
                                       url="/browse/investigation/1/dataset"
@@ -798,7 +778,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               title={null}
                                             >
                                               <WithStyles(ForwardRef(Link))
-                                                aria-label="Breadcrumb-hierarchy-1"
                                                 component={
                                                   Object {
                                                     "$$typeof": Symbol(react.forward_ref),
@@ -816,7 +795,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                 to="/browse/investigation/1/dataset"
                                               >
                                                 <ForwardRef(Link)
-                                                  aria-label="Breadcrumb-hierarchy-1"
                                                   classes={
                                                     Object {
                                                       "button": "MuiLink-button",
@@ -844,7 +822,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   to="/browse/investigation/1/dataset"
                                                 >
                                                   <WithStyles(ForwardRef(Typography))
-                                                    aria-label="Breadcrumb-hierarchy-1"
                                                     className="MuiLink-root MuiLink-underlineHover"
                                                     color="primary"
                                                     component={
@@ -867,7 +844,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                     variant="inherit"
                                                   >
                                                     <ForwardRef(Typography)
-                                                      aria-label="Breadcrumb-hierarchy-1"
                                                       className="MuiLink-root MuiLink-underlineHover"
                                                       classes={
                                                         Object {
@@ -924,14 +900,12 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                       variant="inherit"
                                                     >
                                                       <Link
-                                                        aria-label="Breadcrumb-hierarchy-1"
                                                         className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                         onBlur={[Function]}
                                                         onFocus={[Function]}
                                                         to="/browse/investigation/1/dataset"
                                                       >
                                                         <LinkAnchor
-                                                          aria-label="Breadcrumb-hierarchy-1"
                                                           className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                           href="/browse/investigation/1/dataset"
                                                           navigate={[Function]}
@@ -939,7 +913,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                           onFocus={[Function]}
                                                         >
                                                           <a
-                                                            aria-label="Breadcrumb-hierarchy-1"
                                                             className="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                             href="/browse/investigation/1/dataset"
                                                             onBlur={[Function]}
@@ -963,7 +936,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   class=""
                                                 >
                                                   <a
-                                                    aria-label="Breadcrumb-hierarchy-1"
                                                     class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
                                                     href="/browse/investigation/1/dataset"
                                                   >
@@ -1004,7 +976,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                     key="child-3"
                                   >
                                     <WrappedBreadcrumb
-                                      ariaLabel="Breadcrumb-hierarchy-2"
                                       displayName="INVESTIGATION 1"
                                       key=".2:$breadcrumb-2"
                                     >
@@ -1089,11 +1060,9 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               title={null}
                                             >
                                               <WithStyles(ForwardRef(Typography))
-                                                aria-label="Breadcrumb-hierarchy-2"
                                                 color="textPrimary"
                                               >
                                                 <ForwardRef(Typography)
-                                                  aria-label="Breadcrumb-hierarchy-2"
                                                   classes={
                                                     Object {
                                                       "alignCenter": "MuiTypography-alignCenter",
@@ -1131,7 +1100,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   color="textPrimary"
                                                 >
                                                   <p
-                                                    aria-label="Breadcrumb-hierarchy-2"
                                                     className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
                                                   >
                                                     <span>
@@ -1147,7 +1115,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   class=""
                                                 >
                                                   <p
-                                                    aria-label="Breadcrumb-hierarchy-2"
                                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
                                                   >
                                                     <span>
@@ -1187,7 +1154,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                     key="child-4"
                                   >
                                     <WrappedBreadcrumb
-                                      ariaLabel="Breadcrumb-last"
                                       displayName="breadcrumbs.datafile {count:100}"
                                       isLast={true}
                                       key=".3"
@@ -1273,11 +1239,9 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                               title={null}
                                             >
                                               <WithStyles(ForwardRef(Typography))
-                                                aria-label="Breadcrumb-last"
                                                 color="textPrimary"
                                               >
                                                 <ForwardRef(Typography)
-                                                  aria-label="Breadcrumb-last"
                                                   classes={
                                                     Object {
                                                       "alignCenter": "MuiTypography-alignCenter",
@@ -1315,7 +1279,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   color="textPrimary"
                                                 >
                                                   <p
-                                                    aria-label="Breadcrumb-last"
                                                     className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
                                                   >
                                                     <span>
@@ -1333,7 +1296,6 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders an update
                                                   class=""
                                                 >
                                                   <p
-                                                    aria-label="Breadcrumb-last"
                                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextPrimary"
                                                   >
                                                     <span>
@@ -1391,37 +1353,31 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.proposal {count:100}"
         url="/browse/proposal"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="INVESTIGATION 1"
         key="breadcrumb-1"
         url="/browse/proposal/INVESTIGATION 1/investigation"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-2"
         displayName="Test 1"
         key="breadcrumb-2"
         url="/browse/proposal/INVESTIGATION 1/investigation/1/dataset"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-3"
         displayName="INVESTIGATION 1"
         key="breadcrumb-3"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.datafile {count:100}"
         isLast={true}
       />
@@ -1437,31 +1393,26 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.proposal {count:100}"
         url="/browse/proposal"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="INVESTIGATION 1"
         key="breadcrumb-1"
         url="/browse/proposal/INVESTIGATION 1/investigation"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-2"
         displayName="Test 1"
         key="breadcrumb-2"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.dataset {count:100}"
         isLast={true}
       />
@@ -1477,25 +1428,21 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.proposal {count:100}"
         url="/browse/proposal"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="INVESTIGATION 1"
         key="breadcrumb-1"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.investigation {count:100}"
         isLast={true}
       />
@@ -1511,15 +1458,13 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.proposal {count:100}"
       />
     </WithStyles(WithStyles(ForwardRef(Breadcrumbs)))>
@@ -1534,43 +1479,36 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.instrument {count:100}"
         url="/browse/instrument"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="INVESTIGATION 1"
         key="breadcrumb-1"
         url="/browse/instrument/1/facilityCycle"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-2"
         displayName="INVESTIGATION 1"
         key="breadcrumb-2"
         url="/browse/instrument/1/facilityCycle/1/investigation"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-3"
         displayName="Test 1"
         key="breadcrumb-3"
         url="/browse/instrument/1/facilityCycle/1/investigation/1/dataset"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-4"
         displayName="INVESTIGATION 1"
         key="breadcrumb-4"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.datafile {count:100}"
         isLast={true}
       />
@@ -1586,37 +1524,31 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.instrument {count:100}"
         url="/browse/instrument"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="INVESTIGATION 1"
         key="breadcrumb-1"
         url="/browse/instrument/1/facilityCycle"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-2"
         displayName="INVESTIGATION 1"
         key="breadcrumb-2"
         url="/browse/instrument/1/facilityCycle/1/investigation"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-3"
         displayName="Test 1"
         key="breadcrumb-3"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.dataset {count:100}"
         isLast={true}
       />
@@ -1632,25 +1564,21 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.instrument {count:100}"
         url="/browse/instrument"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="INVESTIGATION 1"
         key="breadcrumb-1"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.facilityCycle {count:100}"
         isLast={true}
       />
@@ -1666,15 +1594,13 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.instrument {count:100}"
       />
     </WithStyles(WithStyles(ForwardRef(Breadcrumbs)))>
@@ -1689,31 +1615,26 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.investigation {count:100}"
         url="/browse/investigation"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="Test 1"
         key="breadcrumb-1"
         url="/browse/investigation/1/dataset"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-2"
         displayName="INVESTIGATION 1"
         key="breadcrumb-2"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.datafile {count:100}"
         isLast={true}
       />
@@ -1729,25 +1650,21 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.investigation {count:100}"
         url="/browse/investigation"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-hierarchy-1"
         displayName="Test 1"
         key="breadcrumb-1"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-last"
         displayName="breadcrumbs.dataset {count:100}"
         isLast={true}
       />
@@ -1763,15 +1680,13 @@ exports[`PageBreadcrumbs - Snapshot Tests (Generic, DLS, ISIS) renders correctly
     square={true}
   >
     <WithStyles(WithStyles(ForwardRef(Breadcrumbs)))
-      aria-label="breadcrumb"
+      aria-label="breadcrumbs.aria_label"
       separator=""
     >
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-home"
         displayName="breadcrumbs.home"
       />
       <WrappedBreadcrumb
-        ariaLabel="Breadcrumb-base"
         displayName="breadcrumbs.investigation {count:100}"
       />
     </WithStyles(WithStyles(ForwardRef(Breadcrumbs)))>

--- a/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
+++ b/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
@@ -54,7 +54,6 @@ interface PageBreadcrumbsState {
 
 interface WrappedBreadcrumbProps {
   displayName: string;
-  ariaLabel: string;
   url?: string;
   isLast?: boolean;
 }
@@ -71,15 +70,11 @@ class WrappedBreadcrumb extends React.Component<WrappedBreadcrumbProps> {
       <ArrowTooltip title={this.props.displayName} percentageWidth={20}>
         <div>
           {this.props.url ? (
-            <MaterialLink
-              component={Link}
-              to={this.props.url}
-              aria-label={this.props.ariaLabel}
-            >
+            <MaterialLink component={Link} to={this.props.url}>
               <span>{this.props.displayName}</span>
             </MaterialLink>
           ) : (
-            <Typography color="textPrimary" aria-label={this.props.ariaLabel}>
+            <Typography color="textPrimary">
               <span>
                 {this.props.isLast ? (
                   <i>{this.props.displayName}</i>
@@ -463,22 +458,22 @@ class PageBreadcrumbs extends React.Component<
         <Paper square elevation={0}>
           {/* // Ensure that there is a path to render, otherwise do not show any breadcrumb. */}
           {this.currentPathnames.length > 0 ? (
-            <StyledBreadcrumbs aria-label="breadcrumb" separator="">
+            <StyledBreadcrumbs
+              aria-label={this.props.t('breadcrumbs.aria_label')}
+              separator=""
+            >
               <WrappedBreadcrumb
                 displayName={this.props.t('breadcrumbs.home')}
-                ariaLabel="Breadcrumb-home"
               />
 
               {/* // Return the base entity as a link. */}
               {breadcrumbState.base.isLast ? (
                 <WrappedBreadcrumb
                   displayName={breadcrumbState.base.displayName}
-                  ariaLabel="Breadcrumb-base"
                 />
               ) : (
                 <WrappedBreadcrumb
                   displayName={breadcrumbState.base.displayName}
-                  ariaLabel="Breadcrumb-base"
                   url={breadcrumbState.base.url + viewString}
                 />
               )}
@@ -492,13 +487,11 @@ class PageBreadcrumbs extends React.Component<
                 return index + 1 === hierarchyKeys.length ? (
                   <WrappedBreadcrumb
                     displayName={breadcrumbInfo.displayName}
-                    ariaLabel={`Breadcrumb-hierarchy-${index + 1}`}
                     key={`breadcrumb-${index + 1}`}
                   />
                 ) : (
                   <WrappedBreadcrumb
                     displayName={breadcrumbInfo.displayName}
-                    ariaLabel={`Breadcrumb-hierarchy-${index + 1}`}
                     url={breadcrumbInfo.url + viewString}
                     key={`breadcrumb-${index + 1}`}
                   />
@@ -509,7 +502,6 @@ class PageBreadcrumbs extends React.Component<
               {breadcrumbState.last.displayName !== '' ? (
                 <WrappedBreadcrumb
                   displayName={breadcrumbState.last.displayName}
-                  ariaLabel="Breadcrumb-last"
                   isLast={true}
                 />
               ) : null}

--- a/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
@@ -113,7 +113,7 @@ describe('PageContainer - Tests', () => {
     const wrapper = createWrapper();
 
     expect(
-      wrapper.find('[aria-label="view-count"]').first().find('h3').text()
+      wrapper.find('.tour-dataview-results').first().find('h3').text()
     ).toBe('app.results: 101');
   });
 
@@ -138,7 +138,7 @@ describe('PageContainer - Tests', () => {
   it('opens search plugin when icon clicked', () => {
     const wrapper = createWrapper();
 
-    wrapper.find('[aria-label="view-search"]').first().simulate('click');
+    wrapper.find('[aria-label="buttons.search"]').first().simulate('click');
 
     expect(history.length).toBe(2);
     expect(history.location.pathname).toBe('/search/data');
@@ -147,7 +147,7 @@ describe('PageContainer - Tests', () => {
   it('opens download plugin when Download Cart clicked', () => {
     const wrapper = createWrapper();
 
-    wrapper.find('[aria-label="view-cart"]').first().simulate('click');
+    wrapper.find('[aria-label="buttons.cart"]').first().simulate('click');
 
     expect(history.length).toBe(2);
     expect(history.location.pathname).toBe('/download');
@@ -177,7 +177,7 @@ describe('PageContainer - Tests', () => {
       wrapper.update();
     });
     expect(
-      wrapper.find('[aria-label="filter-message"]').first().text()
+      wrapper.find('[data-test-id="filter-message"]').first().text()
     ).toEqual('loading.filter_message');
   });
 
@@ -186,24 +186,19 @@ describe('PageContainer - Tests', () => {
 
     const wrapper = createWrapper();
 
-    expect(
-      wrapper.find('[aria-label="page-view app.view_cards"]').exists()
-    ).toBeTruthy();
-    expect(
-      wrapper.find('[aria-label="page-view app.view_cards"]').first().text()
-    ).toEqual('app.view_cards');
+    expect(wrapper.find('.tour-dataview-view-button').exists()).toBeTruthy();
+    expect(wrapper.find('.tour-dataview-view-button').first().text()).toEqual(
+      'app.view_cards'
+    );
 
     // Click view button
-    wrapper
-      .find('[aria-label="page-view app.view_cards"]')
-      .first()
-      .simulate('click');
+    wrapper.find('.tour-dataview-view-button').first().simulate('click');
     wrapper.update();
 
     // Check that the text on the button has changed
-    expect(
-      wrapper.find('[aria-label="page-view app.view_table"]').first().text()
-    ).toEqual('app.view_table');
+    expect(wrapper.find('.tour-dataview-view-button').first().text()).toEqual(
+      'app.view_table'
+    );
   });
 
   it('displays role selector when on My Data route', () => {
@@ -220,7 +215,7 @@ describe('PageContainer - Tests', () => {
     const wrapper = createWrapper();
 
     expect(
-      wrapper.find('[aria-label="filter-message"]').first().text()
+      wrapper.find('[data-test-id="filter-message"]').first().text()
     ).toEqual('loading.filter_message');
   });
 
@@ -229,7 +224,7 @@ describe('PageContainer - Tests', () => {
 
     const wrapper = createWrapper();
 
-    expect(wrapper.exists('[aria-label="filter-message"]')).toBeFalsy();
+    expect(wrapper.exists('[data-test-id="filter-message"]')).toBeFalsy();
   });
 
   it('do not use StyledRouting component on landing pages', () => {

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -167,12 +167,7 @@ const NavBar = React.memo(
       <Sticky>
         <StyledGrid container>
           {/* Hold the breadcrumbs at top left of the page. */}
-          <Grid
-            className="tour-dataview-breadcrumbs"
-            item
-            xs
-            aria-label="page-breadcrumbs"
-          >
+          <Grid className="tour-dataview-breadcrumbs" item xs>
             {/* don't show breadcrumbs on /my-data - only on browse */}
             <Route
               path={[paths.root, paths.studyHierarchy.root]}
@@ -198,7 +193,6 @@ const NavBar = React.memo(
                   direction="row"
                   alignItems="center"
                   justify="center"
-                  aria-label="open-data-warning"
                 >
                   <Grid item>
                     <ArrowTooltip
@@ -221,6 +215,9 @@ const NavBar = React.memo(
                       <IconButton
                         disableRipple
                         style={{ backgroundColor: 'transparent' }}
+                        aria-label={t(
+                          'app.open_data_warning.tooltip_aria_label'
+                        )}
                       >
                         <InfoIcon color="primary" />
                       </IconButton>
@@ -254,7 +251,6 @@ const NavBar = React.memo(
                   item
                   sm={2}
                   xs={3}
-                  aria-label="view-count"
                 >
                   <Paper
                     square
@@ -286,7 +282,7 @@ const NavBar = React.memo(
             <IconButton
               className="tour-dataview-search-icon"
               onClick={props.navigateToSearch}
-              aria-label="view-search"
+              aria-label={t('buttons.search')}
               style={{ margin: 'auto' }}
             >
               <SearchIcon />
@@ -304,7 +300,7 @@ const NavBar = React.memo(
             <IconButton
               className="tour-dataview-cart-icon"
               onClick={props.navigateToDownload}
-              aria-label="view-cart"
+              aria-label={t('buttons.cart')}
               style={{ margin: 'auto' }}
             >
               <Badge
@@ -312,7 +308,6 @@ const NavBar = React.memo(
                   props.cartItems.length > 0 ? props.cartItems.length : null
                 }
                 color="primary"
-                aria-label="view-cart-badge"
               >
                 <ShoppingCartIcon />
               </Badge>
@@ -345,9 +340,6 @@ const ViewButton = (props: {
     <div className={classes.root}>
       <Button
         className="tour-dataview-view-button"
-        aria-label={`page-view ${
-          props.viewCards ? t('app.view_table') : t('app.view_cards')
-        }`}
         variant="contained"
         color="primary"
         size="small"
@@ -387,7 +379,7 @@ const StyledRouting = (props: {
             align="center"
             variant="h6"
             component="h6"
-            aria-label="filter-message"
+            data-test-id="filter-message"
           >
             {t('loading.filter_message')}
           </Typography>
@@ -644,12 +636,7 @@ const PageContainer: React.FC = () => {
               )}
 
               {/* Hold the view for remainder of the page */}
-              <Grid
-                className="tour-dataview-data"
-                item
-                xs={12}
-                aria-label="page-view"
-              >
+              <Grid className="tour-dataview-data" item xs={12}>
                 <ViewRouting
                   view={view}
                   location={location}


### PR DESCRIPTION
## Description

We have a lot of `aria-label`s that are either:
- either not human readable or not translatable
- unnecessary and are only being used as selectors for tests

If an `aria-label` isn't human readable/translatable - it should be made into a translated string. If an `aria-label` is purely being used as a test selector, it should be removed and the tests refactors (either to use existing selectors or add a `data-test-id` attribute specifically for testing). `aria-label`s are only needed when there's information on a page that a sighted user would understand but a screen-reading user would not (e.g. icon buttons)

I've only done two components as I was working on them and noticed the poor `aria-label`s but as part of the accessibility effort we should refactor the rest

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

