### PR TITLE
Configure searchable entities #916

### DIFF
--- a/packages/datagateway-search/public/datagateway-search-settings.example.json
+++ b/packages/datagateway-search/public/datagateway-search-settings.example.json
@@ -27,6 +27,7 @@
       "content": "Select the type of search results to view"
     }
   ],
+  "searchableEntities": ["investigation", "dataset", "datafile"],
   "routes": [
     {
       "section": "Test",

--- a/packages/datagateway-search/src/__snapshots__/searchPageContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageContainer.component.test.tsx.snap
@@ -1310,6 +1310,13 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
             datafileTab={true}
             datasetTab={true}
             investigationTab={true}
+            searchableEntities={
+              Array [
+                "investigation",
+                "dataset",
+                "datafile",
+              ]
+            }
             setDatafileTab={[Function]}
             setDatasetTab={[Function]}
             setInvestigationTab={[Function]}

--- a/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
@@ -48,6 +48,7 @@ describe('Checkbox component tests', () => {
         datafile: [],
         investigation: [],
       },
+      searchableEntities: ['investigation', 'dataset', 'datafile'],
       settingsLoaded: true,
     };
 
@@ -77,6 +78,29 @@ describe('Checkbox component tests', () => {
     datafileCheckbox.find('input').forEach((node) => {
       expect(node.props().checked).toEqual(true);
     });
+  });
+
+  it('renders correctly when datafiles are not searchable', () => {
+    state.dgsearch.searchableEntities = ['investigation', 'dataset'];
+    history.replace('/?searchText=&investigation=false');
+    const wrapper = createWrapper();
+    const investigationCheckbox = wrapper.find(
+      '[aria-label="Investigation checkbox"]'
+    );
+    expect(investigationCheckbox.exists());
+    investigationCheckbox.find('input').forEach((node) => {
+      expect(node.props().checked).toEqual(false);
+    });
+
+    const datasetCheckbox = wrapper.find('[aria-label="Dataset checkbox"]');
+    expect(datasetCheckbox.exists());
+    datasetCheckbox.find('input').forEach((node) => {
+      expect(node.props().checked).toEqual(true);
+    });
+
+    expect(wrapper.find('[aria-label="Datafile checkbox"]').exists()).toEqual(
+      false
+    );
   });
 
   it('pushes URL with new dataset value when user clicks checkbox', () => {

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -31,11 +31,16 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface CheckBoxStoreProps {
   sideLayout: boolean;
+  searchableEntities: string[];
 }
 
 const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
   const classes = useStyles();
-  const { sideLayout } = props;
+  const { sideLayout, searchableEntities } = props;
+
+  const investigationSearchable = searchableEntities.includes('investigation');
+  const datasetSearchable = searchableEntities.includes('dataset');
+  const datafileSearchable = searchableEntities.includes('datafile');
 
   const location = useLocation();
   const { dataset, datafile, investigation } = React.useMemo(
@@ -43,6 +48,11 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
     [location.search]
   );
   const pushSearchToggles = usePushSearchToggles();
+
+  const searchableEntitiesToggles: boolean[] = [];
+  if (investigationSearchable) searchableEntitiesToggles.push(investigation);
+  if (datasetSearchable) searchableEntitiesToggles.push(dataset);
+  if (datafileSearchable) searchableEntitiesToggles.push(datafile);
 
   const handleChange = (name: string, checked: boolean) => (
     event: React.ChangeEvent<HTMLInputElement>
@@ -57,7 +67,7 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
     }
   };
 
-  const error = ![investigation, dataset, datafile].includes(true);
+  const error = !searchableEntitiesToggles.includes(true);
 
   const [t] = useTranslation();
 
@@ -75,47 +85,53 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
           <FormLabel component="legend" className={classes.formLabel}>
             {t('searchBox.checkboxes.text')}
           </FormLabel>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={investigation}
-                onChange={handleChange('Investigation', investigation)}
-                value="Investigation"
-                inputProps={{
-                  'aria-label': t(
-                    'searchBox.checkboxes.investigation_arialabel'
-                  ),
-                }}
-              />
-            }
-            label={t('searchBox.checkboxes.investigation')}
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={dataset}
-                onChange={handleChange('Dataset', dataset)}
-                value="Dataset"
-                inputProps={{
-                  'aria-label': t('searchBox.checkboxes.dataset_arialabel'),
-                }}
-              />
-            }
-            label={t('searchBox.checkboxes.dataset')}
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={datafile}
-                onChange={handleChange('Datafile', datafile)}
-                value="Datafile"
-                inputProps={{
-                  'aria-label': t('searchBox.checkboxes.datafile_arialabel'),
-                }}
-              />
-            }
-            label={t('searchBox.checkboxes.datafile')}
-          />
+          {investigationSearchable && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={investigation}
+                  onChange={handleChange('Investigation', investigation)}
+                  value="Investigation"
+                  inputProps={{
+                    'aria-label': t(
+                      'searchBox.checkboxes.investigation_arialabel'
+                    ),
+                  }}
+                />
+              }
+              label={t('searchBox.checkboxes.investigation')}
+            />
+          )}
+          {datasetSearchable && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={dataset}
+                  onChange={handleChange('Dataset', dataset)}
+                  value="Dataset"
+                  inputProps={{
+                    'aria-label': t('searchBox.checkboxes.dataset_arialabel'),
+                  }}
+                />
+              }
+              label={t('searchBox.checkboxes.dataset')}
+            />
+          )}
+          {datafileSearchable && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={datafile}
+                  onChange={handleChange('Datafile', datafile)}
+                  value="Datafile"
+                  inputProps={{
+                    'aria-label': t('searchBox.checkboxes.datafile_arialabel'),
+                  }}
+                />
+              }
+              label={t('searchBox.checkboxes.datafile')}
+            />
+          )}
         </FormGroup>
       </FormControl>
     </div>
