### PR TITLE
fix search tick focusing problem #911

### DIFF
--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -72,7 +72,11 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
         } tour-search-checkbox`}
       >
         <FormGroup row={!sideLayout}>
-          <FormLabel component="legend" className={classes.formLabel}>
+          <FormLabel
+            component="legend"
+            focused={false}
+            className={classes.formLabel}
+          >
             {t('searchBox.checkboxes.text')}
           </FormLabel>
           <FormControlLabel


### PR DESCRIPTION
## Description
The instruction text next to the tick boxes is changing colour when a tick box is being selected. 
<br><br>
![focusedissuesearch](https://user-images.githubusercontent.com/83226114/141083208-ea19d591-ecda-44ff-81e8-f6f821b60c9e.gif)

- Remove the focusing.
- The error text colour is going to overridden in scigateway as it doesn't have sufficient contrast to satisfy  WCAG 2.1 AA  : ral-facilities/scigateway/issues/803

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #911
