### PR TITLE
Rename 'selections' to 'selection' (#858)

### DIFF
--- a/packages/datagateway-dataview/server/e2e-settings.json
+++ b/packages/datagateway-dataview/server/e2e-settings.json
@@ -52,7 +52,7 @@
     {
       "target": ".tour-dataview-cart-icon",
       "content":
-        "Displays the current number of items in the download selections, and navigates to Datagateway Download"
+        "Displays the current number of items in the download selection, and navigates to Datagateway Download"
     },
     {
       "target": ".tour-dataview-toggle-card",
@@ -71,7 +71,7 @@
     {
       "target": ".tour-dataview-data",
       "content":
-        "The results are displayed here, where it allows for expanding to view details and selecting specific results to add to the selections"
+        "The results are displayed here, where it allows for expanding to view details and selecting specific results to add to the selection"
     }
   ],
   "routes": [

--- a/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
@@ -23,7 +23,7 @@ describe('Download Cart', () => {
     cy.get('#datagateway-download').should('be.visible');
 
     // Ensure we can move away from the table and come back to it.
-    cy.get('[aria-label="Download selections panel"]').should('exist');
+    cy.get('[aria-label="Download selection panel"]').should('exist');
     // Wait for the downloads to be fetched before moving back to the cart.
     cy.get('[aria-label="Downloads"]')
       .should('exist')
@@ -31,8 +31,8 @@ describe('Download Cart', () => {
       .wait('@fetchDownloads');
     cy.get('[aria-label="Download status panel"]').should('exist');
 
-    cy.get('[aria-label="Selections').click().wait('@fetchCart');
-    cy.get('[aria-label="Download selections panel"]').should('exist');
+    cy.get('[aria-label="Selection').click().wait('@fetchCart');
+    cy.get('[aria-label="Download selection panel"]').should('exist');
 
     cy.get('[aria-rowcount=59]', { timeout: 10000 }).should('exist');
   });
@@ -105,7 +105,7 @@ describe('Download Cart', () => {
     cy.contains('Calculating...', { timeout: 20000 }).should('not.exist');
 
     cy.contains(/^DATASET 1$/).should('be.visible');
-    cy.get('[aria-label="Remove DATASET 1 from selections"]').click();
+    cy.get('[aria-label="Remove DATASET 1 from selection"]').click();
     cy.contains(/^DATASET 1$/).should('not.exist');
     cy.get('[aria-rowcount=58]').should('exist');
 
@@ -133,7 +133,7 @@ describe('Download Cart', () => {
 
   it('should be able open and close the download confirmation dialog', () => {
     cy.contains('Calculating...', { timeout: 20000 }).should('not.exist');
-    cy.contains('Download Selections').click();
+    cy.contains('Download Selection').click();
 
     cy.get('[aria-label="Download confirmation dialog"]').should('exist');
     cy.get('[aria-label="Close download confirmation dialog"]')

--- a/packages/datagateway-download/cypress/integration/downloadConfirmation.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadConfirmation.spec.ts
@@ -23,7 +23,7 @@ describe('Download Confirmation', () => {
     });
 
     // Open the confirmation dialog and confirm it is present.
-    cy.contains('Download Selections').click();
+    cy.contains('Download Selection').click();
     cy.get('[aria-label="Download confirmation dialog"]').should('exist');
   });
 

--- a/packages/datagateway-download/public/datagateway-download-settings.example.json
+++ b/packages/datagateway-download/public/datagateway-download-settings.example.json
@@ -22,11 +22,11 @@
     {
       "target": "#plugin-link--download",
       "content":
-        "DataGateway Download allows you to view and manage items in the current download selections as well see previous downloads"
+        "DataGateway Download allows you to view and manage items in the current download selection as well see previous downloads"
     },
     {
       "target": ".tour-download-cart-tab",
-      "content": "Show the items currently in the selections for download"
+      "content": "Show the items currently in the selection for download"
     },
     {
       "target": ".tour-download-downloads-tab",

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -1,10 +1,10 @@
 {
   "downloadTab": {
-    "cart_tab": "Selections",
+    "cart_tab": "Selection",
     "downloads_tab": "Downloads",
-    "cart_tab_arialabel": "Selections",
+    "cart_tab_arialabel": "Selection",
     "downloads_tab_arialabel": "Downloads",
-    "download_cart_panel_arialabel": "Download selections panel",
+    "download_cart_panel_arialabel": "Download selection panel",
     "download_status_panel_arialabel": "Download status panel",
     "last_updated_time_arialabel": "Last updated time",
     "refresh_download_status_arialabel": "Refresh download status table",
@@ -75,9 +75,9 @@
     "name": "Name",
     "type": "Type",
     "size": "Size",
-    "remove": "Remove {{name}} from selections",
+    "remove": "Remove {{name}} from selection",
     "remove_all": "Remove All",
-    "download": "Download Selections",
+    "download": "Download Selection",
     "number_of_files": "Number of files",
     "total_size": "Total size"
   }

--- a/packages/datagateway-download/server/e2e-settings.json
+++ b/packages/datagateway-download/server/e2e-settings.json
@@ -22,11 +22,11 @@
     {
       "target": "#plugin-link--download",
       "content":
-        "DataGateway Download allows you to view and manage items in the current download selections as well see previous downloads"
+        "DataGateway Download allows you to view and manage items in the current download selection as well see previous downloads"
     },
     {
       "target": ".tour-download-cart-tab",
-      "content": "Show the items currently in the selections for download"
+      "content": "Show the items currently in the selection for download"
     },
     {
       "target": ".tour-download-downloads-tab",

--- a/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
@@ -206,10 +206,10 @@ describe('SearchPageContainer Component', () => {
       cy.get('[aria-label="selection-alert-text"]')
         .invoke('text')
         .then((text) => {
-          expect(text.trim()).equal('1 item has been added to selections.');
+          expect(text.trim()).equal('1 item has been added to selection.');
         });
 
-      //Check can go to selections
+      //Check can go to selection
       cy.get('[aria-label="selection-alert-link"]').click();
       cy.location().should((loc) => {
         expect(loc.pathname).to.equal('/download');

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -75,16 +75,16 @@
     "dataset": "Dataset"
   },
   "buttons": {
-    "add_to_cart": "Add to selections",
-    "remove_from_cart": "Remove from selections",
+    "add_to_cart": "Add to selection",
+    "remove_from_cart": "Remove from selection",
     "download": "Download"
   },
   "selec_alert" : {
-    "added": "{{count}} item has been added to selections.",
-    "added_plural" : "{{count}} items have been added to selections.",
-    "removed" : "{{count}} item has been removed from selections.",
-    "removed_plural" : "{{count}} items have been removed from selections.",
-    "link" : "Go to selections."
+    "added": "{{count}} item has been added to selection.",
+    "added_plural" : "{{count}} items have been added to selection.",
+    "removed" : "{{count}} item has been removed from selection.",
+    "removed_plural" : "{{count}} items have been removed from selection.",
+    "link" : "Go to selection."
   },
   "app": {
     "error": "Something went wrong...",    


### PR DESCRIPTION
## Description
This changes 'selections' to 'selection' in the default language files as requested in #858.

## Testing instructions
Ensure new phrasing makes sense.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #858