@@ -125,6 +141,7 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
 const mapStateToProps = (state: StateType): CheckBoxStoreProps => {
   return {
     sideLayout: state.dgsearch.sideLayout,
+    searchableEntities: state.dgsearch.searchableEntities,
   };
 };
 

--- a/packages/datagateway-search/src/searchPageContainer.component.test.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.test.tsx
@@ -692,4 +692,20 @@ describe('SearchPageContainer - Tests', () => {
       }
     );
   });
+
+  it('does not search when there are no searchable entities', async () => {
+    state.dgsearch.searchableEntities = [];
+
+    const wrapper = createWrapper();
+    wrapper
+      .find('button[aria-label="searchBox.search_button_arialabel"]')
+      .simulate('click');
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect((axios.get as jest.Mock).mock.calls.length).toBe(0);
+  });
 });

--- a/packages/datagateway-search/src/searchPageContainer.component.test.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.test.tsx
@@ -76,6 +76,7 @@ describe('SearchPageContainer - Tests', () => {
         currentTab: 'investigation',
       },
       sideLayout: false,
+      searchableEntities: ['investigation', 'dataset', 'datafile'],
       settingsLoaded: true,
     };
 
@@ -107,6 +108,10 @@ describe('SearchPageContainer - Tests', () => {
         return Promise.resolve({ data: [] });
       }
     });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('renders searchPageContainer correctly', () => {
@@ -630,6 +635,57 @@ describe('SearchPageContainer - Tests', () => {
             lower: '201311110000',
             text: 'hello',
             upper: '201611112359',
+          },
+          sessionId: null,
+        },
+      }
+    );
+  });
+
+  it('does not search for non-searchable entities when visiting a direct url', async () => {
+    state.dgsearch.searchableEntities = ['investigation', 'dataset'];
+
+    history.replace('/search/data?searchText=hello&datafiles=true');
+
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Investigation',
+            text: 'hello',
+          },
+          sessionId: null,
+        },
+      }
+    );
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Dataset',
+            text: 'hello',
+          },
+          sessionId: null,
+        },
+      }
+    );
+
+    expect(axios.get).not.toHaveBeenCalledWith(
+      'https://example.com/icat/lucene/data',
+      {
+        params: {
+          maxCount: 300,
+          query: {
+            target: 'Datafile',
+            text: 'hello',
           },
           sessionId: null,
         },

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -120,6 +120,7 @@ const ViewButton = (props: {
 
 interface SearchPageContainerStoreProps {
   sideLayout: boolean;
+  searchableEntities: string[];
   datafileTab: boolean;
   datasetTab: boolean;
   investigationTab: boolean;
@@ -143,6 +144,7 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
     setDatasetTab,
     setInvestigationTab,
     sideLayout,
+    searchableEntities,
     currentTab,
   } = props;
 
@@ -150,14 +152,18 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
   const queryParams = React.useMemo(() => parseSearchToQuery(location.search), [
     location.search,
   ]);
-  const {
-    view,
-    dataset,
-    datafile,
-    investigation,
-    startDate,
-    endDate,
-  } = queryParams;
+  const { view, startDate, endDate } = queryParams;
+  //Do not allow these to be searched if they are not searchable (prevents URL
+  //forcing them to be searched)
+  const investigation = searchableEntities.includes('investigation')
+    ? queryParams.investigation
+    : false;
+  const dataset = searchableEntities.includes('dataset')
+    ? queryParams.dataset
+    : false;
+  const datafile = searchableEntities.includes('datafile')
+    ? queryParams.datafile
+    : false;
 
   const pushView = useUpdateView('push');
   const replaceView = useUpdateView('replace');
@@ -392,6 +398,7 @@ const mapDispatchToProps = (
 
 const mapStateToProps = (state: StateType): SearchPageContainerStoreProps => ({
   sideLayout: state.dgsearch.sideLayout,
+  searchableEntities: state.dgsearch.searchableEntities,
   datafileTab: state.dgsearch.tabs.datafileTab,
   datasetTab: state.dgsearch.tabs.datasetTab,
   investigationTab: state.dgsearch.tabs.investigationTab,

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -1,5 +1,8 @@
-import { configureApp, settingsLoaded } from '.';
-import { SettingsLoadedType } from './actions.types';
+import { configureApp, loadSearchableEntitites, settingsLoaded } from '.';
+import {
+  ConfigureSearchableEntitiesType,
+  SettingsLoadedType,
+} from './actions.types';
 import axios from 'axios';
 import * as log from 'loglevel';
 import { actions, resetActions, dispatch, getState } from '../../setupTests';
@@ -32,6 +35,14 @@ describe('Actions', () => {
     expect(action.type).toEqual(SettingsLoadedType);
   });
 
+  it('given JSON loadSelectAllSetting returns a ConfigureSearchableEntitiesType with ConfigureSearchableEntitiesPayload', () => {
+    const action = loadSearchableEntitites(['investigation', 'dataset']);
+    expect(action.type).toEqual(ConfigureSearchableEntitiesType);
+    expect(action.payload).toEqual({
+      entities: ['investigation', 'dataset'],
+    });
+  });
+
   it('settings are loaded and facilityName, loadUrls and settingsLoaded actions are sent', async () => {
     (axios.get as jest.Mock)
       .mockImplementationOnce(() =>
@@ -42,6 +53,7 @@ describe('Actions', () => {
             apiUrl: 'api',
             downloadApiUrl: 'download-api',
             icatUrl: 'icat',
+            searchableEntities: ['investigation', 'dataset', 'datafile'],
             routes: [
               {
                 section: 'section',
@@ -64,7 +76,7 @@ describe('Actions', () => {
     const asyncAction = configureApp();
     await asyncAction(dispatch, getState);
 
-    expect(actions.length).toEqual(3);
+    expect(actions.length).toEqual(4);
     expect(actions).toContainEqual(loadFacilityName('Generic'));
     expect(actions).toContainEqual(
       loadUrls({
@@ -76,6 +88,9 @@ describe('Actions', () => {
     );
 
     expect(actions).toContainEqual(settingsLoaded());
+    expect(actions).toContainEqual(
+      loadSearchableEntitites(['investigation', 'dataset', 'datafile'])
+    );
     expect(CustomEvent).toHaveBeenCalledTimes(1);
     expect(CustomEvent).toHaveBeenLastCalledWith(MicroFrontendId, {
       detail: {

--- a/packages/datagateway-search/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.types.tsx
@@ -4,6 +4,8 @@ export const SetInvestigationTabType =
   'datagateway_search:set_investigation_tab';
 export const SetCurrentTabType = 'datagateway_search:set_current_tab';
 export const SettingsLoadedType = 'datagateway_search:settings_loaded';
+export const ConfigureSearchableEntitiesType =
+  'datagateway_search:configure_searchable_entities';
 
 export interface TogglePayload {
   toggleOption: boolean;
@@ -11,4 +13,8 @@ export interface TogglePayload {
 
 export interface CurrentTabPayload {
   currentTab: string;
+}
+
+export interface ConfigureSearchableEntitiesPayload {
+  entities: string[];
 }

--- a/packages/datagateway-search/src/state/actions/index.tsx
+++ b/packages/datagateway-search/src/state/actions/index.tsx
@@ -1,5 +1,9 @@
-import { ThunkResult } from '../app.types';
-import { SettingsLoadedType } from './actions.types';
+import { ActionType, ThunkResult } from '../app.types';
+import {
+  ConfigureSearchableEntitiesPayload,
+  ConfigureSearchableEntitiesType,
+  SettingsLoadedType,
+} from './actions.types';
 import {
   loadUrls,
   loadFacilityName,
@@ -16,6 +20,15 @@ import jsrsasign from 'jsrsasign';
 
 export const settingsLoaded = (): Action => ({
   type: SettingsLoadedType,
+});
+
+export const loadSearchableEntitites = (
+  entities: string[]
+): ActionType<ConfigureSearchableEntitiesPayload> => ({
+  type: ConfigureSearchableEntitiesType,
+  payload: {
+    entities: entities,
+  },
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
@@ -58,6 +71,10 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
           throw new Error(
             'One of the URL options (idsUrl, apiUrl, downloadApiUrl, icatUrl) is undefined in settings'
           );
+        }
+
+        if ('searchableEntities' in settings) {
+          dispatch(loadSearchableEntitites(settings['searchableEntities']));
         }
 
         if (Array.isArray(settings['routes']) && settings['routes'].length) {

--- a/packages/datagateway-search/src/state/app.types.tsx
+++ b/packages/datagateway-search/src/state/app.types.tsx
@@ -11,6 +11,7 @@ export interface DGSearchState {
   };
   settingsLoaded: boolean;
   sideLayout: boolean;
+  searchableEntities: string[];
 }
 
 export type StateType = {

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
@@ -6,7 +6,7 @@ import {
   setInvestigationTab,
   setCurrentTab,
 } from '../actions/actions';
-import { settingsLoaded } from '../actions';
+import { loadSearchableEntitites, settingsLoaded } from '../actions';
 
 describe('dgsearch reducer', () => {
   let state: DGSearchState;
@@ -59,5 +59,20 @@ describe('dgsearch reducer', () => {
     const updatedState = DGSearchReducer(state, setCurrentTab('dataset'));
 
     expect(updatedState.tabs.currentTab).toEqual('dataset');
+  });
+
+  it('should set searchableEntities property when configuring action is sent', () => {
+    expect(state.searchableEntities).toEqual([
+      'investigation',
+      'dataset',
+      'datafile',
+    ]);
+
+    const updatedState = DGSearchReducer(
+      state,
+      loadSearchableEntitites(['dataset'])
+    );
+
+    expect(updatedState.searchableEntities).toEqual(['dataset']);
   });
 });

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
@@ -8,6 +8,8 @@ import {
   SettingsLoadedType,
   CurrentTabPayload,
   SetCurrentTabType,
+  ConfigureSearchableEntitiesPayload,
+  ConfigureSearchableEntitiesType,
 } from '../actions/actions.types';
 
 export const initialState: DGSearchState = {
@@ -19,6 +21,7 @@ export const initialState: DGSearchState = {
   },
   settingsLoaded: false,
   sideLayout: false,
+  searchableEntities: ['investigation', 'dataset', 'datafile'],
 };
 
 export function handleSettingsLoaded(state: DGSearchState): DGSearchState {
@@ -80,12 +83,23 @@ export function handleSetCurrentTab(
   };
 }
 
+export function handleConfigureSearchableEntities(
+  state: DGSearchState,
+  payload: ConfigureSearchableEntitiesPayload
+): DGSearchState {
+  return {
+    ...state,
+    searchableEntities: payload.entities,
+  };
+}
+
 const DGSearchReducer = createReducer(initialState, {
   [SetDatasetTabType]: handleSetDatasetTab,
   [SetDatafileTabType]: handleSetDatafileTab,
   [SetInvestigationTabType]: handleSetInvestigationTab,
   [SettingsLoadedType]: handleSettingsLoaded,
   [SetCurrentTabType]: handleSetCurrentTab,
+  [ConfigureSearchableEntitiesType]: handleConfigureSearchableEntities,
 });
 
 export default DGSearchReducer;


### PR DESCRIPTION
## Description
Adds setting named 'searchableEntities' that allows the searchable items to be configured, e.g. `"searchableEntities": ["investigation", "dataset"]` removes the checkbox on search and prevents searching for datafiles regardless of what is defined in the URL query parameters. Screenshot:
![image](https://user-images.githubusercontent.com/90245114/141110815-d557d193-91b0-41be-aeb0-9aa1fea068b6.png)




## Testing instructions
This is a draft as tests need to be added.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #916
