### PR TITLE
Replace resizable icons with lines between columns in tables (#929)

### DIFF
--- a/packages/datagateway-common/src/table/cellRenderers/__snapshots__/dataCell.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/cellRenderers/__snapshots__/dataCell.component.test.tsx.snap
@@ -14,6 +14,11 @@ exports[`Data cell component renders correctly 1`] = `
 >
   <ArrowTooltip
     enterDelay={500}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
     title="non nested property"
   >
     <WithStyles(ForwardRef(Typography))
@@ -23,6 +28,26 @@ exports[`Data cell component renders correctly 1`] = `
       non nested property
     </WithStyles(ForwardRef(Typography))>
   </ArrowTooltip>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "marginLeft": 18,
+        "paddingLeft": "4px",
+        "paddingRight": "4px",
+      }
+    }
+  >
+    <WithStyles(ForwardRef(Divider))
+      flexItem={true}
+      orientation="vertical"
+      style={
+        Object {
+          "height": "100%",
+        }
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -40,6 +65,11 @@ exports[`Data cell component renders nested cell data correctly 1`] = `
 >
   <ArrowTooltip
     enterDelay={500}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
     title="nested property"
   >
     <WithStyles(ForwardRef(Typography))
@@ -49,6 +79,26 @@ exports[`Data cell component renders nested cell data correctly 1`] = `
       nested property
     </WithStyles(ForwardRef(Typography))>
   </ArrowTooltip>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "marginLeft": 18,
+        "paddingLeft": "4px",
+        "paddingRight": "4px",
+      }
+    }
+  >
+    <WithStyles(ForwardRef(Divider))
+      flexItem={true}
+      orientation="vertical"
+      style={
+        Object {
+          "height": "100%",
+        }
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -66,6 +116,11 @@ exports[`Data cell component renders provided cell data correctly 1`] = `
 >
   <ArrowTooltip
     enterDelay={500}
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
     title="provided test"
   >
     <WithStyles(ForwardRef(Typography))
@@ -77,5 +132,25 @@ exports[`Data cell component renders provided cell data correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
   </ArrowTooltip>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "marginLeft": 18,
+        "paddingLeft": "4px",
+        "paddingRight": "4px",
+      }
+    }
+  >
+    <WithStyles(ForwardRef(Divider))
+      flexItem={true}
+      orientation="vertical"
+      style={
+        Object {
+          "height": "100%",
+        }
+      }
+    />
+  </div>
 </div>
 `;

--- a/packages/datagateway-common/src/table/cellRenderers/dataCell.component.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/dataCell.component.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { TableCellProps, TableCellRenderer } from 'react-virtualized';
-import { TableCell, Typography, useMediaQuery } from '@material-ui/core';
+import {
+  Divider,
+  TableCell,
+  Typography,
+  useMediaQuery,
+} from '@material-ui/core';
 import ArrowTooltip, { getTooltipText } from '../../arrowtooltip.component';
 
 type CellRendererProps = TableCellProps & {
@@ -29,11 +34,31 @@ const DataCell = React.memo(
         variant="body"
         style={smWindow ? { paddingLeft: 8, paddingRight: 8 } : {}}
       >
-        <ArrowTooltip title={getTooltipText(cellContent)} enterDelay={500}>
+        <ArrowTooltip
+          title={getTooltipText(cellContent)}
+          enterDelay={500}
+          style={{ flex: 1 }}
+        >
           <Typography variant="body2" noWrap>
             {cellContent}
           </Typography>
         </ArrowTooltip>
+        <div
+          style={{
+            marginLeft: 18,
+            paddingLeft: '4px',
+            paddingRight: '4px',
+            height: '100%',
+          }}
+        >
+          <Divider
+            orientation="vertical"
+            flexItem
+            style={{
+              height: '100%',
+            }}
+          />
+        </div>
       </TableCell>
     );
   }

--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -74,14 +74,26 @@ exports[`Data column header component renders correctly with filter but no sort 
     scale={1}
     transform={null}
   >
