### PR TITLE
#913 - Remove uneccessary includes and type filters

### DIFF
--- a/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
@@ -65,17 +65,6 @@ describe('DLS - Visits Cards', () => {
   });
 
   it('should be able to filter by multiple fields', () => {
-    cy.contains('[role="button"]', 'Type ID').click();
-    cy.contains('[role="button"]', 'Type ID')
-      .parent()
-      .contains('[role="button"]', '2')
-      .click()
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'Type ID - 2').should('exist');
-    cy.get('#card').contains('42');
-
     cy.get('[aria-label="advanced-filters-link"]').click();
     cy.get('[aria-label="Filter by Visit ID"]')
       .first()

--- a/packages/datagateway-dataview/src/views/card/datasetCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/datasetCardView.component.test.tsx
@@ -104,10 +104,6 @@ describe('Dataset - Card View', () => {
           'investigation.id': { eq: investigationId },
         }),
       },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
-      },
     ]);
     expect(useDatasetsPaginated).toHaveBeenCalledWith([
       {
@@ -115,10 +111,6 @@ describe('Dataset - Card View', () => {
         filterValue: JSON.stringify({
           'investigation.id': { eq: investigationId },
         }),
-      },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
       },
     ]);
   });

--- a/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
@@ -47,10 +47,6 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
         'investigation.id': { eq: investigationId },
       }),
     },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
-    },
   ]);
   const { isLoading: dataLoading, data } = useDatasetsPaginated([
     {
@@ -58,10 +54,6 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
       filterValue: JSON.stringify({
         'investigation.id': { eq: investigationId },
       }),
-    },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
     },
   ]);
 

