### PR TITLE
#914 - use selectAllSetting to stop sending allID requests

### DIFF
--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -509,6 +509,18 @@ describe('generic api functions', () => {
       expect(result.current.data).toEqual([1, 2, 3]);
     });
 
+    it('does not send axios request to fetch ids when set to disabled', async () => {
+      const { result } = renderHook(
+        () => useIds('investigation', undefined, false),
+        {
+          wrapper: createReactQueryWrapper(),
+        }
+      );
+
+      expect(result.current.isIdle).toBe(true);
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
     it('sends axios request to fetch ids and calls handleICATError on failure', async () => {
       (axios.get as jest.Mock).mockRejectedValue({
         message: 'Test error',

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -481,7 +481,8 @@ export const fetchIds = (
 
 export const useIds = (
   entityType: 'investigation' | 'dataset' | 'datafile',
-  additionalFilters?: AdditionalFilters
+  additionalFilters?: AdditionalFilters,
+  enabled = true
 ): UseQueryResult<number[], Error> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
@@ -502,6 +503,7 @@ export const useIds = (
       onError: (error) => {
         handleICATError(error);
       },
+      enabled,
     }
   );
 };

--- a/packages/datagateway-common/src/api/investigations.test.tsx
+++ b/packages/datagateway-common/src/api/investigations.test.tsx
@@ -1346,6 +1346,18 @@ describe('investigation api functions', () => {
         expect(result.current.data).toEqual([1, 2, 3]);
       });
 
+      it('does not send axios request to fetch ids when set to disabled', async () => {
+        const { result } = renderHook(
+          () => useISISInvestigationIds(1, 2, false, false),
+          {
+            wrapper: createReactQueryWrapper(history),
+          }
+        );
+
+        expect(result.current.isIdle).toBe(true);
+        expect(axios.get).not.toHaveBeenCalled();
+      });
+
       it('sends axios request to fetch ISIS investigation ids and calls handleICATError on failure', async () => {
         (axios.get as jest.Mock).mockRejectedValue({
           message: 'Test error',

--- a/packages/datagateway-common/src/api/investigations.tsx
+++ b/packages/datagateway-common/src/api/investigations.tsx
@@ -772,7 +772,8 @@ const fetchAllISISInvestigationIds = (
 export const useISISInvestigationIds = (
   instrumentId: number,
   instrumentChildId: number,
-  studyHierarchy: boolean
+  studyHierarchy: boolean,
+  enabled = true
 ): UseQueryResult<number[], AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
@@ -818,6 +819,7 @@ export const useISISInvestigationIds = (
       onError: (error) => {
         handleICATError(error);
       },
+      enabled,
     }
   );
 };

--- a/packages/datagateway-common/src/views/addToCartButton.component.test.tsx
+++ b/packages/datagateway-common/src/views/addToCartButton.component.test.tsx
@@ -90,7 +90,7 @@ describe('Generic add to cart button', () => {
       entityType,
     });
 
-    wrapper.find('#add-to-cart-btn').first().simulate('click');
+    wrapper.find('#add-to-cart-btn-1').first().simulate('click');
 
     expect(useAddToCart).toHaveBeenCalledWith(entityType);
   });
@@ -115,7 +115,7 @@ describe('Generic add to cart button', () => {
       entityType,
     });
 
-    wrapper.find('#remove-from-cart-btn').first().simulate('click');
+    wrapper.find('#remove-from-cart-btn-1').first().simulate('click');
     expect(useRemoveFromCart).toHaveBeenCalledWith(entityType);
   });
 });

--- a/packages/datagateway-common/src/views/addToCartButton.component.tsx
+++ b/packages/datagateway-common/src/views/addToCartButton.component.tsx
@@ -39,7 +39,7 @@ const AddToCartButton: React.FC<AddToCartButtonCombinedProps> = (
 
   return !(selectedIds && selectedIds.includes(entityId)) ? (
     <Button
-      id="add-to-cart-btn"
+      id={`add-to-cart-btn-${entityId}`}
       variant="contained"
       color="primary"
       startIcon={<AddCircleOutlineOutlined />}
@@ -50,7 +50,7 @@ const AddToCartButton: React.FC<AddToCartButtonCombinedProps> = (
     </Button>
   ) : (
     <Button
-      id="remove-from-cart-btn"
+      id={`remove-from-cart-btn-${entityId}`}
       variant="contained"
       color="secondary"
       startIcon={<RemoveCircleOutlineOutlined />}

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
@@ -96,7 +96,7 @@ Object {
 
 exports[`Datafile table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-251"
+  className="makeStyles-root-276"
   container={true}
   direction="column"
   id="details-panel"
@@ -113,7 +113,7 @@ exports[`Datafile table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-252"
+      className="makeStyles-divider-277"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
@@ -247,7 +247,7 @@ Object {
 
 exports[`Dataset table component renders details panel correctly 1`] = `
 <div
-  className="MuiGrid-root makeStyles-root-226 MuiGrid-container MuiGrid-direction-xs-column"
+  className="MuiGrid-root makeStyles-root-251 MuiGrid-container MuiGrid-direction-xs-column"
   id="details-panel"
 >
   <WithStyles(ForwardRef(Grid))
@@ -262,7 +262,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-227"
+      className="makeStyles-divider-252"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -163,7 +163,7 @@ Object {
 
 exports[`Investigation table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-371"
+  className="makeStyles-root-408"
   container={true}
   direction="column"
   id="details-panel"
@@ -180,7 +180,7 @@ exports[`Investigation table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-372"
+      className="makeStyles-divider-409"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/datafileTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/datafileTable.component.test.tsx
@@ -141,18 +141,22 @@ describe('Datafile table component', () => {
         }),
       },
     ]);
-    expect(useIds).toHaveBeenCalledWith('datafile', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
-      },
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'dataset.investigation.id': { eq: investigationId },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'datafile',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
+        },
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            'dataset.investigation.id': { eq: investigationId },
+          }),
+        },
+      ],
+      true
+    );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('datafile');
     expect(useRemoveFromCart).toHaveBeenCalledWith('datafile');
@@ -301,6 +305,20 @@ describe('Datafile table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('datafile', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith(
+      'datafile',
+      expect.anything(),
+      true
+    );
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders actions correctly', () => {

--- a/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
@@ -110,18 +110,22 @@ const DatafileTable = (props: DatafileTableProps): React.ReactElement => {
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
   const pushSort = usePushSort();
-  const { data: allIds } = useIds('datafile', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
-    },
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'dataset.investigation.id': { eq: investigationId },
-      }),
-    },
-  ]);
+  const { data: allIds } = useIds(
+    'datafile',
+    [
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
+      },
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'dataset.investigation.id': { eq: investigationId },
+        }),
+      },
+    ],
+    selectAllSetting
+  );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'datafile'
@@ -204,12 +208,13 @@ const DatafileTable = (props: DatafileTableProps): React.ReactElement => {
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'datafile' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   return (

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
@@ -145,14 +145,18 @@ describe('Dataset table component', () => {
     expect(useDatasetsDatafileCount).toHaveBeenCalledWith({
       pages: [rowData],
     });
-    expect(useIds).toHaveBeenCalledWith('dataset', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'investigation.id': { eq: parseInt(investigationId) },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'dataset',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            'investigation.id': { eq: parseInt(investigationId) },
+          }),
+        },
+      ],
+      true
+    );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('dataset');
     expect(useRemoveFromCart).toHaveBeenCalledWith('dataset');
@@ -301,6 +305,16 @@ describe('Dataset table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('dataset', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith('dataset', expect.anything(), true);
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders details panel correctly', () => {

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
@@ -101,14 +101,18 @@ const DatasetTable = (props: DatasetTableProps): React.ReactElement => {
   const dateFilter = useDateFilter(filters);
   const pushSort = usePushSort();
 
-  const { data: allIds } = useIds('dataset', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'investigation.id': { eq: parseInt(investigationId) },
-      }),
-    },
-  ]);
+  const { data: allIds } = useIds(
+    'dataset',
+    [
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'investigation.id': { eq: parseInt(investigationId) },
+        }),
+      },
+    ],
+    selectAllSetting
+  );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'dataset'
@@ -202,12 +206,13 @@ const DatasetTable = (props: DatasetTableProps): React.ReactElement => {
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'dataset' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   return (

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
@@ -140,18 +140,22 @@ describe('DLS datafiles table component', () => {
         }),
       },
     ]);
-    expect(useIds).toHaveBeenCalledWith('datafile', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
-      },
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'dataset.investigation.id': { eq: investigationId },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'datafile',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
+        },
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            'dataset.investigation.id': { eq: investigationId },
+          }),
+        },
+      ],
+      true
+    );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('datafile');
     expect(useRemoveFromCart).toHaveBeenCalledWith('datafile');
@@ -302,6 +306,20 @@ describe('DLS datafiles table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('datafile', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith(
+      'datafile',
+      expect.anything(),
+      true
+    );
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it("doesn't display download button for datafiles with no location", () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -53,18 +53,22 @@ const DLSDatafilesTable = (
   const dateFilter = useDateFilter(filters);
   const pushSort = usePushSort();
 
-  const { data: allIds } = useIds('datafile', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
-    },
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'dataset.investigation.id': { eq: investigationId },
-      }),
-    },
-  ]);
+  const { data: allIds } = useIds(
+    'datafile',
+    [
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
+      },
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'dataset.investigation.id': { eq: investigationId },
+        }),
+      },
+    ],
+    selectAllSetting
+  );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'datafile'
@@ -148,12 +152,13 @@ const DLSDatafilesTable = (
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'datafile' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   return (

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
@@ -144,14 +144,18 @@ describe('DLS Dataset table component', () => {
     expect(useDatasetsDatafileCount).toHaveBeenCalledWith({
       pages: [rowData],
     });
-    expect(useIds).toHaveBeenCalledWith('dataset', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'investigation.id': { eq: parseInt(investigationId) },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'dataset',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            'investigation.id': { eq: parseInt(investigationId) },
+          }),
+        },
+      ],
+      true
+    );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('dataset');
     expect(useRemoveFromCart).toHaveBeenCalledWith('dataset');
@@ -300,6 +304,16 @@ describe('DLS Dataset table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('dataset', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith('dataset', expect.anything(), true);
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders Dataset title as a link', () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -52,14 +52,18 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
   const dateFilter = useDateFilter(filters);
   const pushSort = usePushSort();
 
-  const { data: allIds } = useIds('dataset', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'investigation.id': { eq: parseInt(investigationId) },
-      }),
-    },
-  ]);
+  const { data: allIds } = useIds(
+    'dataset',
+    [
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'investigation.id': { eq: parseInt(investigationId) },
+        }),
+      },
+    ],
+    selectAllSetting
+  );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'dataset'
@@ -159,12 +163,13 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'dataset' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   return (

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
@@ -144,7 +144,7 @@ describe('Investigation table component', () => {
     expect(useInvestigationsDatasetCount).toHaveBeenCalledWith({
       pages: [rowData],
     });
-    expect(useIds).toHaveBeenCalledWith('investigation');
+    expect(useIds).toHaveBeenCalledWith('investigation', undefined, true);
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('investigation');
     expect(useRemoveFromCart).toHaveBeenCalledWith('investigation');
@@ -306,6 +306,16 @@ describe('Investigation table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('investigation', undefined, false);
+    expect(useIds).not.toHaveBeenCalledWith('investigation', undefined, true);
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders details panel correctly', () => {

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -118,7 +118,7 @@ const InvestigationTable = (): React.ReactElement => {
       }),
     },
   ]);
-  const { data: allIds } = useIds('investigation');
+  const { data: allIds } = useIds('investigation', undefined, selectAllSetting);
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'investigation'
@@ -128,22 +128,23 @@ const InvestigationTable = (): React.ReactElement => {
     isLoading: removeFromCartLoading,
   } = useRemoveFromCart('investigation');
 
+  const aggregatedData: Investigation[] = React.useMemo(
+    () => (data ? ('pages' in data ? data.pages.flat() : data) : []),
+    [data]
+  );
+
   const selectedRows = React.useMemo(
     () =>
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'investigation' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
-  );
-
-  const aggregatedData: Investigation[] = React.useMemo(
-    () => (data ? ('pages' in data ? data.pages.flat() : data) : []),
-    [data]
+    [cartItems, selectAllSetting, allIds]
   );
 
   const textFilter = useTextFilter(filters);

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-375"
+      className="makeStyles-root-409"
       container={true}
       direction="column"
     >
@@ -209,7 +209,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-376"
+          className="makeStyles-divider-410"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
@@ -214,7 +214,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-408"
+      className="makeStyles-root-445"
       container={true}
       direction="column"
     >
@@ -230,7 +230,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-409"
+          className="makeStyles-divider-446"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
@@ -140,18 +140,22 @@ describe('ISIS datafiles table component', () => {
         }),
       },
     ]);
-    expect(useIds).toHaveBeenCalledWith('datafile', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
-      },
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'dataset.investigation.id': { eq: investigationId },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'datafile',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
+        },
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            'dataset.investigation.id': { eq: investigationId },
+          }),
+        },
+      ],
+      true
+    );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('datafile');
     expect(useRemoveFromCart).toHaveBeenCalledWith('datafile');
@@ -300,6 +304,20 @@ describe('ISIS datafiles table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('datafile', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith(
+      'datafile',
+      expect.anything(),
+      true
+    );
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders actions correctly', () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -55,18 +55,22 @@ const ISISDatafilesTable = (
   const dateFilter = useDateFilter(filters);
   const pushSort = usePushSort();
 
-  const { data: allIds } = useIds('datafile', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
-    },
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'dataset.investigation.id': { eq: investigationId },
-      }),
-    },
-  ]);
+  const { data: allIds } = useIds(
+    'datafile',
+    [
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({ 'dataset.id': { eq: datasetId } }),
+      },
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'dataset.investigation.id': { eq: investigationId },
+        }),
+      },
+    ],
+    selectAllSetting
+  );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'datafile'
@@ -149,12 +153,13 @@ const ISISDatafilesTable = (
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'datafile' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   return (

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
@@ -149,14 +149,18 @@ describe('ISIS Dataset table component', () => {
     expect(useDatasetSizes).toHaveBeenCalledWith({
       pages: [rowData],
     });
-    expect(useIds).toHaveBeenCalledWith('dataset', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'investigation.id': { eq: parseInt(investigationId) },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'dataset',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            'investigation.id': { eq: parseInt(investigationId) },
+          }),
+        },
+      ],
+      true
+    );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('dataset');
     expect(useRemoveFromCart).toHaveBeenCalledWith('dataset');
@@ -305,6 +309,16 @@ describe('ISIS Dataset table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('dataset', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith('dataset', expect.anything(), true);
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders dataset name as a link', () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -69,14 +69,18 @@ const ISISDatasetsTable = (
   const dateFilter = useDateFilter(filters);
   const pushSort = usePushSort();
 
-  const { data: allIds } = useIds('dataset', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'investigation.id': { eq: parseInt(investigationId) },
-      }),
-    },
-  ]);
+  const { data: allIds } = useIds(
+    'dataset',
+    [
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'investigation.id': { eq: parseInt(investigationId) },
+        }),
+      },
+    ],
+    selectAllSetting
+  );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'dataset'
@@ -167,12 +171,13 @@ const ISISDatasetsTable = (
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'dataset' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   const detailsPanel = React.useCallback(

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -173,7 +173,8 @@ describe('ISIS Investigations table component', () => {
     expect(useISISInvestigationIds).toHaveBeenCalledWith(
       parseInt(instrumentId),
       parseInt(instrumentChildId),
-      studyHierarchy
+      studyHierarchy,
+      true
     );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('investigation');
@@ -336,6 +337,16 @@ describe('ISIS Investigations table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useISISInvestigationIds).toHaveBeenCalledWith(4, 5, false, false);
+    expect(useISISInvestigationIds).not.toHaveBeenCalledWith(4, 5, false, true);
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders details panel correctly and it fetches data and can navigate', () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -69,7 +69,8 @@ const ISISInvestigationsTable = (
   const { data: allIds } = useISISInvestigationIds(
     parseInt(instrumentId),
     parseInt(instrumentChildId),
-    studyHierarchy
+    studyHierarchy,
+    selectAllSetting
   );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
@@ -85,12 +86,13 @@ const ISISInvestigationsTable = (
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'investigation' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   const aggregatedData: Investigation[] = React.useMemo(

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
@@ -214,14 +214,18 @@ describe('ISIS MyData table component', () => {
     expect(useInvestigationSizes).toHaveBeenCalledWith({
       pages: [rowData],
     });
-    expect(useIds).toHaveBeenCalledWith('investigation', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'investigationUsers.user.name': { eq: 'testUser' },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'investigation',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            'investigationUsers.user.name': { eq: 'testUser' },
+          }),
+        },
+      ],
+      true
+    );
     expect(useCart).toHaveBeenCalled();
     expect(useAddToCart).toHaveBeenCalledWith('investigation');
     expect(useRemoveFromCart).toHaveBeenCalledWith('investigation');
@@ -381,6 +385,24 @@ describe('ISIS MyData table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgdataview.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith(
+      'investigation',
+      expect.anything(),
+      false
+    );
+    expect(useIds).not.toHaveBeenCalledWith(
+      'investigation',
+      expect.anything(),
+      true
+    );
+    expect(wrapper.exists('[aria-label="select all rows"]')).toBe(false);
   });
 
   it('renders details panel correctly and it fetches data and can navigate', () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -78,14 +78,18 @@ const ISISMyDataTable = (): React.ReactElement => {
       ]),
     },
   ]);
-  const { data: allIds } = useIds('investigation', [
-    {
-      filterType: 'where',
-      filterValue: JSON.stringify({
-        'investigationUsers.user.name': { eq: username },
-      }),
-    },
-  ]);
+  const { data: allIds } = useIds(
+    'investigation',
+    [
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'investigationUsers.user.name': { eq: username },
+        }),
+      },
+    ],
+    selectAllSetting
+  );
   const { data: cartItems } = useCart();
   const { mutate: addToCart, isLoading: addToCartLoading } = useAddToCart(
     'investigation'
@@ -101,12 +105,13 @@ const ISISMyDataTable = (): React.ReactElement => {
       cartItems
         ?.filter(
           (cartItem) =>
-            allIds &&
             cartItem.entityType === 'investigation' &&
-            allIds.includes(cartItem.entityId)
+            // if select all is disabled, it's safe to just pass the whole cart as selectedRows
+            (!selectAllSetting ||
+              (allIds && allIds.includes(cartItem.entityId)))
         )
         .map((cartItem) => cartItem.entityId),
-    [cartItems, allIds]
+    [cartItems, selectAllSetting, allIds]
   );
 
   const aggregatedData: Investigation[] = React.useMemo(

--- a/packages/datagateway-search/public/datagateway-search-settings.example.json
+++ b/packages/datagateway-search/public/datagateway-search-settings.example.json
@@ -4,11 +4,11 @@
   "apiUrl": "example.api.url",
   "downloadApiUrl": "example.download.api.url",
   "icatUrl": "example.icat.url",
+  "selectAllSetting": true,
   "helpSteps": [
     {
       "target": "#plugin-link--search-data",
-      "content":
-        "DataGateway Search allows you to search for specific datasets, datafiles or investigations using date and text filters"
+      "content": "DataGateway Search allows you to search for specific datasets, datafiles or investigations using date and text filters"
     },
     {
       "target": ".tour-search-textfield",

--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
@@ -1272,6 +1272,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       },
                       "currentResultOptions": Object {
                         "_defaulted": true,
+                        "enabled": true,
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
@@ -1308,6 +1309,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       ],
                       "options": Object {
                         "_defaulted": true,
+                        "enabled": true,
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
@@ -1336,6 +1338,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                   ],
                   "options": Object {
                     "_defaulted": true,
+                    "enabled": true,
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
@@ -2287,6 +2290,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       },
                       "currentResultOptions": Object {
                         "_defaulted": true,
+                        "enabled": true,
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
@@ -2323,6 +2327,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       ],
                       "options": Object {
                         "_defaulted": true,
+                        "enabled": true,
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
@@ -2351,6 +2356,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                   ],
                   "options": Object {
                     "_defaulted": true,
+                    "enabled": true,
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
@@ -4018,6 +4024,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                   }
                                   data={Array []}
                                   detailsPanel={[Function]}
+                                  disableSelectAll={false}
                                   loadMoreRows={[Function]}
                                   loading={false}
                                   onCheck={[Function]}

--- a/packages/datagateway-search/src/card/datasetSearchCardView.component.test.tsx
+++ b/packages/datagateway-search/src/card/datasetSearchCardView.component.test.tsx
@@ -304,7 +304,7 @@ describe('Dataset - Card View', () => {
     ).toEqual('Calculating...');
   });
 
-  it('renders DLS link correctly', () => {
+  it("renders DLS link correctly and doesn't allow for download", () => {
     const wrapper = createWrapper('dls');
 
     expect(wrapper.find(CardView).find('a').first().prop('href')).toEqual(
@@ -313,6 +313,8 @@ describe('Dataset - Card View', () => {
     expect(wrapper.find(CardView).find('a').first().text()).toEqual(
       'Dataset test name'
     );
+    expect(wrapper.exists('#add-to-cart-btn-1')).toBe(true);
+    expect(wrapper.exists('#download-btn-1')).toBe(false);
   });
 
   it('renders ISIS link & file sizes correctly', () => {

--- a/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
@@ -277,23 +277,35 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
   const classes = useStyles();
 
   const buttons = React.useMemo(
-    () => [
-      (dataset: Dataset) => (
-        <div className={classes.actionButtons}>
-          <AddToCartButton
-            entityType="dataset"
-            allIds={data?.map((dataset) => dataset.id) ?? []}
-            entityId={dataset.id}
-          />
-          <DownloadButton
-            entityType="dataset"
-            entityId={dataset.id}
-            entityName={dataset.name}
-          />
-        </div>
-      ),
-    ],
-    [classes.actionButtons, data]
+    () =>
+      hierarchy !== 'dls'
+        ? [
+            (dataset: Dataset) => (
+              <div className={classes.actionButtons}>
+                <AddToCartButton
+                  entityType="dataset"
+                  allIds={data?.map((dataset) => dataset.id) ?? []}
+                  entityId={dataset.id}
+                />
+                <DownloadButton
+                  entityType="dataset"
+                  entityId={dataset.id}
+                  entityName={dataset.name}
+                />
+              </div>
+            ),
+          ]
+        : [
+            (dataset: Dataset) => (
+              <AddToCartButton
+                entityType="dataset"
+                allIds={data?.map((dataset) => dataset.id) ?? []}
+                entityId={dataset.id}
+              />
+            ),
+          ],
+
+    [classes.actionButtons, data, hierarchy]
   );
 
   return (

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
@@ -297,13 +297,15 @@ describe('Investigation - Card View', () => {
     ).toEqual('Calculating...');
   });
 
-  it('renders DLS link correctly', () => {
+  it("renders DLS link correctly and doesn't allow for cart selection or download", () => {
     const wrapper = createWrapper('dls');
 
     expect(wrapper.find(CardView).find('a').first().prop('href')).toEqual(
       '/browse/proposal/Investigation test name/investigation/1/dataset'
     );
     expect(wrapper.find(CardView).find('a').first().text()).toEqual('Test 1');
+    expect(wrapper.exists('#add-to-cart-btn-1')).toBe(false);
+    expect(wrapper.exists('#download-btn-1')).toBe(false);
   });
 
   it('renders ISIS link & file sizes correctly', () => {

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
@@ -314,23 +314,26 @@ const InvestigationCardView = (
   const classes = useStyles();
 
   const buttons = React.useMemo(
-    () => [
-      (investigation: Investigation) => (
-        <div className={classes.actionButtons}>
-          <AddToCartButton
-            entityType="investigation"
-            allIds={data?.map((investigation) => investigation.id) ?? []}
-            entityId={investigation.id}
-          />
-          <DownloadButton
-            entityType="investigation"
-            entityId={investigation.id}
-            entityName={investigation.name}
-          />
-        </div>
-      ),
-    ],
-    [classes.actionButtons, data]
+    () =>
+      hierarchy !== 'dls'
+        ? [
+            (investigation: Investigation) => (
+              <div className={classes.actionButtons}>
+                <AddToCartButton
+                  entityType="investigation"
+                  allIds={data?.map((investigation) => investigation.id) ?? []}
+                  entityId={investigation.id}
+                />
+                <DownloadButton
+                  entityType="investigation"
+                  entityId={investigation.id}
+                  entityName={investigation.name}
+                />
+              </div>
+            ),
+          ]
+        : [],
+    [classes.actionButtons, data, hierarchy]
   );
 
   const customFilters = React.useMemo(

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -1,5 +1,8 @@
-import { configureApp, settingsLoaded } from '.';
-import { SettingsLoadedType } from './actions.types';
+import { configureApp, loadSelectAllSetting, settingsLoaded } from '.';
+import {
+  ConfigureSelectAllSettingType,
+  SettingsLoadedType,
+} from './actions.types';
 import axios from 'axios';
 import * as log from 'loglevel';
 import { actions, resetActions, dispatch, getState } from '../../setupTests';
@@ -32,6 +35,14 @@ describe('Actions', () => {
     expect(action.type).toEqual(SettingsLoadedType);
   });
 
+  it('given JSON loadSelectAllSetting returns a ConfigureSelectAllSettingType with ConfigureSelectAllSettingPayload', () => {
+    const action = loadSelectAllSetting(false);
+    expect(action.type).toEqual(ConfigureSelectAllSettingType);
+    expect(action.payload).toEqual({
+      settings: false,
+    });
+  });
+
   it('settings are loaded and facilityName, loadUrls and settingsLoaded actions are sent', async () => {
     (axios.get as jest.Mock)
       .mockImplementationOnce(() =>
@@ -42,6 +53,7 @@ describe('Actions', () => {
             apiUrl: 'api',
             downloadApiUrl: 'download-api',
             icatUrl: 'icat',
+            selectAllSetting: false,
             routes: [
               {
                 section: 'section',
@@ -64,7 +76,7 @@ describe('Actions', () => {
     const asyncAction = configureApp();
     await asyncAction(dispatch, getState);
 
-    expect(actions.length).toEqual(3);
+    expect(actions.length).toEqual(4);
     expect(actions).toContainEqual(loadFacilityName('Generic'));
     expect(actions).toContainEqual(
       loadUrls({
@@ -74,6 +86,7 @@ describe('Actions', () => {
         icatUrl: 'icat',
       })
     );
+    expect(actions).toContainEqual(loadSelectAllSetting(false));
 
     expect(actions).toContainEqual(settingsLoaded());
     expect(CustomEvent).toHaveBeenCalledTimes(1);
@@ -104,6 +117,7 @@ describe('Actions', () => {
             idsUrl: 'ids',
             apiUrl: 'api',
             downloadApiUrl: 'download-api',
+            selectAllSetting: false,
             routes: [
               {
                 section: 'section0',
@@ -175,6 +189,7 @@ describe('Actions', () => {
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
           icatUrl: 'icat',
+          selectAllSetting: true,
         },
       })
     );

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -91,7 +91,7 @@ describe('Actions', () => {
     const asyncAction = configureApp();
     await asyncAction(dispatch, getState);
 
-    expect(actions.length).toEqual(4);
+    expect(actions.length).toEqual(5);
     expect(actions).toContainEqual(loadFacilityName('Generic'));
     expect(actions).toContainEqual(
       loadUrls({
@@ -102,11 +102,12 @@ describe('Actions', () => {
       })
     );
     expect(actions).toContainEqual(loadSelectAllSetting(false));
-
-    expect(actions).toContainEqual(settingsLoaded());
     expect(actions).toContainEqual(
       loadSearchableEntitites(['investigation', 'dataset', 'datafile'])
     );
+
+    expect(actions).toContainEqual(settingsLoaded());
+
     expect(CustomEvent).toHaveBeenCalledTimes(1);
     expect(CustomEvent).toHaveBeenLastCalledWith(MicroFrontendId, {
       detail: {

--- a/packages/datagateway-search/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.types.tsx
@@ -4,6 +4,8 @@ export const SetInvestigationTabType =
   'datagateway_search:set_investigation_tab';
 export const SetCurrentTabType = 'datagateway_search:set_current_tab';
 export const SettingsLoadedType = 'datagateway_search:settings_loaded';
+export const ConfigureSelectAllSettingType =
+  'datagateway_search:configure_select_all';
 
 export interface TogglePayload {
   toggleOption: boolean;
@@ -11,4 +13,8 @@ export interface TogglePayload {
 
 export interface CurrentTabPayload {
   currentTab: string;
+}
+
+export interface ConfigureSelectAllSettingPayload {
+  settings: boolean;
 }

--- a/packages/datagateway-search/src/state/actions/index.tsx
+++ b/packages/datagateway-search/src/state/actions/index.tsx
@@ -1,5 +1,9 @@
-import { ThunkResult } from '../app.types';
-import { SettingsLoadedType } from './actions.types';
+import { ActionType, ThunkResult } from '../app.types';
+import {
+  ConfigureSelectAllSettingPayload,
+  ConfigureSelectAllSettingType,
+  SettingsLoadedType,
+} from './actions.types';
 import {
   loadUrls,
   loadFacilityName,
@@ -16,6 +20,15 @@ import jsrsasign from 'jsrsasign';
 
 export const settingsLoaded = (): Action => ({
   type: SettingsLoadedType,
+});
+
+export const loadSelectAllSetting = (
+  selectAllSetting: boolean
+): ActionType<ConfigureSelectAllSettingPayload> => ({
+  type: ConfigureSelectAllSettingType,
+  payload: {
+    settings: selectAllSetting,
+  },
 });
 
 export const configureApp = (): ThunkResult<Promise<void>> => {
@@ -58,6 +71,10 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
           throw new Error(
             'One of the URL options (idsUrl, apiUrl, downloadApiUrl, icatUrl) is undefined in settings'
           );
+        }
+
+        if ('selectAllSetting' in settings) {
+          dispatch(loadSelectAllSetting(settings['selectAllSetting']));
         }
 
         if (Array.isArray(settings['routes']) && settings['routes'].length) {

--- a/packages/datagateway-search/src/state/app.types.tsx
+++ b/packages/datagateway-search/src/state/app.types.tsx
@@ -9,6 +9,7 @@ export interface DGSearchState {
     investigationTab: boolean;
     currentTab: string;
   };
+  selectAllSetting: boolean;
   settingsLoaded: boolean;
   sideLayout: boolean;
 }

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
@@ -6,7 +6,7 @@ import {
   setInvestigationTab,
   setCurrentTab,
 } from '../actions/actions';
-import { settingsLoaded } from '../actions';
+import { loadSelectAllSetting, settingsLoaded } from '../actions';
 
 describe('dgsearch reducer', () => {
   let state: DGSearchState;
@@ -59,5 +59,13 @@ describe('dgsearch reducer', () => {
     const updatedState = DGSearchReducer(state, setCurrentTab('dataset'));
 
     expect(updatedState.tabs.currentTab).toEqual('dataset');
+  });
+
+  it('should set selectAllSetting when configuring action is sent', () => {
+    expect(state.selectAllSetting).toEqual(true);
+
+    const updatedState = DGSearchReducer(state, loadSelectAllSetting(false));
+
+    expect(updatedState.selectAllSetting).toEqual(false);
   });
 });

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
@@ -8,6 +8,8 @@ import {
   SettingsLoadedType,
   CurrentTabPayload,
   SetCurrentTabType,
+  ConfigureSelectAllSettingType,
+  ConfigureSelectAllSettingPayload,
 } from '../actions/actions.types';
 
 export const initialState: DGSearchState = {
@@ -17,6 +19,7 @@ export const initialState: DGSearchState = {
     investigationTab: false,
     currentTab: 'investigation',
   },
+  selectAllSetting: true,
   settingsLoaded: false,
   sideLayout: false,
 };
@@ -80,12 +83,23 @@ export function handleSetCurrentTab(
   };
 }
 
+export function handleConfigureSelectAllSetting(
+  state: DGSearchState,
+  payload: ConfigureSelectAllSettingPayload
+): DGSearchState {
+  return {
+    ...state,
+    selectAllSetting: payload.settings,
+  };
+}
+
 const DGSearchReducer = createReducer(initialState, {
   [SetDatasetTabType]: handleSetDatasetTab,
   [SetDatafileTabType]: handleSetDatafileTab,
   [SetInvestigationTabType]: handleSetInvestigationTab,
   [SettingsLoadedType]: handleSettingsLoaded,
   [SetCurrentTabType]: handleSetCurrentTab,
+  [ConfigureSelectAllSettingType]: handleConfigureSelectAllSetting,
 });
 
 export default DGSearchReducer;

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -105,6 +105,7 @@ Object {
     },
   ],
   "detailsPanel": [Function],
+  "disableSelectAll": false,
   "loadMoreRows": [Function],
   "loading": false,
   "onCheck": [MockFunction],
@@ -118,7 +119,7 @@ Object {
 
 exports[`Datafile search table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-253"
+  className="makeStyles-root-281"
   container={true}
   direction="column"
   id="details-panel"
@@ -135,7 +136,7 @@ exports[`Datafile search table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-254"
+      className="makeStyles-divider-282"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
@@ -251,6 +251,7 @@ Object {
     },
   ],
   "detailsPanel": [Function],
+  "disableSelectAll": false,
   "loadMoreRows": [Function],
   "loading": false,
   "onCheck": [MockFunction],
@@ -264,7 +265,7 @@ Object {
 
 exports[`Dataset table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-253"
+  className="makeStyles-root-281"
   container={true}
   direction="column"
   id="details-panel"
@@ -281,7 +282,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-254"
+      className="makeStyles-divider-282"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
@@ -107,6 +107,7 @@ Object {
     },
   ],
   "detailsPanel": [Function],
+  "disableSelectAll": false,
   "loadMoreRows": [Function],
   "loading": false,
   "onCheck": [MockFunction],
@@ -120,7 +121,7 @@ Object {
 
 exports[`Investigation Search Table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-371"
+  className="makeStyles-root-408"
   container={true}
   direction="column"
   id="details-panel"
@@ -137,7 +138,7 @@ exports[`Investigation Search Table component renders details panel correctly 1`
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-372"
+      className="makeStyles-divider-409"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -217,14 +217,18 @@ describe('Datafile search table component', () => {
         }),
       },
     ]);
-    expect(useIds).toHaveBeenCalledWith('datafile', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          id: { in: [1] },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'datafile',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            id: { in: [1] },
+          }),
+        },
+      ],
+      true
+    );
 
     expect(useAddToCart).toHaveBeenCalledWith('datafile');
     expect(useRemoveFromCart).toHaveBeenCalledWith('datafile');
@@ -373,6 +377,20 @@ describe('Datafile search table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgsearch.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('datafile', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith(
+      'datafile',
+      expect.anything(),
+      true
+    );
+    expect(wrapper.find('[aria-label="select all rows"]')).toHaveLength(0);
   });
 
   it('renders details panel correctly', () => {

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -229,14 +229,18 @@ describe('Dataset table component', () => {
         }),
       },
     ]);
-    expect(useIds).toHaveBeenCalledWith('dataset', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          id: { in: [1] },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'dataset',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            id: { in: [1] },
+          }),
+        },
+      ],
+      true
+    );
 
     expect(useAddToCart).toHaveBeenCalledWith('dataset');
     expect(useRemoveFromCart).toHaveBeenCalledWith('dataset');
@@ -387,6 +391,16 @@ describe('Dataset table component', () => {
 
     expect(selectAllCheckbox.prop('checked')).toEqual(false);
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
+  });
+
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgsearch.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith('dataset', expect.anything(), false);
+    expect(useIds).not.toHaveBeenCalledWith('dataset', expect.anything(), true);
+    expect(wrapper.find('[aria-label="select all rows"]')).toHaveLength(0);
   });
 
   it('renders details panel correctly', () => {

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
@@ -236,14 +236,18 @@ describe('Investigation Search Table component', () => {
         }),
       },
     ]);
-    expect(useIds).toHaveBeenCalledWith('investigation', [
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          id: { in: [1] },
-        }),
-      },
-    ]);
+    expect(useIds).toHaveBeenCalledWith(
+      'investigation',
+      [
+        {
+          filterType: 'where',
+          filterValue: JSON.stringify({
+            id: { in: [1] },
+          }),
+        },
+      ],
+      true
+    );
 
     expect(useAddToCart).toHaveBeenCalledWith('investigation');
     expect(useRemoveFromCart).toHaveBeenCalledWith('investigation');
@@ -409,6 +413,24 @@ describe('Investigation Search Table component', () => {
     expect(selectAllCheckbox.prop('data-indeterminate')).toEqual(false);
   });
 
+  it('no select all checkbox appears and no fetchAllIds sent if selectAllSetting is false', () => {
+    state.dgsearch.selectAllSetting = false;
+
+    const wrapper = createWrapper();
+
+    expect(useIds).toHaveBeenCalledWith(
+      'investigation',
+      expect.anything(),
+      false
+    );
+    expect(useIds).not.toHaveBeenCalledWith(
+      'investigation',
+      expect.anything(),
+      true
+    );
+    expect(wrapper.find('[aria-label="select all rows"]')).toHaveLength(0);
+  });
+
   it('renders details panel correctly', () => {
     const wrapper = shallow(
       <InvestigationDetailsPanel
@@ -477,13 +499,14 @@ describe('Investigation Search Table component', () => {
     expect(wrapper.find('[aria-colindex=7]').text()).toEqual('Calculating...');
   });
 
-  it('renders DLS link correctly', () => {
+  it("renders DLS link correctly and doesn't allow for cart selection", () => {
     const wrapper = createWrapper('dls');
 
-    expect(wrapper.find('[aria-colindex=3]').find('a').prop('href')).toEqual(
+    expect(wrapper.find('[aria-colindex=2]').find('a').prop('href')).toEqual(
       '/browse/proposal/Test 1/investigation/1/dataset'
     );
-    expect(wrapper.find('[aria-colindex=3]').text()).toEqual('Test 1');
+    expect(wrapper.find('[aria-colindex=2]').text()).toEqual('Test 1');
+    expect(wrapper.find('[aria-label="select row 0"]')).toHaveLength(0);
   });
 
   it('renders ISIS link & file sizes correctly', () => {


### PR DESCRIPTION
## Description

We now no longer send `allId` requests if `selectAll` has been disabled via `selectAllSetting`. This improves performance. Additionally, I had to add `selectAllSetting` to `datagateway-search`, and I also did some further modifications to search to ensure DLS views don't have investigation download avaialble nor direct download.

## Testing instructions
- [x] Review code
- [ ] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #914 