-    <Memo(ForwardRef(DragIndicatorIcon))
-      fontSize="small"
+    <div
       style={
         Object {
           "cursor": "col-resize",
+          "marginLeft": 18,
+          "paddingLeft": "4px",
+          "paddingRight": "4px",
         }
       }
-    />
+    >
+      <WithStyles(ForwardRef(Divider))
+        flexItem={true}
+        orientation="vertical"
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
+      />
+    </div>
   </Draggable>
 </div>
 `;
@@ -166,14 +178,26 @@ exports[`Data column header component renders correctly with sort and filter 1`]
     scale={1}
     transform={null}
   >
-    <Memo(ForwardRef(DragIndicatorIcon))
-      fontSize="small"
+    <div
       style={
         Object {
           "cursor": "col-resize",
+          "marginLeft": 18,
+          "paddingLeft": "4px",
+          "paddingRight": "4px",
         }
       }
-    />
+    >
+      <WithStyles(ForwardRef(Divider))
+        flexItem={true}
+        orientation="vertical"
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
+      />
+    </div>
   </Draggable>
 </div>
 `;
@@ -254,14 +278,26 @@ exports[`Data column header component renders correctly with sort but no filter 
     scale={1}
     transform={null}
   >
-    <Memo(ForwardRef(DragIndicatorIcon))
-      fontSize="small"
+    <div
       style={
         Object {
           "cursor": "col-resize",
+          "marginLeft": 18,
+          "paddingLeft": "4px",
+          "paddingRight": "4px",
         }
       }
-    />
+    >
+      <WithStyles(ForwardRef(Divider))
+        flexItem={true}
+        orientation="vertical"
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
+      />
+    </div>
   </Draggable>
 </div>
 `;
@@ -336,14 +372,26 @@ exports[`Data column header component renders correctly without sort or filter 1
     scale={1}
     transform={null}
   >
-    <Memo(ForwardRef(DragIndicatorIcon))
-      fontSize="small"
+    <div
       style={
         Object {
           "cursor": "col-resize",
+          "marginLeft": 18,
+          "paddingLeft": "4px",
+          "paddingRight": "4px",
         }
       }
-    />
+    >
+      <WithStyles(ForwardRef(Divider))
+        flexItem={true}
+        orientation="vertical"
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
+      />
+    </div>
   </Draggable>
 </div>
 `;

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -7,8 +7,8 @@ import {
   Box,
   Typography,
   useMediaQuery,
+  Divider,
 } from '@material-ui/core';
-import { DragIndicator } from '@material-ui/icons';
 import Draggable from 'react-draggable';
 
 const DataHeader = React.memo(
@@ -100,12 +100,22 @@ const DataHeader = React.memo(
             window.dispatchEvent(event);
           }}
         >
-          <DragIndicator
-            fontSize="small"
+          <div
             style={{
+              marginLeft: 18,
+              paddingLeft: '4px',
+              paddingRight: '4px',
               cursor: 'col-resize',
             }}
-          />
+          >
+            <Divider
+              orientation="vertical"
+              flexItem
+              style={{
+                height: '100%',
+              }}
+            />
+          </div>
         </Draggable>
       </TableCell>
     );

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -62,11 +62,13 @@ const styles = (theme: Theme): StyleRules =>
       flex: 1,
       overflow: 'hidden',
       height: rowHeight,
+      padding: 0,
     },
     headerTableCell: {
       flex: 1,
       height: headerHeight,
       justifyContent: 'space-between',
+      padding: 0,
     },
   });
 


### PR DESCRIPTION
## Description
Adds lines between the columns in tables and changes the draggable icon for resizing columns to the dividers in the headers.
![image](https://user-images.githubusercontent.com/90245114/142235247-4be74d21-f117-4912-9f96-72ff7c9dde73.png)


## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #929