--- a/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsDatasetsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsDatasetsCardView.component.test.tsx.snap
@@ -5,14 +5,6 @@ Object {
   "buttons": Array [
     [Function],
   ],
-  "customFilters": Array [
-    Object {
-      "dataKey": "type.id",
-      "filterItems": Array [],
-      "label": "datasets.type.id",
-      "prefixLabel": true,
-    },
-  ],
   "data": Array [
     Object {
       "createTime": "2019-07-23",

--- a/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsVisitsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsVisitsCardView.component.test.tsx.snap
@@ -2,14 +2,6 @@
 
 exports[`DLS Visits - Card View renders correctly 1`] = `
 Object {
-  "customFilters": Array [
-    Object {
-      "dataKey": "type.id",
-      "filterItems": Array [],
-      "label": "investigations.type.id",
-      "prefixLabel": true,
-    },
-  ],
   "data": Array [
     Object {
       "id": 1,

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
@@ -105,10 +105,6 @@ describe('DLS Datasets - Card View', () => {
           'investigation.id': { eq: investigationId },
         }),
       },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
-      },
     ]);
     expect(useDatasetsPaginated).toHaveBeenCalledWith([
       {
@@ -116,14 +112,6 @@ describe('DLS Datasets - Card View', () => {
         filterValue: JSON.stringify({
           'investigation.id': { eq: investigationId },
         }),
-      },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
-      },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('type'),
       },
     ]);
   });

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
@@ -13,11 +13,8 @@ import {
   usePushResults,
   usePushSort,
   useTextFilter,
-  useCustomFilter,
   useDatasetsDatafileCount,
   AddToCartButton,
-  useCustomFilterCount,
-  formatFilterCount,
 } from 'datagateway-common';
 import { CalendarToday } from '@material-ui/icons';
 import ConfirmationNumberIcon from '@material-ui/icons/ConfirmationNumber';
@@ -55,37 +52,8 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
         'investigation.id': { eq: investigationId },
       }),
     },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
-    },
   ]);
   const { data, isLoading: dataLoading } = useDatasetsPaginated([
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'investigation.id': { eq: investigationId },
-      }),
-    },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
-    },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('type'),
-    },
-  ]);
-
-  const { data: typeIds } = useCustomFilter('dataset', 'type.id', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'investigation.id': { eq: investigationId },
-      }),
-    },
-  ]);
-  const typeIdCounts = useCustomFilterCount('dataset', 'type.id', typeIds, [
     {
       filterType: 'where',
       filterValue: JSON.stringify({
@@ -176,23 +144,6 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
     [data]
   );
 
-  const customFilters = React.useMemo(
-    () => [
-      {
-        label: t('datasets.type.id'),
-        dataKey: 'type.id',
-        filterItems: typeIds
-          ? typeIds.map((id, i) => ({
-              name: id,
-              count: formatFilterCount(typeIdCounts[i]),
-            }))
-          : [],
-        prefixLabel: true,
-      },
-    ],
-    [t, typeIds, typeIdCounts]
-  );
-
   return (
     <CardView
       data={data ?? []}
@@ -214,7 +165,6 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
         <DatasetDetailsPanel rowData={dataset} />
       )}
       buttons={buttons}
-      customFilters={customFilters}
     />
   );
 };

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
@@ -117,10 +117,6 @@ describe('DLS Visits - Card View', () => {
           investigationInstruments: 'instrument',
         }),
       },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('type'),
-      },
     ]);
     expect(useInvestigationsDatasetCount).toHaveBeenCalledWith(cardData);
   });

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
@@ -7,7 +7,6 @@ import {
   tableLink,
   parseSearchToQuery,
   useDateFilter,
-  useCustomFilter,
   useInvestigationCount,
   useInvestigationsPaginated,
   usePushFilters,
@@ -18,8 +17,6 @@ import {
   useInvestigationsDatasetCount,
   nestedValue,
   ArrowTooltip,
-  useCustomFilterCount,
-  formatFilterCount,
 } from 'datagateway-common';
 import VisitDetailsPanel from '../../detailsPanels/dls/visitDetailsPanel.component';
 import {
@@ -73,29 +70,8 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
         investigationInstruments: 'instrument',
       }),
     },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('type'),
-    },
   ]);
   const countQueries = useInvestigationsDatasetCount(data);
-  const { data: typeIds } = useCustomFilter('investigation', 'type.id', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({ name: { eq: proposalName } }),
-    },
-  ]);
-  const typeIdCounts = useCustomFilterCount(
-    'investigation',
-    'type.id',
-    typeIds,
-    [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({ name: { eq: proposalName } }),
-      },
-    ]
-  );
 
   const title = React.useMemo(
     () => ({
@@ -168,23 +144,6 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
     [countQueries, data, dateFilter, t, textFilter]
   );
 
-  const customFilters = React.useMemo(
-    () => [
-      {
-        label: t('investigations.type.id'),
-        dataKey: 'type.id',
-        filterItems: typeIds
-          ? typeIds.map((id, i) => ({
-              name: id,
-              count: formatFilterCount(typeIdCounts[i]),
-            }))
-          : [],
-        prefixLabel: true,
-      },
-    ],
-    [t, typeIds, typeIdCounts]
-  );
-
   return (
     <CardView
       data={data ?? []}
@@ -205,7 +164,6 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
       moreInformation={(investigation: Investigation) => (
         <VisitDetailsPanel rowData={investigation} />
       )}
-      customFilters={customFilters}
     />
   );
 };

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
@@ -112,10 +112,6 @@ describe('ISIS Datasets - Card View', () => {
           'investigation.id': { eq: investigationId },
         }),
       },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
-      },
     ]);
     expect(useDatasetsPaginated).toHaveBeenCalledWith([
       {
@@ -123,10 +119,6 @@ describe('ISIS Datasets - Card View', () => {
         filterValue: JSON.stringify({
           'investigation.id': { eq: investigationId },
         }),
-      },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
       },
     ]);
   });

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
@@ -76,10 +76,6 @@ const ISISDatasetsCardView = (
         'investigation.id': { eq: investigationId },
       }),
     },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
-    },
   ]);
   const { data, isLoading: dataLoading } = useDatasetsPaginated([
     {
@@ -87,10 +83,6 @@ const ISISDatasetsCardView = (
       filterValue: JSON.stringify({
         'investigation.id': { eq: investigationId },
       }),
-    },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
     },
   ]);
   const sizeQueries = useDatasetSizes(data);

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
@@ -125,10 +125,6 @@ describe('Dataset table component', () => {
           'investigation.id': { eq: investigationId },
         }),
       },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
-      },
     ]);
     expect(useDatasetsInfinite).toHaveBeenCalledWith([
       {
@@ -136,10 +132,6 @@ describe('Dataset table component', () => {
         filterValue: JSON.stringify({
           'investigation.id': { eq: investigationId },
         }),
-      },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
       },
     ]);
     expect(useDatasetsDatafileCount).toHaveBeenCalledWith({

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
@@ -125,10 +125,6 @@ const DatasetTable = (props: DatasetTableProps): React.ReactElement => {
         'investigation.id': { eq: investigationId },
       }),
     },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
-    },
   ]);
 
   const { fetchNextPage, data } = useDatasetsInfinite([
@@ -137,10 +133,6 @@ const DatasetTable = (props: DatasetTableProps): React.ReactElement => {
       filterValue: JSON.stringify({
         'investigation.id': { eq: investigationId },
       }),
-    },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
     },
   ]);
 

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
@@ -124,10 +124,6 @@ describe('DLS Dataset table component', () => {
           'investigation.id': { eq: investigationId },
         }),
       },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
-      },
     ]);
     expect(useDatasetsInfinite).toHaveBeenCalledWith([
       {
@@ -135,10 +131,6 @@ describe('DLS Dataset table component', () => {
         filterValue: JSON.stringify({
           'investigation.id': { eq: investigationId },
         }),
-      },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
       },
     ]);
     expect(useDatasetsDatafileCount).toHaveBeenCalledWith({

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -76,10 +76,6 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
         'investigation.id': { eq: investigationId },
       }),
     },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
-    },
   ]);
 
   const { fetchNextPage, data } = useDatasetsInfinite([
@@ -88,10 +84,6 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
       filterValue: JSON.stringify({
         'investigation.id': { eq: investigationId },
       }),
-    },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
     },
   ]);
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
@@ -129,10 +129,6 @@ describe('ISIS Dataset table component', () => {
           'investigation.id': { eq: investigationId },
         }),
       },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
-      },
     ]);
     expect(useDatasetsInfinite).toHaveBeenCalledWith([
       {
@@ -140,10 +136,6 @@ describe('ISIS Dataset table component', () => {
         filterValue: JSON.stringify({
           'investigation.id': { eq: investigationId },
         }),
-      },
-      {
-        filterType: 'include',
-        filterValue: JSON.stringify('investigation'),
       },
     ]);
     expect(useDatasetSizes).toHaveBeenCalledWith({

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -93,10 +93,6 @@ const ISISDatasetsTable = (
         'investigation.id': { eq: investigationId },
       }),
     },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
-    },
   ]);
 
   const { fetchNextPage, data } = useDatasetsInfinite([
@@ -105,10 +101,6 @@ const ISISDatasetsTable = (
       filterValue: JSON.stringify({
         'investigation.id': { eq: investigationId },
       }),
-    },
-    {
-      filterType: 'include',
-      filterValue: JSON.stringify('investigation'),
     },
   ]);
 


### PR DESCRIPTION
## Description
The dataset views all had an include for investigation which I believe was a holdover from the DB backend days. This makes the queries less performant to the point I couldn't fetch 50 datasets on DLS preprod.

Also, the type filters on DLS card views was meaningless and so I removed it as well.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #913 
