### PR TITLE
Default sorting in table and card views #931

### DIFF
--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -8,7 +8,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useUpdateView,
 } from './index';
 import {
@@ -303,17 +303,31 @@ describe('generic api functions', () => {
       jest.resetModules();
     });
 
-    describe('usePushSort', () => {
-      it('returns callback that when called pushes a new sort to the url query', () => {
-        const { result } = renderHook(() => usePushSort(), {
+    describe('useSort', () => {
+      it('returns callback that can push a new sort to the url query', () => {
+        const { result } = renderHook(() => useSort(), {
           wrapper,
         });
 
         act(() => {
-          result.current('name', 'asc');
+          result.current('name', 'asc', 'push');
         });
 
         expect(pushSpy).toHaveBeenCalledWith({
+          search: `?sort=${encodeURIComponent('{"name":"asc"}')}`,
+        });
+      });
+
+      it('returns callback that can replace the sort with a new one in the url query', () => {
+        const { result } = renderHook(() => useSort(), {
+          wrapper,
+        });
+
+        act(() => {
+          result.current('name', 'asc', 'replace');
+        });
+
+        expect(replaceSpy).toHaveBeenCalledWith({
           search: `?sort=${encodeURIComponent('{"name":"asc"}')}`,
         });
       });
@@ -326,12 +340,12 @@ describe('generic api functions', () => {
           ),
         }));
 
-        const { result } = renderHook(() => usePushSort(), {
+        const { result } = renderHook(() => useSort(), {
           wrapper,
         });
 
         act(() => {
-          result.current('name', null);
+          result.current('name', null, 'push');
         });
 
         expect(pushSpy).toHaveBeenCalledWith({
@@ -409,7 +423,7 @@ describe('generic api functions', () => {
     });
 
     describe('useUpdateView', () => {
-      it('returns callback that when called pushes a new page to the url query', () => {
+      it('returns callback that when called pushes a new view to the url query', () => {
         const { result } = renderHook(() => useUpdateView('push'), {
           wrapper,
         });
@@ -421,7 +435,7 @@ describe('generic api functions', () => {
         expect(pushSpy).toHaveBeenCalledWith('?view=table');
       });
 
-      it('returns callback that when called replaces the current page with a new one in the url query', () => {
+      it('returns callback that when called replaces the current view with a new one in the url query', () => {
         const { result } = renderHook(() => useUpdateView('replace'), {
           wrapper,
         });

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -10,6 +10,7 @@ import {
   QueryParams,
   ViewsType,
   Entity,
+  UpdateMethod,
 } from '../app.types';
 import {
   useQueries,
@@ -243,13 +244,19 @@ export const getApiParams = (props: {
   return searchParams;
 };
 
-export const usePushSort = (): ((
+export const useSort = (): ((
   sortKey: string,
-  order: Order | null
+  order: Order | null,
+  updateMethod: UpdateMethod
 ) => void) => {
-  const { push } = useHistory();
+  const { push, replace } = useHistory();
+
   return React.useCallback(
-    (sortKey: string, order: Order | null): void => {
+    (
+      sortKey: string,
+      order: Order | null,
+      updateMethod: UpdateMethod
+    ): void => {
       let query = parseSearchToQuery(window.location.search);
       if (order !== null) {
         query = {
@@ -269,9 +276,11 @@ export const usePushSort = (): ((
           },
         };
       }
-      push({ search: `?${parseQueryToSearch(query).toString()}` });
+      (updateMethod === 'push' ? push : replace)({
+        search: `?${parseQueryToSearch(query).toString()}`,
+      });
     },
-    [push]
+    [push, replace]
   );
 };
 
@@ -339,7 +348,7 @@ export const usePushResults = (): ((results: number) => void) => {
 };
 
 export const useUpdateView = (
-  updateMethod: 'push' | 'replace'
+  updateMethod: UpdateMethod
 ): ((view: ViewsType) => void) => {
   const { push, replace } = useHistory();
   const functionToUse = updateMethod === 'push' ? push : replace;

--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -276,6 +276,7 @@ export interface TextFilter {
 export type Filter = string[] | TextFilter | DateFilter;
 
 export type Order = 'asc' | 'desc';
+
 export type UpdateMethod = 'push' | 'replace';
 
 export interface FiltersType {

--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -276,6 +276,7 @@ export interface TextFilter {
 export type Filter = string[] | TextFilter | DateFilter;
 
 export type Order = 'asc' | 'desc';
+export type UpdateMethod = 'push' | 'replace';
 
 export interface FiltersType {
   [column: string]: Filter;

--- a/packages/datagateway-common/src/card/cardView.component.test.tsx
+++ b/packages/datagateway-common/src/card/cardView.component.test.tsx
@@ -284,7 +284,7 @@ describe('Card View', () => {
 
     // Click to sort ascending
     button.simulate('click');
-    expect(onSort).toHaveBeenNthCalledWith(1, 'title', 'asc');
+    expect(onSort).toHaveBeenNthCalledWith(1, 'title', 'asc', 'push');
     updatedProps = {
       ...updatedProps,
       sort: { title: 'asc' },
@@ -293,7 +293,7 @@ describe('Card View', () => {
 
     // Click to sort descending
     button.simulate('click');
-    expect(onSort).toHaveBeenNthCalledWith(2, 'title', 'desc');
+    expect(onSort).toHaveBeenNthCalledWith(2, 'title', 'desc', 'push');
     updatedProps = {
       ...updatedProps,
       sort: { title: 'desc' },
@@ -302,7 +302,29 @@ describe('Card View', () => {
 
     // Click to clear sorting
     button.simulate('click');
-    expect(onSort).toHaveBeenNthCalledWith(3, 'title', null);
+    expect(onSort).toHaveBeenNthCalledWith(3, 'title', null, 'push');
+  });
+
+  it('default sort applied correctly', () => {
+    const updatedProps: CardViewProps = {
+      ...props,
+      title: { ...props.title, defaultSort: 'asc' },
+      description: { dataKey: 'name', label: 'Name', defaultSort: 'desc' },
+      information: [
+        { dataKey: 'visitId' },
+        {
+          dataKey: 'test',
+          label: 'Name',
+          defaultSort: 'asc',
+        },
+      ],
+    };
+    const wrapper = createWrapper(updatedProps);
+    wrapper.update();
+
+    expect(onSort).toHaveBeenCalledWith('title', 'asc', 'replace');
+    expect(onSort).toHaveBeenCalledWith('name', 'desc', 'replace');
+    expect(onSort).toHaveBeenCalledWith('test', 'asc', 'replace');
   });
 
   it('can sort by description with label', () => {
@@ -318,7 +340,7 @@ describe('Card View', () => {
 
     // Click to sort ascending
     button.simulate('click');
-    expect(onSort).toHaveBeenCalledWith('name', 'asc');
+    expect(onSort).toHaveBeenCalledWith('name', 'asc', 'push');
   });
 
   it('can sort by description without label', () => {
@@ -334,7 +356,7 @@ describe('Card View', () => {
 
     // Click to sort ascending
     button.simulate('click');
-    expect(onSort).toHaveBeenCalledWith('name', 'asc');
+    expect(onSort).toHaveBeenCalledWith('name', 'asc', 'push');
   });
 
   it('page changed when sort applied', () => {
@@ -345,7 +367,7 @@ describe('Card View', () => {
 
     // Click to sort ascending
     button.simulate('click');
-    expect(onSort).toHaveBeenCalledWith('title', 'asc');
+    expect(onSort).toHaveBeenCalledWith('title', 'asc', 'push');
     expect(onPageChange).toHaveBeenCalledWith(1);
   });
 
@@ -382,7 +404,7 @@ describe('Card View', () => {
     const button = wrapper.find(ListItemText).first();
     expect(button.text()).toEqual('visitId');
     button.simulate('click');
-    expect(onSort).toHaveBeenCalledWith('visitId', 'asc');
+    expect(onSort).toHaveBeenCalledWith('visitId', 'asc', 'push');
   });
 
   it('information displays with content that has no tooltip', () => {

--- a/packages/datagateway-common/src/card/cardView.component.tsx
+++ b/packages/datagateway-common/src/card/cardView.component.tsx
@@ -21,7 +21,14 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Pagination } from '@material-ui/lab';
 import ArrowTooltip from '../arrowtooltip.component';
-import { Entity, Filter, Order, SortType, FiltersType } from '../app.types';
+import {
+  Entity,
+  Filter,
+  Order,
+  SortType,
+  FiltersType,
+  UpdateMethod,
+} from '../app.types';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import AdvancedFilter from './advancedFilter.component';
@@ -95,7 +102,11 @@ export interface CardViewProps {
   onPageChange: (page: number) => void;
   onFilter: (filter: string, data: Filter | null) => void;
   onResultsChange: (page: number) => void;
-  onSort: (sort: string, order: Order | null) => void;
+  onSort: (
+    sort: string,
+    order: Order | null,
+    defaultSort: UpdateMethod
+  ) => void;
 
   // Props to get title, description of the card
   // represented by data.
@@ -559,7 +570,11 @@ const CardView = (props: CardViewProps): React.ReactElement => {
                             key={i}
                             button
                             onClick={() => {
-                              onSort(s.dataKey, nextSortDirection(s.dataKey));
+                              onSort(
+                                s.dataKey,
+                                nextSortDirection(s.dataKey),
+                                'push'
+                              );
                               if (page !== 1) {
                                 onPageChange(1);
                               }

--- a/packages/datagateway-common/src/card/cardView.component.tsx
+++ b/packages/datagateway-common/src/card/cardView.component.tsx
@@ -248,6 +248,8 @@ const CardView = (props: CardViewProps): React.ReactElement => {
     (information ? information.some((i) => !i.disableSort) : false);
 
   //Apply default sort on page load (but only if not already defined in URL params)
+  //This will apply them in the order of title, description and information, wherever
+  //defaultSort has been provided
   React.useEffect(() => {
     if (title.defaultSort !== undefined && sort[title.dataKey] === undefined)
       onSort(title.dataKey, title.defaultSort, 'replace');

--- a/packages/datagateway-common/src/card/cardView.component.tsx
+++ b/packages/datagateway-common/src/card/cardView.component.tsx
@@ -106,7 +106,7 @@ export interface CardViewProps {
   onSort: (
     sort: string,
     order: Order | null,
-    defaultSort: UpdateMethod
+    updateMethod: UpdateMethod
   ) => void;
 
   // Props to get title, description of the card

--- a/packages/datagateway-common/src/card/cardView.component.tsx
+++ b/packages/datagateway-common/src/card/cardView.component.tsx
@@ -74,6 +74,7 @@ export interface CardViewDetails {
   // Filter and sort options.
   filterComponent?: (label: string, dataKey: string) => React.ReactElement;
   disableSort?: boolean;
+  defaultSort?: Order;
   noTooltip?: boolean;
 }
 
@@ -245,6 +246,28 @@ const CardView = (props: CardViewProps): React.ReactElement => {
     !title.disableSort ||
     (description ? !description.disableSort : false) ||
     (information ? information.some((i) => !i.disableSort) : false);
+
+  //Apply default sort on page load (but only if not already defined in URL params)
+  React.useEffect(() => {
+    if (title.defaultSort !== undefined && sort[title.dataKey] === undefined)
+      onSort(title.dataKey, title.defaultSort, 'replace');
+    if (
+      description &&
+      description.defaultSort !== undefined &&
+      sort[description.dataKey] === undefined
+    )
+      onSort(description.dataKey, description.defaultSort, 'replace');
+    if (information) {
+      information.forEach((element: CardViewDetails) => {
+        if (
+          element.defaultSort !== undefined &&
+          sort[element.dataKey] === undefined
+        )
+          onSort(element.dataKey, element.defaultSort, 'replace');
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Get sort information from title, description and information lists.
   React.useEffect(() => {

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { createShallow } from '@material-ui/core/test-utils';
+import { createMount, createShallow } from '@material-ui/core/test-utils';
 import DataHeader from './dataHeader.component';
 import TextColumnFilter from '../columnFilters/textColumnFilter.component';
 import { TableSortLabel } from '@material-ui/core';
 
 describe('Data column header component', () => {
   let shallow;
+  let mount;
   const onSort = jest.fn();
   const resizeColumn = jest.fn();
   const dataHeaderProps = {
@@ -30,6 +31,12 @@ describe('Data column header component', () => {
 
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'div' });
+    mount = createMount();
+  });
+
+  afterEach(() => {
+    onSort.mockClear();
+    resizeColumn.mockClear();
   });
 
   it('renders correctly without sort or filter', () => {
@@ -69,7 +76,7 @@ describe('Data column header component', () => {
       const label = wrapper.find(TableSortLabel);
 
       label.simulate('click');
-      expect(onSort).toHaveBeenCalledWith('test', 'asc');
+      expect(onSort).toHaveBeenCalledWith('test', 'asc', 'push');
     });
 
     it('sets desc order', () => {
@@ -80,7 +87,7 @@ describe('Data column header component', () => {
       const label = wrapper.find(TableSortLabel);
 
       label.simulate('click');
-      expect(onSort).toHaveBeenCalledWith('test', 'desc');
+      expect(onSort).toHaveBeenCalledWith('test', 'desc', 'push');
     });
 
     it('sets null order', () => {
@@ -91,7 +98,27 @@ describe('Data column header component', () => {
       const label = wrapper.find(TableSortLabel);
 
       label.simulate('click');
-      expect(onSort).toHaveBeenCalledWith('test', null);
+      expect(onSort).toHaveBeenCalledWith('test', null, 'push');
+    });
+  });
+
+  describe('calls the onSort method when default sort is specified', () => {
+    it('sets asc order', () => {
+      const wrapper = mount(
+        <DataHeader {...dataHeaderProps} defaultSort="asc" />
+      );
+      wrapper.update();
+
+      expect(onSort).toHaveBeenCalledWith('test', 'asc', 'replace');
+    });
+
+    it('sets desc order', () => {
+      const wrapper = mount(
+        <DataHeader {...dataHeaderProps} defaultSort="desc" />
+      );
+      wrapper.update();
+
+      expect(onSort).toHaveBeenCalledWith('test', 'desc', 'replace');
     });
   });
 

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -45,6 +45,7 @@ const DataHeader = React.memo(
     const currSortDirection = sort[dataKey];
 
     //Apply default sort on page load (but only if not already defined in URL params)
+    //This will apply them in the order of the column definitions given to a table
     React.useEffect(() => {
       if (defaultSort !== undefined && currSortDirection === undefined)
         onSort(dataKey, defaultSort, 'replace');

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Order } from '../../app.types';
+import { Order, UpdateMethod } from '../../app.types';
 import { TableHeaderProps } from 'react-virtualized';
 import {
   TableCell,
@@ -16,7 +16,11 @@ const DataHeader = React.memo(
     props: TableHeaderProps & {
       className: string;
       sort: { [column: string]: Order };
-      onSort: (column: string, order: Order | null) => void;
+      onSort: (
+        column: string,
+        order: Order | null,
+        defaultSort: UpdateMethod
+      ) => void;
       resizeColumn: (dataKey: string, deltaX: number) => void;
       labelString: string;
       icon?: React.ComponentType<unknown>;
@@ -40,8 +44,13 @@ const DataHeader = React.memo(
 
     //Apply default sort on page load
     React.useEffect(() => {
-      if (defaultSort !== undefined)
-        onSort(dataKey, defaultSort === undefined ? null : defaultSort);
+      const defaultSortProvided = defaultSort !== undefined;
+      if (defaultSortProvided)
+        onSort(
+          dataKey,
+          defaultSort !== undefined ? defaultSort : null,
+          defaultSortProvided ? 'replace' : 'push'
+        );
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -63,7 +72,7 @@ const DataHeader = React.memo(
         className={'tour-dataview-sort'}
         active={dataKey in sort}
         direction={currSortDirection}
-        onClick={() => onSort(dataKey, nextSortDirection)}
+        onClick={() => onSort(dataKey, nextSortDirection, 'push')}
       >
         <Typography
           noWrap

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -42,19 +42,15 @@ const DataHeader = React.memo(
       filterComponent,
     } = props;
 
-    //Apply default sort on page load
+    const currSortDirection = sort[dataKey];
+
+    //Apply default sort on page load (but only if not already defined in URL params)
     React.useEffect(() => {
-      const defaultSortProvided = defaultSort !== undefined;
-      if (defaultSortProvided)
-        onSort(
-          dataKey,
-          defaultSort !== undefined ? defaultSort : null,
-          defaultSortProvided ? 'replace' : 'push'
-        );
+      if (defaultSort !== undefined && currSortDirection === undefined)
+        onSort(dataKey, defaultSort, 'replace');
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const currSortDirection = sort[dataKey];
     let nextSortDirection: Order | null = null;
     switch (currSortDirection) {
       case 'asc':

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -7,8 +7,8 @@ import {
   Box,
   Typography,
   useMediaQuery,
-  Divider,
 } from '@material-ui/core';
+import { DragIndicator } from '@material-ui/icons';
 import Draggable from 'react-draggable';
 
 const DataHeader = React.memo(
@@ -118,22 +118,12 @@ const DataHeader = React.memo(
             window.dispatchEvent(event);
           }}
         >
-          <div
+          <DragIndicator
+            fontSize="small"
             style={{
-              marginLeft: 18,
-              paddingLeft: '4px',
-              paddingRight: '4px',
               cursor: 'col-resize',
             }}
-          >
-            <Divider
-              orientation="vertical"
-              flexItem
-              style={{
-                height: '100%',
-              }}
-            />
-          </div>
+          />
         </Draggable>
       </TableCell>
     );

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -7,8 +7,8 @@ import {
   Box,
   Typography,
   useMediaQuery,
+  Divider,
 } from '@material-ui/core';
-import { DragIndicator } from '@material-ui/icons';
 import Draggable from 'react-draggable';
 
 const DataHeader = React.memo(
@@ -21,6 +21,7 @@ const DataHeader = React.memo(
       labelString: string;
       icon?: React.ComponentType<unknown>;
       filterComponent?: (label: string, dataKey: string) => React.ReactElement;
+      defaultSort?: Order;
     }
   ): React.ReactElement => {
     const {
@@ -31,10 +32,18 @@ const DataHeader = React.memo(
       label,
       labelString,
       disableSort,
+      defaultSort,
       resizeColumn,
       icon: Icon,
       filterComponent,
     } = props;
+
+    //Apply default sort on page load
+    React.useEffect(() => {
+      if (defaultSort !== undefined)
+        onSort(dataKey, defaultSort === undefined ? null : defaultSort);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const currSortDirection = sort[dataKey];
     let nextSortDirection: Order | null = null;
@@ -100,12 +109,22 @@ const DataHeader = React.memo(
             window.dispatchEvent(event);
           }}
         >
-          <DragIndicator
-            fontSize="small"
+          <div
             style={{
+              marginLeft: 18,
+              paddingLeft: '4px',
+              paddingRight: '4px',
               cursor: 'col-resize',
             }}
-          />
+          >
+            <Divider
+              orientation="vertical"
+              flexItem
+              style={{
+                height: '100%',
+              }}
+            />
+          </div>
         </Draggable>
       </TableCell>
     );

--- a/packages/datagateway-common/src/table/table.component.test.tsx
+++ b/packages/datagateway-common/src/table/table.component.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createMount } from '@material-ui/core/test-utils';
-import Table from './table.component';
+import Table, { ColumnType } from './table.component';
 import { formatBytes } from './cellRenderers/cellContentRenderers';
 import { TableCellProps } from 'react-virtualized';
 import TextColumnFilter from './columnFilters/textColumnFilter.component';
@@ -48,7 +48,7 @@ describe('Table component', () => {
           return formatBytes(cellProps.cellData);
         },
       },
-    ],
+    ] as ColumnType[],
   };
 
   beforeEach(() => {
@@ -57,6 +57,7 @@ describe('Table component', () => {
 
   afterEach(() => {
     mount.cleanUp();
+    onSort.mockClear();
   });
 
   it('renders data columns correctly', () => {
@@ -112,7 +113,22 @@ describe('Table component', () => {
       .first()
       .simulate('click');
 
-    expect(onSort).toHaveBeenCalledWith('TEST1', 'asc');
+    expect(onSort).toHaveBeenCalledWith('TEST1', 'asc', 'push');
+  });
+
+  it('calls onSort function when defaultSort has been specified', () => {
+    const sortedTableProps = {
+      ...tableProps,
+      columns: [
+        { ...tableProps.columns[0], defaultSort: 'asc' },
+        { ...tableProps.columns[1], defaultSort: 'desc' },
+      ],
+    };
+    const wrapper = mount(<Table {...sortedTableProps} />);
+    wrapper.update();
+
+    expect(onSort).toHaveBeenCalledWith('TEST1', 'asc', 'replace');
+    expect(onSort).toHaveBeenCalledWith('TEST2', 'desc', 'replace');
   });
 
   it('renders select column correctly, with both allIds defined and undefined', () => {

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -100,7 +100,7 @@ interface VirtualizedTableProps {
   onSort: (
     column: string,
     order: Order | null,
-    defaultSort: UpdateMethod
+    updateMethod: UpdateMethod
   ) => void;
   detailsPanel?: React.ComponentType<DetailsPanelProps>;
   actions?: React.ComponentType<TableActionProps>[];

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -19,7 +19,7 @@ import {
   TableRowRenderer,
 } from 'react-virtualized';
 import clsx from 'clsx';
-import { Entity, Order, ICATEntity } from '../app.types';
+import { Entity, Order, ICATEntity, UpdateMethod } from '../app.types';
 import ExpandCell from './cellRenderers/expandCell.component';
 import DataCell from './cellRenderers/dataCell.component';
 import ActionCell from './cellRenderers/actionCell.component';
@@ -97,7 +97,11 @@ interface VirtualizedTableProps {
   loadMoreRows?: (offsetParams: IndexRange) => Promise<unknown>;
   totalRowCount?: number;
   sort: { [column: string]: Order };
-  onSort: (column: string, order: Order | null) => void;
+  onSort: (
+    column: string,
+    order: Order | null,
+    defaultSort: UpdateMethod
+  ) => void;
   detailsPanel?: React.ComponentType<DetailsPanelProps>;
   actions?: React.ComponentType<TableActionProps>[];
   actionsWidth?: number;

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -77,6 +77,7 @@ export interface ColumnType {
   cellContentRenderer?: TableCellRenderer;
   className?: string;
   disableSort?: boolean;
+  defaultSort?: Order;
   filterComponent?: (label: string, dataKey: string) => React.ReactElement;
 }
 
@@ -393,6 +394,7 @@ const VirtualizedTable = React.memo(
                       icon,
                       filterComponent,
                       disableSort,
+                      defaultSort,
                     }) => {
                       return (
                         <Column
@@ -414,6 +416,7 @@ const VirtualizedTable = React.memo(
                               labelString={label}
                               filterComponent={filterComponent}
                               resizeColumn={resizeColumn}
+                              defaultSort={defaultSort}
                             />
                           )}
                           className={clsx(classes.flexContainer, className)}

--- a/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/datasets.spec.ts
@@ -19,94 +19,116 @@ describe('DLS - Datasets Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
-    cy.get('#card').contains('DATASET 1').click({ force: true });
+    cy.get('#card').contains('DATASET 241').click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/proposal/INVESTIGATION%201/investigation/1/dataset/1/datafile'
+      '/browse/proposal/INVESTIGATION%201/investigation/1/dataset/241/datafile'
     );
-  });
-
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-      timeout: 10000,
-    });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 1');
-
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-      timeout: 10000,
-    });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains('DATASET 241');
-
-    cy.contains('[role="button"]', 'Name').click();
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 1');
-  });
-
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Create Time')
-      .click()
-      .wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 1');
-
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-      timeout: 10000,
-    });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 1');
-  });
-
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('241')
-      .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
-    cy.get('#card').contains('DATASET 241');
-
-    cy.get('input[id="Create Time filter from"]')
-      .type('2019-01-01')
-      .wait(['@getDatasetsCount'], { timeout: 10000 });
-    cy.get('button[aria-label="Create Time filter to, date picker"]')
-      .parent()
-      .find('button')
-      .click();
-    cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
-    cy.contains('OK').click().wait(['@getDatasetsCount'], { timeout: 10000 });
-    const date = new Date();
-    date.setDate(1);
-    cy.get('input[id="Create Time filter to"]').should(
-      'have.value',
-      date.toISOString().slice(0, 10)
-    );
-    cy.get('#card').should('not.exist');
   });
 
   it('should be able to expand "More Information"', () => {
     cy.get('#card').contains('More Information').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('DATASET 1');
+      .contains('DATASET 241');
     cy.get('#calculate-size-btn').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('4.24 GB', { timeout: 10000 });
+      .contains('6.01 GB', { timeout: 10000 });
 
     cy.get('#dataset-type-tab').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
       .contains('DATASETTYPE 2');
+  });
+
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@getDatasetsOrder', { timeout: 10000 });
+    });
+
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+        timeout: 10000,
+      });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 1');
+
+      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+        timeout: 10000,
+      });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains('DATASET 241');
+
+      cy.contains('[role="button"]', 'Name').click();
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 1');
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@getDatasetsOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 1');
+
+      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+        timeout: 10000,
+      });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 1');
+    });
+  });
+
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@getDatasetsOrder', { timeout: 10000 });
+    });
+
+    it('should be able to filter by multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Name"]')
+        .first()
+        .type('241')
+        .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
+      cy.get('#card').contains('DATASET 241');
+
+      cy.get('input[id="Create Time filter from"]')
+        .type('2019-01-01')
+        .wait(['@getDatasetsCount'], { timeout: 10000 });
+      cy.get('button[aria-label="Create Time filter to, date picker"]')
+        .parent()
+        .find('button')
+        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
+      cy.contains('OK').click().wait(['@getDatasetsCount'], { timeout: 10000 });
+      const date = new Date();
+      date.setDate(1);
+      cy.get('input[id="Create Time filter to"]').should(
+        'have.value',
+        date.toISOString().slice(0, 10)
+      );
+      cy.get('#card').should('not.exist');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
@@ -17,73 +17,95 @@ describe('DLS - Proposals Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
-    cy.get('#card')
-      .contains('Including spend increase ability music skill former.')
-      .click({ force: true });
+    cy.get('#card').contains('About quickly both stop.').click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/proposal/INVESTIGATION%201/investigation'
+      '/browse/proposal/INVESTIGATION%2030/investigation'
     );
   });
 
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('About quickly both stop.');
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+    });
 
-    cy.contains('[role="button"]', 'Title').click();
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains('Yourself smile either I pass significant.');
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('About quickly both stop.');
 
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains(
-      'Including spend increase ability music skill former.'
-    );
+      cy.contains('[role="button"]', 'Title').click();
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains('Yourself smile either I pass significant.');
+
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains(
+        'Including spend increase ability music skill former.'
+      );
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Name')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('INVESTIGATION 1');
+
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('INVESTIGATION 1');
+    });
   });
 
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Name')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('INVESTIGATION 1');
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+    });
 
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('INVESTIGATION 1');
-  });
+    it('multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Title"]')
+        .first()
+        .type('Dog')
+        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('Energy place money bad authority.');
 
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Title"]')
-      .first()
-      .type('Dog')
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('Energy place money bad authority.');
-
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('2')
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('INVESTIGATION 192');
+      cy.get('[aria-label="Filter by Name"]')
+        .first()
+        .type('2')
+        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('INVESTIGATION 192');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/visits.spec.ts
@@ -17,6 +17,10 @@ describe('DLS - Visits Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
@@ -25,73 +29,6 @@ describe('DLS - Visits Cards', () => {
       'eq',
       '/browse/proposal/INVESTIGATION%201/investigation/1/dataset'
     );
-  });
-
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Visit ID')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('42');
-
-    cy.contains('[role="button"]', 'Visit ID')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains('42');
-
-    cy.contains('[role="button"]', 'Visit ID').click();
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('42');
-  });
-
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('42');
-
-    cy.contains('[role="button"]', 'Visit ID')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('42');
-  });
-
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Visit ID"]')
-      .first()
-      .type('4')
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('42');
-
-    cy.get('input[id="Start Date filter from"]')
-      .type('2019-01-01')
-      .wait(['@getInvestigationsCount'], { timeout: 10000 });
-    cy.get('button[aria-label="Start Date filter to, date picker"]')
-      .parent()
-      .find('button')
-      .click();
-    cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
-    cy.contains('OK')
-      .click()
-      .wait(['@getInvestigationsCount'], { timeout: 10000 });
-    const date = new Date();
-    date.setDate(1);
-    cy.get('input[id="Start Date filter to"]').should(
-      'have.value',
-      date.toISOString().slice(0, 10)
-    );
-    cy.get('#card').should('not.exist');
   });
 
   it('should be able to expand "More Information"', () => {
@@ -115,5 +52,90 @@ describe('DLS - Visits Cards', () => {
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
       .contains('Eat interest seem black easy various.');
+  });
+
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+    });
+
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Visit ID')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('42');
+
+      cy.contains('[role="button"]', 'Visit ID')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains('42');
+
+      cy.contains('[role="button"]', 'Visit ID').click();
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('42');
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('42');
+
+      cy.contains('[role="button"]', 'Visit ID')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('42');
+    });
+  });
+
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+    });
+
+    it('multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Visit ID"]')
+        .first()
+        .type('4')
+        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('42');
+
+      cy.get('input[id="Start Date filter from"]')
+        .type('2019-01-01')
+        .wait(['@getInvestigationsCount'], { timeout: 10000 });
+      cy.get('button[aria-label="Start Date filter to, date picker"]')
+        .parent()
+        .find('button')
+        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
+      cy.contains('OK')
+        .click()
+        .wait(['@getInvestigationsCount'], { timeout: 10000 });
+      const date = new Date();
+      date.setDate(1);
+      cy.get('input[id="Start Date filter to"]').should(
+        'have.value',
+        date.toISOString().slice(0, 10)
+      );
+      cy.get('#card').should('not.exist');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/isis/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/datasets.spec.ts
@@ -18,6 +18,10 @@ describe('ISIS - Datasets Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
@@ -28,72 +32,12 @@ describe('ISIS - Datasets Cards', () => {
     );
   });
 
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-      timeout: 10000,
-    });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 337');
-
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-      timeout: 10000,
-    });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains('DATASET 97');
-
-    cy.contains('[role="button"]', 'Name').click();
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 97');
-  });
-
-  it('should be able to sort by multiple fields', () => {
+  it('should be able to expand "More Information"', () => {
+    //Revert the default sort
     cy.contains('[role="button"]', 'Create Time')
       .click()
-      .wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 337');
+      .wait('@getDatasetsOrder', { timeout: 10000 });
 
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-      timeout: 10000,
-    });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('DATASET 337');
-  });
-
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('337')
-      .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
-    cy.get('#card').contains('DATASET 337');
-
-    cy.get('input[id="Create Time filter from"]')
-      .type('2019-01-01')
-      .wait(['@getDatasetsCount'], { timeout: 10000 });
-    cy.get('button[aria-label="Create Time filter to, date picker"]')
-      .parent()
-      .find('button')
-      .click();
-    cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
-    cy.contains('OK').click().wait(['@getDatasetsCount'], { timeout: 10000 });
-    const date = new Date();
-    date.setDate(1);
-    cy.get('input[id="Create Time filter to"]').should(
-      'have.value',
-      date.toISOString().slice(0, 10)
-    );
-    cy.get('#card').should('not.exist');
-  });
-
-  it('should be able to expand "More Information"', () => {
     cy.get('#card').contains('More Information').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
@@ -107,5 +51,88 @@ describe('ISIS - Datasets Cards', () => {
       'eq',
       '/browse/instrument/1/facilityCycle/16/investigation/97/dataset/97/datafile'
     );
+  });
+
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@getDatasetsOrder', { timeout: 10000 });
+    });
+
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+        timeout: 10000,
+      });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 337');
+
+      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+        timeout: 10000,
+      });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains('DATASET 97');
+
+      cy.contains('[role="button"]', 'Name').click();
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 97');
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@getDatasetsOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 337');
+
+      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+        timeout: 10000,
+      });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('DATASET 337');
+    });
+  });
+
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@getDatasetsOrder', { timeout: 10000 });
+    });
+
+    it('multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Name"]')
+        .first()
+        .type('337')
+        .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
+      cy.get('#card').contains('DATASET 337');
+
+      cy.get('input[id="Create Time filter from"]')
+        .type('2019-01-01')
+        .wait(['@getDatasetsCount'], { timeout: 10000 });
+      cy.get('button[aria-label="Create Time filter to, date picker"]')
+        .parent()
+        .find('button')
+        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
+      cy.contains('OK').click().wait(['@getDatasetsCount'], { timeout: 10000 });
+      const date = new Date();
+      date.setDate(1);
+      cy.get('input[id="Create Time filter to"]').should(
+        'have.value',
+        date.toISOString().slice(0, 10)
+      );
+      cy.get('#card').should('not.exist');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/facilityCycles.spec.ts
@@ -15,24 +15,21 @@ describe('ISIS - FacilityCycles Cards', () => {
     cy.get('#datagateway-dataview').should('be.visible');
 
     //Default sort
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
     cy.contains('[role="button"]', 'desc').should('exist');
     cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
-    cy.get('#card').contains('2000 cycle 2').click({ force: true });
+    cy.get('#card').contains('2019 cycle 4').click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/instrument/1/facilityCycle/1/investigation'
+      '/browse/instrument/1/facilityCycle/79/investigation'
     );
   });
 
   describe('should be able to sort by', () => {
     beforeEach(() => {
       //Revert the default sort
-      cy.contains('[role="button"]', 'Name').click().click();
       cy.contains('[role="button"]', 'Start Date')
         .click()
         .wait('@getFacilityCyclesOrder', { timeout: 10000 });
@@ -77,7 +74,6 @@ describe('ISIS - FacilityCycles Cards', () => {
   describe('should be able to filter by', () => {
     beforeEach(() => {
       //Revert the default sort
-      cy.contains('[role="button"]', 'Name').click().click();
       cy.contains('[role="button"]', 'Start Date')
         .click()
         .wait('@getFacilityCyclesOrder', { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/integration/card/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/facilityCycles.spec.ts
@@ -13,6 +13,12 @@ describe('ISIS - FacilityCycles Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
@@ -23,69 +29,88 @@ describe('ISIS - FacilityCycles Cards', () => {
     );
   });
 
-  // Note that Name and Description currently fail to sort
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('2000 cycle 2');
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Name').click().click();
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
+    });
+    // Note that Name and Description currently fail to sort
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('2000 cycle 2');
 
-    cy.contains('[role="button"]', 'Start Date').click();
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains('2019 cycle ');
+      cy.contains('[role="button"]', 'Start Date').click();
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains('2019 cycle ');
 
-    cy.contains('[role="button"]', 'Start Date').click();
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('2000 cycle 2');
+      cy.contains('[role="button"]', 'Start Date').click();
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('2000 cycle 2');
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('2000 cycle 2');
+
+      cy.contains('[role="button"]', 'End Date')
+        .click()
+        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('2000 cycle 2');
+    });
   });
 
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('2000 cycle 2');
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Name').click().click();
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
+    });
 
-    cy.contains('[role="button"]', 'End Date')
-      .click()
-      .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('2000 cycle 2');
-  });
+    it('multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Name"]')
+        .first()
+        .type('4')
+        .wait(['@getFacilityCyclesCount', '@getFacilityCyclesOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('2004 cycle 1');
 
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('4')
-      .wait(['@getFacilityCyclesCount', '@getFacilityCyclesOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('2004 cycle 1');
-
-    cy.get('input[id="Start Date filter from"]')
-      .type('2019-01-01')
-      .wait(['@getFacilityCyclesCount'], { timeout: 10000 });
-    cy.get('button[aria-label="Start Date filter to, date picker"]')
-      .parent()
-      .find('button')
-      .click();
-    cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
-    cy.contains('OK')
-      .click()
-      .wait(['@getFacilityCyclesCount'], { timeout: 10000 });
-    const date = new Date();
-    date.setDate(1);
-    cy.get('input[id="Start Date filter to"]').should(
-      'have.value',
-      date.toISOString().slice(0, 10)
-    );
-    cy.get('#card').contains('2019 cycle 4');
+      cy.get('input[id="Start Date filter from"]')
+        .type('2019-01-01')
+        .wait(['@getFacilityCyclesCount'], { timeout: 10000 });
+      cy.get('button[aria-label="Start Date filter to, date picker"]')
+        .parent()
+        .find('button')
+        .click();
+      cy.get('.MuiPickersDay-day[tabindex="0"]').first().click();
+      cy.contains('OK')
+        .click()
+        .wait(['@getFacilityCyclesCount'], { timeout: 10000 });
+      const date = new Date();
+      date.setDate(1);
+      cy.get('input[id="Start Date filter to"]').should(
+        'have.value',
+        date.toISOString().slice(0, 10)
+      );
+      cy.get('#card').contains('2019 cycle 4');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/isis/instruments.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/instruments.spec.ts
@@ -13,83 +13,106 @@ describe('ISIS - Instruments Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
     cy.get('#card')
-      .contains('Season identify professor happen third.')
+      .contains('Air it quickly everybody have image left.')
       .click({ force: true });
-    cy.location('pathname').should('eq', '/browse/instrument/1/facilityCycle');
-  });
-
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Name')
-      .click()
-      .wait('@getInstrumentsOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('Air it quickly everybody have image left.');
-
-    cy.contains('[role="button"]', 'Name')
-      .click()
-      .wait('@getInstrumentsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains('With piece reason late model.');
-
-    cy.contains('[role="button"]', 'Name')
-      .click()
-      .wait('@getInstrumentsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('Season identify professor happen third.');
-  });
-
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Description')
-      .click()
-      .wait('@getInstrumentsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('Near must surface law how full.');
-
-    cy.contains('[role="button"]', 'Type')
-      .click()
-      .wait('@getInstrumentsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('4');
-  });
-
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('Near')
-      .wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('Near must surface law how full.');
-
-    cy.get('[aria-label="Filter by Type"]')
-      .first()
-      .type('4')
-      .wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('4');
+    cy.location('pathname').should('eq', '/browse/instrument/11/facilityCycle');
   });
 
   it('should be able to expand "More Information"', () => {
     cy.get('#card').contains('More Information').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('Season identify professor happen third.');
+      .contains('Air it quickly everybody have image left.');
     cy.get('#instrument-users-tab').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('Marcus Dixon');
+      .contains('Brianna Martin');
+  });
+
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Name')
+        .click()
+        .click()
+        .wait('@getInstrumentsOrder', { timeout: 10000 });
+    });
+
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Name')
+        .click()
+        .wait('@getInstrumentsOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('Air it quickly everybody have image left.');
+
+      cy.contains('[role="button"]', 'Name')
+        .click()
+        .wait('@getInstrumentsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains('With piece reason late model.');
+
+      cy.contains('[role="button"]', 'Name')
+        .click()
+        .wait('@getInstrumentsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('Season identify professor happen third.');
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Description')
+        .click()
+        .wait('@getInstrumentsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('Near must surface law how full.');
+
+      cy.contains('[role="button"]', 'Type')
+        .click()
+        .wait('@getInstrumentsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('4');
+    });
+  });
+
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Name')
+        .click()
+        .click()
+        .wait('@getInstrumentsOrder', { timeout: 10000 });
+    });
+    it('multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Name"]')
+        .first()
+        .type('Near')
+        .wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('Near must surface law how full.');
+
+      cy.get('[aria-label="Filter by Type"]')
+        .first()
+        .type('4')
+        .wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('4');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
@@ -15,8 +15,6 @@ describe('ISIS - Investigations Cards', () => {
     cy.get('#datagateway-dataview').should('be.visible');
 
     //Default sort
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
     cy.contains('[role="button"]', 'desc').should('exist');
     cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
@@ -114,7 +112,6 @@ describe('ISIS - Investigations Cards', () => {
   describe('should be able to sort by', () => {
     beforeEach(() => {
       //Revert the default sort
-      cy.contains('[role="button"]', 'Title').click().click();
       cy.contains('[role="button"]', 'Start Date')
         .click()
         .wait('@getInvestigationsOrder', { timeout: 10000 });
@@ -171,7 +168,6 @@ describe('ISIS - Investigations Cards', () => {
   describe('should be able to filter by', () => {
     beforeEach(() => {
       //Revert the default sort
-      cy.contains('[role="button"]', 'Title').click().click();
       cy.contains('[role="button"]', 'Start Date')
         .click()
         .wait('@getInvestigationsOrder', { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/investigations.spec.ts
@@ -13,113 +13,139 @@ describe('ISIS - Investigations Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
     cy.get('#card')
-      .contains('He represent address cut environmental special size.')
+      .contains('Again bad simply low summer.')
       .click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/instrument/1/facilityCycle/16/investigation/16'
+      '/browse/instrument/1/facilityCycle/16/investigation/97'
     );
-  });
-
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('Again bad simply low summer.');
-
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains(
-      'He represent address cut environmental special size.'
-    );
-
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains(
-      'He represent address cut environmental special size.'
-    );
-  });
-
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains(
-      'He represent address cut environmental special size.'
-    );
-
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains(
-      'He represent address cut environmental special size.'
-    );
-  });
-
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Title"]')
-      .first()
-      .type('cut')
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains(
-      'He represent address cut environmental special size.'
-    );
-
-    cy.get('input[id="Start Date filter from"]')
-      .type('2004-01-01')
-      .wait(['@getInvestigationsCount'], { timeout: 10000 });
-    cy.get('#card').contains(
-      'He represent address cut environmental special size.'
-    );
-    cy.get('input[id="Start Date filter to"]')
-      .type('2004-01-02')
-      .wait(['@getInvestigationsCount'], { timeout: 10000 });
-    cy.get('#card').should('not.exist');
   });
 
   it('should be able to expand "More Information"', () => {
     cy.get('#card').contains('More Information').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('INVESTIGATION 16');
+      .contains('INVESTIGATION 97');
     cy.get('#card')
-      .contains('1-314-79096-X')
-      .should('have.attr', 'href', 'https://doi.org/1-314-79096-X');
+      .contains('1-896651-96-8')
+      .should('have.attr', 'href', 'https://doi.org/1-896651-96-8');
     cy.get('#investigation-users-tab').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('Corey Cook');
+      .contains('Noah Jones');
     cy.get('#investigation-samples-tab').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('SAMPLE 16');
+      .contains('SAMPLE 97');
     cy.get('#investigation-publications-tab').click({ force: true });
     cy.get('#card')
       .get('[aria-label="card-more-information"]')
-      .contains('Fish page on factor nature everybody action.');
+      .contains('Safe tough case newspaper.');
     cy.get('#investigation-datasets-tab').click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/instrument/1/facilityCycle/16/investigation/16/dataset'
+      '/browse/instrument/1/facilityCycle/16/investigation/97/dataset'
     );
+  });
+
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Title').click().click();
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+    });
+
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('Again bad simply low summer.');
+
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains(
+        'He represent address cut environmental special size.'
+      );
+
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains(
+        'He represent address cut environmental special size.'
+      );
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains(
+        'He represent address cut environmental special size.'
+      );
+
+      cy.contains('[role="button"]', 'Title')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains(
+        'He represent address cut environmental special size.'
+      );
+    });
+  });
+
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Title').click().click();
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getInvestigationsOrder', { timeout: 10000 });
+    });
+
+    it('multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Title"]')
+        .first()
+        .type('cut')
+        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains(
+        'He represent address cut environmental special size.'
+      );
+
+      cy.get('input[id="Start Date filter from"]')
+        .type('2004-01-01')
+        .wait(['@getInvestigationsCount'], { timeout: 10000 });
+      cy.get('#card').contains(
+        'He represent address cut environmental special size.'
+      );
+      cy.get('input[id="Start Date filter to"]')
+        .type('2004-01-02')
+        .wait(['@getInvestigationsCount'], { timeout: 10000 });
+      cy.get('#card').should('not.exist');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/isis/studies.spec.ts
@@ -13,82 +13,104 @@ describe('ISIS - Studies Cards', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click a study to see its landing page', () => {
-    cy.get('#card').contains('STUDY 4').click({ force: true });
+    cy.get('#card').contains('STUDY 494').click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browseStudyHierarchy/instrument/1/study/4'
+      '/browseStudyHierarchy/instrument/1/study/494'
     );
   });
 
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getStudiesOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('STUDY 325');
+  describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getStudiesOrder', { timeout: 10000 });
+    });
 
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getStudiesOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('#card').contains('STUDY 494');
+    it('one field', () => {
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getStudiesOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('STUDY 325');
 
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getStudiesOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('not.exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('STUDY 4');
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getStudiesOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('exist');
+      cy.get('#card').contains('STUDY 494');
+
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getStudiesOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('not.exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('STUDY 4');
+    });
+
+    it('multiple fields', () => {
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getStudiesOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('STUDY 325');
+
+      cy.contains('[role="button"]', 'End Date')
+        .click()
+        .wait('@getStudiesOrder', {
+          timeout: 10000,
+        });
+      cy.contains('[role="button"]', 'asc').should('exist');
+      cy.contains('[role="button"]', 'desc').should('not.exist');
+      cy.get('#card').contains('STUDY 325');
+    });
   });
 
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getStudiesOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('STUDY 325');
+  describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date')
+        .click()
+        .wait('@getStudiesOrder', { timeout: 10000 });
+    });
 
-    cy.contains('[role="button"]', 'End Date')
-      .click()
-      .wait('@getStudiesOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('#card').contains('STUDY 325');
-  });
+    it('multiple fields', () => {
+      cy.get('[aria-label="advanced-filters-link"]').click();
 
-  it('should be able to filter by multiple fields', () => {
-    cy.get('[aria-label="advanced-filters-link"]').click();
+      cy.get('[aria-label="Filter by Name"]')
+        .first()
+        .type('1')
+        .wait(['@getStudiesCount', '@getStudiesOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('STUDY 11');
 
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('1')
-      .wait(['@getStudiesCount', '@getStudiesOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('STUDY 11');
-
-    cy.get('[aria-label="Filter by Title"]')
-      .first()
-      .type('peace')
-      .wait(['@getStudiesCount', '@getStudiesOrder'], {
-        timeout: 10000,
-      });
-    cy.get('#card').contains('STUDY 341');
+      cy.get('[aria-label="Filter by Title"]')
+        .first()
+        .type('peace')
+        .wait(['@getStudiesCount', '@getStudiesOrder'], {
+          timeout: 10000,
+        });
+      cy.get('#card').contains('STUDY 341');
+    });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
@@ -6,6 +6,7 @@ describe('Add/remove from cart functionality', () => {
     cy.intercept('/investigations/').as('getInvestigation');
     cy.intercept('/instruments/1').as('getInstrument');
     cy.intercept('/facilitycycles/16').as('getFacilityCycle');
+    cy.intercept('/datafiles?order=').as('getDatafilesOrder');
   });
 
   describe('should be able to select datafiles', () => {
@@ -242,6 +243,11 @@ describe('Add/remove from cart functionality', () => {
         cy.visit(
           '/browse/proposal/INVESTIGATION%201/investigation/1/dataset/1/datafile'
         ).wait(['@getDatafiles', '@getDatafiles', '@getDatafileCount']);
+
+        //Revert the default sort
+        cy.contains('[role="button"]', 'Create Time')
+          .click()
+          .wait('@getDatafilesOrder', { timeout: 10000 });
       });
 
       it('individually', () => {

--- a/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
@@ -6,7 +6,6 @@ describe('Add/remove from cart functionality', () => {
     cy.intercept('/investigations/').as('getInvestigation');
     cy.intercept('/instruments/1').as('getInstrument');
     cy.intercept('/facilitycycles/16').as('getFacilityCycle');
-    cy.intercept('/datafiles?order=').as('getDatafilesOrder');
   });
 
   describe('should be able to select datafiles', () => {
@@ -243,11 +242,6 @@ describe('Add/remove from cart functionality', () => {
         cy.visit(
           '/browse/proposal/INVESTIGATION%201/investigation/1/dataset/1/datafile'
         ).wait(['@getDatafiles', '@getDatafiles', '@getDatafileCount']);
-
-        //Revert the default sort
-        cy.contains('[role="button"]', 'Create Time')
-          .click()
-          .wait('@getDatafilesOrder', { timeout: 10000 });
       });
 
       it('individually', () => {
@@ -320,7 +314,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 1"]').should('be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo(0, 350);
-        cy.get('[aria-label="select row 9"]').should('not.be.checked');
+        cy.get('[aria-label="select row 14"]').should('not.be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo('bottom').wait('@getDatafiles');
         cy.get('[aria-label="grid"]').scrollTo('bottom');
@@ -463,7 +457,7 @@ describe('Add/remove from cart functionality', () => {
       it('by all items in a filtered table', () => {
         cy.get('[aria-label="Filter by Location"]')
           .first()
-          .type('e')
+          .type('ge')
           .wait(['@getDatafiles', '@getDatafiles']);
 
         cy.get('[aria-label="select all rows"]').check();
@@ -474,7 +468,7 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get(
-          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
+          `[aria-label="select row ${Math.floor(Math.random() * 6)}"]`
         ).should('be.checked');
 
         cy.get('[aria-label="Filter by Location"]').first().clear();
@@ -486,13 +480,13 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'true');
 
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="select row 1"]').should('be.checked');
-        cy.get('[aria-label="select row 20"]').should('not.be.checked');
+        cy.get('[aria-label="select row 4"]').should('be.checked');
+        cy.get('[aria-label="select row 10"]').should('be.checked');
+        cy.get('[aria-label="select row 0"]').should('not.be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo('bottom').wait('@getDatafiles');
         cy.get('[aria-label="grid"]').scrollTo('bottom');
-        cy.get('[aria-label="select row 44"]').should('not.be.checked');
+        cy.get('[aria-label="select row 53"]').should('not.be.checked');
         cy.get('[aria-label="select row 54"]').should('be.checked');
       });
 

--- a/packages/datagateway-dataview/cypress/integration/table/dls/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/datafiles.spec.ts
@@ -14,6 +14,10 @@ describe('DLS - Datafiles Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should not load incorrect URL', () => {
@@ -96,6 +100,13 @@ describe('DLS - Datafiles Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@datafilesOrder', { timeout: 10000 });
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Location')
         .click()
@@ -169,6 +180,13 @@ describe('DLS - Datafiles Table', () => {
   });
 
   describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@datafilesOrder', { timeout: 10000 });
+    });
+
     it('text', () => {
       cy.get('[aria-label="Filter by Location"]').first().type('rise');
 
@@ -226,6 +244,13 @@ describe('DLS - Datafiles Table', () => {
   });
 
   describe('should be able to view details', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@datafilesOrder', { timeout: 10000 });
+    });
+
     it('when no other row is showing details', () => {
       cy.get('[aria-label="Show details"]').first().click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
@@ -23,6 +23,10 @@ describe('DLS - Datasets Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should not load incorrect URL', () => {
@@ -37,7 +41,7 @@ describe('DLS - Datasets Table', () => {
 
     cy.location('pathname').should(
       'eq',
-      '/browse/proposal/INVESTIGATION%201/investigation/1/dataset/1/datafile'
+      '/browse/proposal/INVESTIGATION%201/investigation/1/dataset/241/datafile'
     );
   });
 
@@ -109,6 +113,11 @@ describe('DLS - Datasets Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time').click();
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Name')
         .click()
@@ -205,6 +214,11 @@ describe('DLS - Datasets Table', () => {
   });
 
   describe('should be able to view details', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time').click();
+    });
+
     it('when no other row is showing details', () => {
       cy.get('[aria-label="Show details"]').first().click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/dls/myData.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/myData.spec.ts
@@ -19,6 +19,10 @@ describe('DLS - MyData Table', () => {
     it('should load correctly', () => {
       cy.title().should('equal', 'DataGateway DataView');
       cy.get('#datagateway-dataview').should('be.visible');
+
+      //Default sort
+      cy.get('[aria-sort="descending"]').should('exist');
+      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
     });
 
     it('should be able to click an investigation to see its datasets', () => {
@@ -90,8 +94,12 @@ describe('DLS - MyData Table', () => {
     });
 
     describe('should be able to sort by', () => {
-      it('ascending order', () => {
+      beforeEach(() => {
+        //Revert the default sort
         cy.contains('[role="button"]', 'Start Date').click();
+      });
+
+      it('ascending order', () => {
         cy.contains('[role="button"]', 'Title').click();
 
         cy.get('[aria-sort="ascending"]').should('exist');
@@ -102,7 +110,6 @@ describe('DLS - MyData Table', () => {
       });
 
       it('descending order', () => {
-        cy.contains('[role="button"]', 'Start Date').click();
         cy.contains('[role="button"]', 'Title').click();
         cy.contains('[role="button"]', 'Title').click();
         cy.get('[aria-sort="descending"]').should('exist');
@@ -117,8 +124,6 @@ describe('DLS - MyData Table', () => {
       });
 
       it('no order', () => {
-        cy.contains('[role="button"]', 'Start Date').click();
-
         cy.get('[aria-sort="ascending"]').should('not.exist');
         cy.get('[aria-sort="descending"]').should('not.exist');
         cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
@@ -133,7 +138,6 @@ describe('DLS - MyData Table', () => {
       });
 
       it('multiple columns', () => {
-        cy.contains('[role="button"]', 'Start Date').click();
         cy.contains('[role="button"]', 'Title').click();
         cy.contains('[role="button"]', 'Instrument').click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/proposals.spec.ts
@@ -9,6 +9,10 @@ describe('DLS - Proposals Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
   });
 
   it('should be able to click a proposal to see its investigations', () => {
@@ -16,7 +20,7 @@ describe('DLS - Proposals Table', () => {
 
     cy.location('pathname').should(
       'eq',
-      '/browse/proposal/INVESTIGATION%201/investigation'
+      '/browse/proposal/INVESTIGATION%2030/investigation'
     );
   });
 
@@ -91,6 +95,9 @@ describe('DLS - Proposals Table', () => {
   describe('should be able to sort by', () => {
     beforeEach(() => {
       cy.wait(['@investigations', '@investigationsCount'], { timeout: 10000 });
+
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Title').click().click();
     });
 
     it('ascending order', () => {

--- a/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
@@ -19,6 +19,10 @@ describe('DLS - Visits Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click an investigation to see its datasets', () => {
@@ -97,6 +101,11 @@ describe('DLS - Visits Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date').click();
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Visit ID').click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/datafiles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/datafiles.spec.ts
@@ -30,6 +30,10 @@ describe('ISIS - Datafiles Table', () => {
     it('should load correctly', () => {
       cy.title().should('equal', 'DataGateway DataView');
       cy.get('#datagateway-dataview').should('be.visible');
+
+      //Default sort
+      cy.get('[aria-sort="descending"]').should('exist');
+      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
     });
 
     it('should not load incorrect URL', () => {
@@ -48,6 +52,13 @@ describe('ISIS - Datafiles Table', () => {
     });
 
     describe('should be able to sort by', () => {
+      beforeEach(() => {
+        //Revert the default sort
+        cy.contains('[role="button"]', 'Modified Time')
+          .click()
+          .wait('@datafilesOrder', { timeout: 10000 });
+      });
+
       it('ascending order', () => {
         cy.contains('[role="button"]', 'Location')
           .click()
@@ -151,6 +162,13 @@ describe('ISIS - Datafiles Table', () => {
     });
 
     describe('should be able to view details', () => {
+      beforeEach(() => {
+        //Revert the default sort
+        cy.contains('[role="button"]', 'Modified Time')
+          .click()
+          .wait('@datafilesOrder', { timeout: 10000 });
+      });
+
       it('when no other row is showing details', () => {
         cy.get('[aria-label="Show details"]').first().click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/datasets.spec.ts
@@ -13,6 +13,10 @@ describe('ISIS - Datasets Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should not load incorrect URL', () => {
@@ -100,6 +104,13 @@ describe('ISIS - Datasets Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Create Time')
+        .click()
+        .wait('@datasetsOrder', { timeout: 10000 });
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Name')
         .click()

--- a/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
@@ -7,6 +7,12 @@ describe('ISIS - FacilityCycles Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click a facility cycle to see its investigations', () => {
@@ -91,6 +97,12 @@ describe('ISIS - FacilityCycles Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Name').click().click();
+      cy.contains('[role="button"]', 'Start Date').click();
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Name').click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/facilityCycles.spec.ts
@@ -9,8 +9,6 @@ describe('ISIS - FacilityCycles Table', () => {
     cy.get('#datagateway-dataview').should('be.visible');
 
     //Default sort
-    cy.get('[aria-sort="ascending"]').should('exist');
-    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
     cy.get('[aria-sort="descending"]').should('exist');
     cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
@@ -19,7 +17,7 @@ describe('ISIS - FacilityCycles Table', () => {
     cy.get('[role="gridcell"] a').first().click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/instrument/1/facilityCycle/1/investigation'
+      '/browse/instrument/1/facilityCycle/79/investigation'
     );
   });
 
@@ -99,7 +97,6 @@ describe('ISIS - FacilityCycles Table', () => {
   describe('should be able to sort by', () => {
     beforeEach(() => {
       //Revert the default sort
-      cy.contains('[role="button"]', 'Name').click().click();
       cy.contains('[role="button"]', 'Start Date').click();
     });
 
@@ -162,7 +159,7 @@ describe('ISIS - FacilityCycles Table', () => {
 
       cy.get('[aria-rowcount="2"]').should('exist');
       cy.get('[aria-rowindex="2"] [aria-colindex="2"]').contains(
-        '2010-08-04 00:00:00+00:00'
+        '2010-06-03 00:00:00+00:00'
       );
     });
 
@@ -188,7 +185,7 @@ describe('ISIS - FacilityCycles Table', () => {
 
       cy.get('[aria-rowcount="19"]').should('exist');
       cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        '2010-06-03 00:00:00+00:00'
+        '2019-08-04 00:00:00+00:00'
       );
     });
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/instruments.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/instruments.spec.ts
@@ -7,11 +7,15 @@ describe('ISIS - Instruments Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
   });
 
   it('should be able to click an instrument to see its facilityCycle', () => {
     cy.get('[role="gridcell"] a').first().click({ force: true });
-    cy.location('pathname').should('eq', '/browse/instrument/1/facilityCycle');
+    cy.location('pathname').should('eq', '/browse/instrument/11/facilityCycle');
   });
 
   // Not enough data in instruments to scroll down and load more rows.
@@ -22,6 +26,11 @@ describe('ISIS - Instruments Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Name').click().click();
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Name').click();
 
@@ -78,6 +87,11 @@ describe('ISIS - Instruments Table', () => {
   });
 
   describe('should be able to view details', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Name').click().click();
+    });
+
     it('when no other row is showing details', () => {
       cy.get('[aria-label="Show details"]').first().click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
@@ -9,8 +9,6 @@ describe('ISIS - Investigations Table', () => {
     cy.get('#datagateway-dataview').should('be.visible');
 
     //Default sort
-    cy.get('[aria-sort="ascending"]').should('exist');
-    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('exist');
     cy.get('[aria-sort="descending"]').should('exist');
     cy.get('.MuiTableSortLabel-iconDirectionDesc').should('exist');
   });
@@ -111,7 +109,6 @@ describe('ISIS - Investigations Table', () => {
   describe('should be able to sort by', () => {
     beforeEach(() => {
       //Revert the default sort
-      cy.contains('[role="button"]', 'Title').click().click();
       cy.contains('[role="button"]', 'Start Date').click();
     });
 
@@ -214,7 +211,6 @@ describe('ISIS - Investigations Table', () => {
   describe('should be able to view details', () => {
     beforeEach(() => {
       //Revert the default sort
-      cy.contains('[role="button"]', 'Title').click().click();
       cy.contains('[role="button"]', 'Start Date').click();
 
       // Check that we have received the size from the API as this will produce

--- a/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/investigations.spec.ts
@@ -7,13 +7,19 @@ describe('ISIS - Investigations Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('exist');
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('exist');
   });
 
   it('should be able to click an investigation to see its landing page', () => {
     cy.get('[role="gridcell"] a').first().click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/instrument/1/facilityCycle/16/investigation/16'
+      '/browse/instrument/1/facilityCycle/16/investigation/97'
     );
   });
 
@@ -89,6 +95,12 @@ describe('ISIS - Investigations Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Title').click().click();
+      cy.contains('[role="button"]', 'Start Date').click();
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Title').click();
 
@@ -187,6 +199,10 @@ describe('ISIS - Investigations Table', () => {
 
   describe('should be able to view details', () => {
     beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Title').click().click();
+      cy.contains('[role="button"]', 'Start Date').click();
+
       // Check that we have received the size from the API as this will produce
       // a re-render which can prevent the click.
       cy.contains('[aria-rowindex="1"] [aria-colindex="6"]', '10.2 GB').should(

--- a/packages/datagateway-dataview/cypress/integration/table/isis/myData.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/myData.spec.ts
@@ -21,6 +21,10 @@ describe('ISIS - MyData Table', () => {
     it('should load correctly', () => {
       cy.title().should('equal', 'DataGateway DataView');
       cy.get('#datagateway-dataview').should('be.visible');
+
+      //Default sort
+      cy.get('[aria-sort="descending"]').should('exist');
+      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('exist');
     });
 
     it('should be able to click an investigation to see its landing page', () => {
@@ -99,9 +103,13 @@ describe('ISIS - MyData Table', () => {
     });
 
     describe('should be able to sort by', () => {
-      it('ascending order', () => {
+      beforeEach(() => {
+        //Revert the default sort
         cy.contains('[role="button"]', 'Start Date').click();
-        cy.contains('[role="button"]', 'Title').click();
+      });
+
+      it('ascending order', () => {
+        cy.contains('[role="button"]', 'Title').first().click();
 
         cy.get('[aria-sort="ascending"]').should('exist');
         cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
@@ -111,7 +119,6 @@ describe('ISIS - MyData Table', () => {
       });
 
       it('descending order', () => {
-        cy.contains('[role="button"]', 'Start Date').click();
         cy.contains('[role="button"]', 'Title').click();
         cy.contains('[role="button"]', 'Title').click();
         cy.get('[aria-sort="descending"]').should('exist');
@@ -126,8 +133,6 @@ describe('ISIS - MyData Table', () => {
       });
 
       it('no order', () => {
-        cy.contains('[role="button"]', 'Start Date').click();
-
         cy.get('[aria-sort="ascending"]').should('not.exist');
         cy.get('[aria-sort="descending"]').should('not.exist');
         cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
@@ -142,7 +147,6 @@ describe('ISIS - MyData Table', () => {
       });
 
       it('multiple columns', () => {
-        cy.contains('[role="button"]', 'Start Date').click();
         cy.contains('[role="button"]', 'Title').click();
         cy.contains('[role="button"]', 'Instrument').click();
 

--- a/packages/datagateway-dataview/cypress/integration/table/isis/studies.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/isis/studies.spec.ts
@@ -7,13 +7,17 @@ describe('ISIS - Studies Table', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
+
+    //Default sort
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
   it('should be able to click a facility cycle to see its landing page', () => {
     cy.get('[role="gridcell"] a').first().click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browseStudyHierarchy/instrument/1/study/4'
+      '/browseStudyHierarchy/instrument/1/study/494'
     );
   });
 
@@ -84,6 +88,11 @@ describe('ISIS - Studies Table', () => {
   });
 
   describe('should be able to sort by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date').click();
+    });
+
     it('ascending order', () => {
       cy.contains('[role="button"]', 'Name').click();
 
@@ -138,6 +147,11 @@ describe('ISIS - Studies Table', () => {
   });
 
   describe('should be able to filter by', () => {
+    beforeEach(() => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date').click();
+    });
+
     it('text', () => {
       cy.get('[aria-label="Filter by Name"]').first().type('3');
 

--- a/packages/datagateway-dataview/server/e2e-settings.json
+++ b/packages/datagateway-dataview/server/e2e-settings.json
@@ -6,9 +6,9 @@
     "datasetGetSize": false,
     "datasetGetCount": true
   },
-  "idsUrl": "https://localhost:8181/ids",
-  "apiUrl": "http://localhost:5000",
-  "downloadApiUrl": "https://localhost:8181/topcat",
+  "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
+  "apiUrl": "https://scigateway-preprod.esc.rl.ac.uk/datagateway-api",
+  "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",
   "breadcrumbs": {
     "proposal": {
       "replaceEntity": "investigation",

--- a/packages/datagateway-dataview/server/e2e-settings.json
+++ b/packages/datagateway-dataview/server/e2e-settings.json
@@ -6,9 +6,9 @@
     "datasetGetSize": false,
     "datasetGetCount": true
   },
-  "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
-  "apiUrl": "https://scigateway-preprod.esc.rl.ac.uk/datagateway-api",
-  "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",
+  "idsUrl": "https://localhost:8181/ids",
+  "apiUrl": "http://localhost:5000",
+  "downloadApiUrl": "https://localhost:8181/topcat",
   "breadcrumbs": {
     "proposal": {
       "replaceEntity": "investigation",

--- a/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
@@ -11,7 +11,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   AddToCartButton,
 } from 'datagateway-common';
@@ -35,7 +35,7 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -123,7 +123,7 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsDatasetsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsDatasetsCardView.component.test.tsx.snap
@@ -36,6 +36,7 @@ Object {
     },
     Object {
       "dataKey": "createTime",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -96,7 +97,9 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "createTime": "desc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "name",

--- a/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsProposalsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsProposalsCardView.component.test.tsx.snap
@@ -24,10 +24,13 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "title": "asc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "title",
+    "defaultSort": "asc",
     "filterComponent": [Function],
     "label": "investigations.title",
   },

--- a/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsVisitsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsVisitsCardView.component.test.tsx.snap
@@ -48,6 +48,7 @@ Object {
     },
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -82,7 +83,9 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "startDate": "desc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "visitId",

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
@@ -162,6 +162,16 @@ describe('DLS Datasets - Card View', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
@@ -11,7 +11,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   useDatasetsDatafileCount,
   AddToCartButton,
@@ -40,7 +40,7 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -150,7 +150,7 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
@@ -21,6 +21,7 @@ import ConfirmationNumberIcon from '@material-ui/icons/ConfirmationNumber';
 import DatasetDetailsPanel from '../../detailsPanels/dls/datasetDetailsPanel.component';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 
 interface DLSDatasetsCVProps {
   proposalName: string;
@@ -64,7 +65,7 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
 
   const datafileCountQueries = useDatasetsDatafileCount(data);
 
-  const title = React.useMemo(
+  const title: CardViewDetails = React.useMemo(
     () => ({
       // Provide label for filter component.
       label: t('datasets.name'),
@@ -81,7 +82,7 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
     [investigationId, proposalName, t, textFilter, view]
   );
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('datasets.details.description'),
       dataKey: 'description',
@@ -90,7 +91,7 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
     [t, textFilter]
   );
 
-  const information = React.useMemo(
+  const information: CardViewDetails[] = React.useMemo(
     () => [
       {
         icon: ConfirmationNumberIcon,
@@ -108,6 +109,7 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
@@ -133,6 +133,16 @@ describe('DLS Proposals - Card View', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"title":"asc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 
@@ -141,7 +151,7 @@ describe('DLS Proposals - Card View', () => {
     button.simulate('click');
 
     expect(history.location.search).toBe(
-      `?sort=${encodeURIComponent('{"title":"asc"}')}`
+      `?sort=${encodeURIComponent('{"title":"desc"}')}`
     );
   });
 

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
@@ -14,6 +14,7 @@ import {
 } from 'datagateway-common';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 
 const DLSProposalsCardView = (): React.ReactElement => {
   const [t] = useTranslation();
@@ -46,7 +47,7 @@ const DLSProposalsCardView = (): React.ReactElement => {
     },
   ]);
 
-  const title = React.useMemo(
+  const title: CardViewDetails = React.useMemo(
     () => ({
       label: t('investigations.title'),
       dataKey: 'title',
@@ -57,11 +58,12 @@ const DLSProposalsCardView = (): React.ReactElement => {
           view
         ),
       filterComponent: textFilter,
+      defaultSort: 'asc',
     }),
     [t, textFilter, view]
   );
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('investigations.name'),
       dataKey: 'name',

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
@@ -9,7 +9,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +25,7 @@ const DLSProposalsCardView = (): React.ReactElement => {
   );
 
   const textFilter = useTextFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -76,7 +76,7 @@ const DLSProposalsCardView = (): React.ReactElement => {
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
@@ -167,6 +167,16 @@ describe('DLS Visits - Card View', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"startDate":"desc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
@@ -27,6 +27,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { Typography } from '@material-ui/core';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 
 interface DLSVisitsCVProps {
   proposalName: string;
@@ -88,7 +89,7 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
     [proposalName, t, textFilter, view]
   );
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('investigations.details.summary'),
       dataKey: 'summary',
@@ -97,7 +98,7 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
     [t, textFilter]
   );
 
-  const information = React.useMemo(
+  const information: CardViewDetails[] = React.useMemo(
     () => [
       {
         icon: Assessment,
@@ -133,6 +134,7 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
@@ -12,7 +12,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   useInvestigationsDatasetCount,
   nestedValue,
@@ -45,7 +45,7 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -150,7 +150,7 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
@@ -21,7 +21,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   AddToCartButton,
 } from 'datagateway-common';
@@ -40,7 +40,7 @@ const InvestigationCardView = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -205,7 +205,7 @@ const InvestigationCardView = (): React.ReactElement => {
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisDatasetsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisDatasetsCardView.component.test.tsx.snap
@@ -37,6 +37,7 @@ Object {
     },
     Object {
       "dataKey": "createTime",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -71,7 +72,9 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "createTime": "desc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "name",

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisFacilityCyclesCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisFacilityCyclesCardView.component.test.tsx.snap
@@ -17,6 +17,7 @@ Object {
   "information": Array [
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -50,10 +51,13 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "startDate": "desc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "name",
+    "defaultSort": "asc",
     "filterComponent": [Function],
     "label": "facilitycycles.name",
   },

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisFacilityCyclesCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisFacilityCyclesCardView.component.test.tsx.snap
@@ -57,7 +57,6 @@ Object {
   "title": Object {
     "content": [Function],
     "dataKey": "name",
-    "defaultSort": "asc",
     "filterComponent": [Function],
     "label": "facilitycycles.name",
   },

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisInstrumentsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisInstrumentsCardView.component.test.tsx.snap
@@ -52,10 +52,13 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "fullName": "asc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "fullName",
+    "defaultSort": "asc",
     "filterComponent": [Function],
     "label": "instruments.name",
   },

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisInvestigationsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisInvestigationsCardView.component.test.tsx.snap
@@ -88,6 +88,7 @@ Object {
     },
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -122,10 +123,13 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "startDate": "desc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "title",
+    "defaultSort": "asc",
     "filterComponent": [Function],
     "label": "investigations.title",
   },

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisInvestigationsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisInvestigationsCardView.component.test.tsx.snap
@@ -129,7 +129,6 @@ Object {
   "title": Object {
     "content": [Function],
     "dataKey": "title",
-    "defaultSort": "asc",
     "filterComponent": [Function],
     "label": "investigations.title",
   },

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisStudiesCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisStudiesCardView.component.test.tsx.snap
@@ -35,6 +35,7 @@ Object {
     Object {
       "content": [Function],
       "dataKey": "studyInvestigations.investigation.startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -69,7 +70,9 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "studyInvestigations.investigation.startDate": "desc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "name",

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
@@ -199,6 +199,16 @@ describe('ISIS Datasets - Card View', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
@@ -12,7 +12,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   AddToCartButton,
   DownloadButton,
@@ -64,7 +64,7 @@ const ISISDatasetsCardView = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -185,7 +185,7 @@ const ISISDatasetsCardView = (
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import DatasetDetailsPanel from '../../detailsPanels/isis/datasetDetailsPanel.component';
 import { useHistory, useLocation } from 'react-router';
 import { Theme, createStyles, makeStyles } from '@material-ui/core';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -91,7 +92,7 @@ const ISISDatasetsCardView = (
   const instrumentChild = studyHierarchy ? 'study' : 'facilityCycle';
   const urlPrefix = `/${pathRoot}/instrument/${instrumentId}/${instrumentChild}/${instrumentChildId}/investigation/${investigationId}/dataset`;
 
-  const title = React.useMemo(
+  const title: CardViewDetails = React.useMemo(
     () => ({
       // Provide label for filter component.
       label: t('datasets.name'),
@@ -104,7 +105,7 @@ const ISISDatasetsCardView = (
     [t, textFilter, urlPrefix, view]
   );
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('datasets.details.description'),
       dataKey: 'description',
@@ -113,7 +114,7 @@ const ISISDatasetsCardView = (
     [t, textFilter]
   );
 
-  const information = React.useMemo(
+  const information: CardViewDetails[] = React.useMemo(
     () => [
       {
         icon: Save,
@@ -131,6 +132,7 @@ const ISISDatasetsCardView = (
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
@@ -154,9 +154,6 @@ describe('ISIS Facility Cycles - Card View', () => {
 
     expect(history.length).toBe(1);
     expect(replaceSpy).toHaveBeenCalledWith({
-      search: `?sort=${encodeURIComponent('{"name":"asc"}')}`,
-    });
-    expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
   });

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
@@ -36,6 +36,7 @@ describe('ISIS Facility Cycles - Card View', () => {
   let state: StateType;
   let cardData: FacilityCycle[];
   let history: History;
+  let replaceSpy: jest.SpyInstance;
 
   const createWrapper = (): ReactWrapper => {
     const store = mockStore(state);
@@ -67,6 +68,7 @@ describe('ISIS Facility Cycles - Card View', () => {
       },
     ];
     history = createMemoryHistory();
+    replaceSpy = jest.spyOn(history, 'replace');
 
     (useFacilityCycleCount as jest.Mock).mockReturnValue({
       data: 1,
@@ -144,6 +146,19 @@ describe('ISIS Facility Cycles - Card View', () => {
       .simulate('change', { target: { value: '' } });
 
     expect(history.location.search).toBe('?');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"name":"asc"}')}`,
+    });
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
+    });
   });
 
   it('updates sort query params on sort', () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
@@ -10,7 +10,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import { CalendarToday } from '@material-ui/icons';
@@ -35,7 +35,7 @@ const ISISFacilityCyclesCardView = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -96,7 +96,7 @@ const ISISFacilityCyclesCardView = (
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
@@ -16,6 +16,7 @@ import {
 import { CalendarToday } from '@material-ui/icons';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 
 interface ISISFacilityCyclesCVProps {
   instrumentId: string;
@@ -48,7 +49,7 @@ const ISISFacilityCyclesCardView = (
     parseInt(instrumentId)
   );
 
-  const title = React.useMemo(
+  const title: CardViewDetails = React.useMemo(
     () => ({
       label: t('facilitycycles.name'),
       dataKey: 'name',
@@ -59,11 +60,12 @@ const ISISFacilityCyclesCardView = (
           view
         ),
       filterComponent: textFilter,
+      defaultSort: 'asc',
     }),
     [t, textFilter, instrumentId, view]
   );
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('facilitycycles.description'),
       dataKey: 'description',
@@ -72,13 +74,14 @@ const ISISFacilityCyclesCardView = (
     [t, textFilter]
   );
 
-  const information = React.useMemo(
+  const information: CardViewDetails[] = React.useMemo(
     () => [
       {
         icon: CalendarToday,
         label: t('facilitycycles.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
@@ -60,7 +60,6 @@ const ISISFacilityCyclesCardView = (
           view
         ),
       filterComponent: textFilter,
-      defaultSort: 'asc',
     }),
     [t, textFilter, instrumentId, view]
   );

--- a/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.test.tsx
@@ -145,6 +145,16 @@ describe('ISIS Instruments - Card View', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"fullName":"asc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 
@@ -153,7 +163,7 @@ describe('ISIS Instruments - Card View', () => {
     button.simulate('click');
 
     expect(history.location.search).toBe(
-      `?sort=${encodeURIComponent('{"fullName":"asc"}')}`
+      `?sort=${encodeURIComponent('{"fullName":"desc"}')}`
     );
   });
 

--- a/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
@@ -3,7 +3,6 @@ import { Title, Link as LinkIcon } from '@material-ui/icons';
 import {
   CardView,
   Instrument,
-  Order,
   parseSearchToQuery,
   tableLink,
   useInstrumentCount,
@@ -14,6 +13,7 @@ import {
   useSort,
   useTextFilter,
 } from 'datagateway-common';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
@@ -47,7 +47,7 @@ const ISISInstrumentsCardView = (
   } = useInstrumentCount();
   const { isLoading: dataLoading, data } = useInstrumentsPaginated();
 
-  const title = React.useMemo(() => {
+  const title: CardViewDetails = React.useMemo(() => {
     const pathRoot = studyHierarchy ? 'browseStudyHierarchy' : 'browse';
     const instrumentChild = studyHierarchy ? 'study' : 'facilityCycle';
     return {
@@ -60,11 +60,11 @@ const ISISInstrumentsCardView = (
           view
         ),
       filterComponent: textFilter,
-      defaultSort: 'asc' as Order,
+      defaultSort: 'asc',
     };
   }, [t, textFilter, view, studyHierarchy]);
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('instruments.description'),
       dataKey: 'description',
@@ -73,7 +73,7 @@ const ISISInstrumentsCardView = (
     [t, textFilter]
   );
 
-  const information = React.useMemo(
+  const information: CardViewDetails[] = React.useMemo(
     () => [
       {
         icon: Title,

--- a/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
@@ -3,6 +3,7 @@ import { Title, Link as LinkIcon } from '@material-ui/icons';
 import {
   CardView,
   Instrument,
+  Order,
   parseSearchToQuery,
   tableLink,
   useInstrumentCount,
@@ -59,6 +60,7 @@ const ISISInstrumentsCardView = (
           view
         ),
       filterComponent: textFilter,
+      defaultSort: 'asc' as Order,
     };
   }, [t, textFilter, view, studyHierarchy]);
 

--- a/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
@@ -10,7 +10,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import React from 'react';
@@ -35,7 +35,7 @@ const ISISInstrumentsCardView = (
   );
 
   const textFilter = useTextFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -102,7 +102,7 @@ const ISISInstrumentsCardView = (
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
@@ -41,6 +41,7 @@ describe('ISIS Investigations - Card View', () => {
   let state: StateType;
   let cardData: Investigation[];
   let history: History;
+  let replaceSpy: jest.SpyInstance;
 
   const createWrapper = (studyHierarchy = false): ReactWrapper => {
     const store = mockStore(state);
@@ -73,6 +74,7 @@ describe('ISIS Investigations - Card View', () => {
       },
     ];
     history = createMemoryHistory();
+    replaceSpy = jest.spyOn(history, 'replace');
 
     mockStore = configureStore([thunk]);
     state = JSON.parse(
@@ -200,6 +202,19 @@ describe('ISIS Investigations - Card View', () => {
         .first()
         .prop('href')
     ).toEqual('https://doi.org/study pid');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"title":"asc"}')}`,
+    });
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
+    });
   });
 
   it('updates sort query params on sort', () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
@@ -210,9 +210,6 @@ describe('ISIS Investigations - Card View', () => {
 
     expect(history.length).toBe(1);
     expect(replaceSpy).toHaveBeenCalledWith({
-      search: `?sort=${encodeURIComponent('{"title":"asc"}')}`,
-    });
-    expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
   });

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -20,7 +20,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   ArrowTooltip,
   AddToCartButton,
@@ -67,7 +67,7 @@ const ISISInvestigationsCardView = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -229,7 +229,7 @@ const ISISInvestigationsCardView = (
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -103,7 +103,6 @@ const ISISInvestigationsCardView = (
           view
         ),
       filterComponent: textFilter,
-      defaultSort: 'asc',
     }),
     [t, textFilter, urlPrefix, view]
   );

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -31,6 +31,7 @@ import { useTranslation } from 'react-i18next';
 import InvestigationDetailsPanel from '../../detailsPanels/isis/investigationDetailsPanel.component';
 import { useHistory, useLocation } from 'react-router';
 import { Theme, createStyles, makeStyles } from '@material-ui/core';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -91,7 +92,7 @@ const ISISInvestigationsCardView = (
   const instrumentChild = studyHierarchy ? 'study' : 'facilityCycle';
   const urlPrefix = `/${pathRoot}/instrument/${instrumentId}/${instrumentChild}/${instrumentChildId}/investigation`;
 
-  const title = React.useMemo(
+  const title: CardViewDetails = React.useMemo(
     () => ({
       label: t('investigations.title'),
       dataKey: 'title',
@@ -102,11 +103,12 @@ const ISISInvestigationsCardView = (
           view
         ),
       filterComponent: textFilter,
+      defaultSort: 'asc',
     }),
     [t, textFilter, urlPrefix, view]
   );
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('investigations.details.summary'),
       dataKey: 'summary',
@@ -115,7 +117,7 @@ const ISISInvestigationsCardView = (
     [t, textFilter]
   );
 
-  const information = React.useMemo(
+  const information: CardViewDetails[] = React.useMemo(
     () => [
       {
         icon: Fingerprint,
@@ -175,6 +177,7 @@ const ISISInvestigationsCardView = (
         label: t('investigations.details.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.test.tsx
@@ -125,6 +125,18 @@ describe('ISIS Studies - Card View', () => {
     ]);
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent(
+        '{"studyInvestigations.investigation.startDate":"desc"}'
+      )}`
+    );
+  });
+
   it('updates filter query params on text filter', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
@@ -8,7 +8,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useStudiesPaginated,
   useStudyCount,
   useTextFilter,
@@ -35,7 +35,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -130,7 +130,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
@@ -17,6 +17,7 @@ import PublicIcon from '@material-ui/icons/Public';
 import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
+import { CardViewDetails } from 'datagateway-common/lib/card/cardView.component';
 
 interface ISISStudiesCVProps {
   instrumentId: string;
@@ -84,7 +85,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
     };
   }, [t, textFilter, instrumentId, view]);
 
-  const description = React.useMemo(
+  const description: CardViewDetails = React.useMemo(
     () => ({
       label: t('studies.title'),
       dataKey: 'studyInvestigations.investigation.title',
@@ -96,7 +97,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
     [t, textFilter]
   );
 
-  const information = React.useMemo(
+  const information: CardViewDetails[] = React.useMemo(
     () => [
       {
         icon: PublicIcon,
@@ -111,6 +112,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
         content: (study: Study) =>
           study.studyInvestigations?.[0]?.investigation?.startDate ?? '',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
@@ -22,7 +22,7 @@ import {
   useTextFilter,
   useDateFilter,
   ColumnType,
-  usePushSort,
+  useSort,
   useIds,
   useCart,
   useAddToCart,
@@ -109,7 +109,7 @@ const DatafileTable = (props: DatafileTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const { data: allIds } = useIds(
     'datafile',
     [
@@ -224,7 +224,7 @@ const DatafileTable = (props: DatafileTableProps): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
@@ -21,7 +21,7 @@ import {
   useTextFilter,
   useDateFilter,
   ColumnType,
-  usePushSort,
+  useSort,
   useIds,
   useCart,
   useAddToCart,
@@ -99,7 +99,7 @@ const DatasetTable = (props: DatasetTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const { data: allIds } = useIds(
     'dataset',
@@ -214,7 +214,7 @@ const DatasetTable = (props: DatasetTableProps): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatafilesTable.component.test.tsx.snap
@@ -57,6 +57,7 @@ Object {
     },
     Object {
       "dataKey": "createTime",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -87,7 +88,9 @@ Object {
   "onSort": [Function],
   "onUncheck": [MockFunction],
   "selectedRows": Array [],
-  "sort": Object {},
+  "sort": Object {
+    "createTime": "desc",
+  },
   "totalRowCount": 0,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
@@ -198,6 +198,7 @@ Object {
     },
     Object {
       "dataKey": "createTime",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -240,7 +241,9 @@ Object {
   "onSort": [Function],
   "onUncheck": [MockFunction],
   "selectedRows": Array [],
-  "sort": Object {},
+  "sort": Object {
+    "createTime": "desc",
+  },
   "totalRowCount": 0,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsMyDataTable.component.test.tsx.snap
@@ -70,6 +70,7 @@ Object {
     },
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsProposalsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsProposalsTable.component.test.tsx.snap
@@ -15,6 +15,7 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "title",
+      "defaultSort": "asc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -65,7 +66,9 @@ Object {
   ],
   "loadMoreRows": [Function],
   "onSort": [Function],
-  "sort": Object {},
+  "sort": Object {
+    "title": "asc",
+  },
   "totalRowCount": 1,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsVisitsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsVisitsTable.component.test.tsx.snap
@@ -56,6 +56,7 @@ Object {
     },
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -106,7 +107,9 @@ Object {
   "detailsPanel": [Function],
   "loadMoreRows": [Function],
   "onSort": [Function],
-  "sort": Object {},
+  "sort": Object {
+    "startDate": "desc",
+  },
   "totalRowCount": 1,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
@@ -225,6 +225,16 @@ describe('DLS datafiles table component', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -136,6 +136,7 @@ const DLSDatafilesTable = (
           return formatBytes(cellProps.cellData);
         },
         filterComponent: textFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -136,13 +136,13 @@ const DLSDatafilesTable = (
           return formatBytes(cellProps.cellData);
         },
         filterComponent: textFilter,
-        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,
         label: t('datafiles.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
     ],
     [t, dateFilter, textFilter]

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -13,7 +13,7 @@ import {
   useTextFilter,
   useDateFilter,
   ColumnType,
-  usePushSort,
+  useSort,
   useIds,
   useCart,
   useAddToCart,
@@ -51,7 +51,7 @@ const DLSDatafilesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const { data: allIds } = useIds(
     'datafile',
@@ -168,7 +168,7 @@ const DLSDatafilesTable = (
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
@@ -215,6 +215,16 @@ describe('DLS Dataset table component', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -13,7 +13,7 @@ import {
   useTextFilter,
   useDateFilter,
   ColumnType,
-  usePushSort,
+  useSort,
   useIds,
   useCart,
   useAddToCart,
@@ -50,7 +50,7 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const { data: allIds } = useIds(
     'dataset',
@@ -171,7 +171,7 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -130,6 +130,7 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.test.tsx
@@ -156,8 +156,8 @@ describe('DLS MyData table component', () => {
   it('sorts by startDate desc and filters startDate to be before the current date on load', () => {
     createWrapper();
 
-    expect(history.length).toBe(3);
-    expect(history.entries[1].search).toBe(
+    expect(history.length).toBe(2);
+    expect(history.entries[0].search).toBe(
       `?sort=${encodeURIComponent(JSON.stringify({ startDate: 'desc' }))}`
     );
     expect(history.location.search).toBe(

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -11,7 +11,7 @@ import {
   useInvestigationsDatasetCount,
   useInvestigationsInfinite,
   usePushFilters,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import React from 'react';
@@ -75,7 +75,7 @@ const DLSMyDataTable = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
 
   const loadMoreRows = React.useCallback(
@@ -155,7 +155,7 @@ const DLSMyDataTable = (): React.ReactElement => {
 
   React.useEffect(() => {
     // Sort and filter by startDate upon load.
-    if (!('startDate' in sort)) pushSort('startDate', 'desc');
+    if (!('startDate' in sort)) handleSort('startDate', 'desc', 'push');
     if (!('startDate' in filters))
       pushFilters('startDate', {
         endDate: `${new Date(Date.now()).toISOString().split('T')[0]}`,
@@ -170,7 +170,7 @@ const DLSMyDataTable = (): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       detailsPanel={VisitDetailsPanel}
       columns={columns}
     />

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -141,6 +141,7 @@ const DLSMyDataTable = (): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,
@@ -155,7 +156,6 @@ const DLSMyDataTable = (): React.ReactElement => {
 
   React.useEffect(() => {
     // Sort and filter by startDate upon load.
-    if (!('startDate' in sort)) handleSort('startDate', 'desc', 'push');
     if (!('startDate' in filters))
       pushFilters('startDate', {
         endDate: `${new Date(Date.now()).toISOString().split('T')[0]}`,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
@@ -120,7 +120,7 @@ describe('DLS Proposals table component', () => {
 
   it('calls useInvestigationsInfinite when loadMoreRows is called', () => {
     const fetchNextPage = jest.fn();
-    (useInvestigationsInfinite as jest.Mock).mockReturnValueOnce({
+    (useInvestigationsInfinite as jest.Mock).mockReturnValue({
       data: { pages: [rowData] },
       fetchNextPage,
     });
@@ -157,6 +157,16 @@ describe('DLS Proposals table component', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"title":"asc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 
@@ -167,7 +177,7 @@ describe('DLS Proposals table component', () => {
 
     expect(history.length).toBe(2);
     expect(history.location.search).toBe(
-      `?sort=${encodeURIComponent('{"title":"asc"}')}`
+      `?sort=${encodeURIComponent('{"title":"desc"}')}`
     );
   });
 

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -6,7 +6,7 @@ import {
   useInvestigationsInfinite,
   useInvestigationCount,
   parseSearchToQuery,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import React from 'react';
@@ -43,7 +43,7 @@ const DLSProposalsTable = (): React.ReactElement => {
   );
 
   const textFilter = useTextFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -89,7 +89,7 @@ const DLSProposalsTable = (): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       columns={columns}
     />
   );

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -65,6 +65,7 @@ const DLSProposalsTable = (): React.ReactElement => {
           );
         },
         filterComponent: textFilter,
+        defaultSort: 'asc',
       },
       {
         icon: TitleIcon,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.test.tsx
@@ -132,7 +132,7 @@ describe('DLS Visits table component', () => {
 
   it('calls useInvestigationsInfinite when loadMoreRows is called', () => {
     const fetchNextPage = jest.fn();
-    (useInvestigationsInfinite as jest.Mock).mockReturnValueOnce({
+    (useInvestigationsInfinite as jest.Mock).mockReturnValue({
       data: { pages: [rowData] },
       fetchNextPage,
     });
@@ -190,6 +190,16 @@ describe('DLS Visits table component', () => {
 
     expect(history.length).toBe(3);
     expect(history.location.search).toBe('?');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"startDate":"desc"}')}`
+    );
   });
 
   it('updates sort query params on sort', () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
@@ -116,6 +116,7 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
@@ -9,7 +9,7 @@ import {
   useInvestigationCount,
   useInvestigationsInfinite,
   useInvestigationsDatasetCount,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import React from 'react';
@@ -65,7 +65,7 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -133,7 +133,7 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       detailsPanel={VisitDetailsPanel}
       columns={columns}
     />

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -21,7 +21,7 @@ import {
   useAddToCart,
   useRemoveFromCart,
   parseSearchToQuery,
-  usePushSort,
+  useSort,
   useTextFilter,
   useDateFilter,
   useInvestigationsDatasetCount,
@@ -149,7 +149,7 @@ const InvestigationTable = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -259,7 +259,7 @@ const InvestigationTable = (): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
@@ -59,6 +59,7 @@ Object {
     },
     Object {
       "dataKey": "modTime",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -89,7 +90,9 @@ Object {
   "onSort": [Function],
   "onUncheck": [MockFunction],
   "selectedRows": Array [],
-  "sort": Object {},
+  "sort": Object {
+    "modTime": "desc",
+  },
   "totalRowCount": 0,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
@@ -48,6 +48,7 @@ Object {
     },
     Object {
       "dataKey": "createTime",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -90,7 +91,9 @@ Object {
   "onSort": [Function],
   "onUncheck": [MockFunction],
   "selectedRows": Array [],
-  "sort": Object {},
+  "sort": Object {
+    "createTime": "desc",
+  },
   "totalRowCount": 0,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
@@ -15,7 +15,6 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "name",
-      "defaultSort": "asc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
@@ -15,6 +15,7 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "name",
+      "defaultSort": "asc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -28,6 +29,7 @@ Object {
     },
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -64,7 +66,9 @@ Object {
   ],
   "loadMoreRows": [Function],
   "onSort": [Function],
-  "sort": Object {},
+  "sort": Object {
+    "startDate": "desc",
+  },
   "totalRowCount": 1,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInstrumentsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInstrumentsTable.component.test.tsx.snap
@@ -15,6 +15,7 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "fullName",
+      "defaultSort": "asc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -45,7 +46,9 @@ Object {
   "detailsPanel": [Function],
   "loadMoreRows": [Function],
   "onSort": [Function],
-  "sort": Object {},
+  "sort": Object {
+    "fullName": "asc",
+  },
   "totalRowCount": 1,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -21,6 +21,7 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "title",
+      "defaultSort": "asc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -89,6 +90,7 @@ Object {
     },
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -153,7 +155,9 @@ Object {
   "onSort": [Function],
   "onUncheck": [MockFunction],
   "selectedRows": Array [],
-  "sort": Object {},
+  "sort": Object {
+    "startDate": "desc",
+  },
   "totalRowCount": 0,
 }
 `;
@@ -193,7 +197,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-409"
+      className="makeStyles-root-443"
       container={true}
       direction="column"
     >
@@ -209,7 +213,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-410"
+          className="makeStyles-divider-444"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -21,7 +21,6 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "title",
-      "defaultSort": "asc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
@@ -100,6 +100,7 @@ Object {
     },
     Object {
       "dataKey": "startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -214,7 +215,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-445"
+      className="makeStyles-root-482"
       container={true}
       direction="column"
     >
@@ -230,7 +231,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-446"
+          className="makeStyles-divider-483"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
@@ -56,6 +56,7 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "studyInvestigations.investigation.startDate",
+      "defaultSort": "desc",
       "filterComponent": [Function],
       "icon": Object {
         "$$typeof": Symbol(react.memo),
@@ -93,7 +94,9 @@ Object {
   ],
   "loadMoreRows": [Function],
   "onSort": [Function],
-  "sort": Object {},
+  "sort": Object {
+    "studyInvestigations.investigation.startDate": "desc",
+  },
   "totalRowCount": 1,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
@@ -223,6 +223,16 @@ describe('ISIS datafiles table component', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"modTime":"desc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -143,6 +143,7 @@ const ISISDatafilesTable = (
         label: t('datafiles.modified_time'),
         dataKey: 'modTime',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
     ],
     [t, dateFilter, textFilter]

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -14,7 +14,7 @@ import {
   useTextFilter,
   useDateFilter,
   ColumnType,
-  usePushSort,
+  useSort,
   useIds,
   useCart,
   useAddToCart,
@@ -53,7 +53,7 @@ const ISISDatafilesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const { data: allIds } = useIds(
     'datafile',
@@ -169,7 +169,7 @@ const ISISDatafilesTable = (
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
@@ -220,6 +220,16 @@ describe('ISIS Dataset table component', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -14,7 +14,7 @@ import {
   useTextFilter,
   useDateFilter,
   ColumnType,
-  usePushSort,
+  useSort,
   useIds,
   useCart,
   useAddToCart,
@@ -67,7 +67,7 @@ const ISISDatasetsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const { data: allIds } = useIds(
     'dataset',
@@ -190,7 +190,7 @@ const ISISDatasetsTable = (
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -147,6 +147,7 @@ const ISISDatasetsTable = (
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.test.tsx
@@ -168,9 +168,6 @@ describe('ISIS FacilityCycles table component', () => {
 
     expect(history.length).toBe(1);
     expect(replaceSpy).toHaveBeenCalledWith({
-      search: `?sort=${encodeURIComponent('{"name":"asc"}')}`,
-    });
-    expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
   });

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.test.tsx
@@ -34,6 +34,7 @@ describe('ISIS FacilityCycles table component', () => {
   let state: StateType;
   let rowData: FacilityCycle[];
   let history: History;
+  let replaceSpy: jest.SpyInstance;
 
   const createWrapper = (): ReactWrapper => {
     const store = mockStore(state);
@@ -60,6 +61,7 @@ describe('ISIS FacilityCycles table component', () => {
       },
     ];
     history = createMemoryHistory();
+    replaceSpy = jest.spyOn(history, 'replace');
 
     mockStore = configureStore([thunk]);
     state = JSON.parse(
@@ -100,7 +102,7 @@ describe('ISIS FacilityCycles table component', () => {
 
   it('calls useFacilityCyclesInfinite when loadMoreRows is called', () => {
     const fetchNextPage = jest.fn();
-    (useFacilityCyclesInfinite as jest.Mock).mockReturnValueOnce({
+    (useFacilityCyclesInfinite as jest.Mock).mockReturnValue({
       data: { pages: [rowData] },
       fetchNextPage,
     });
@@ -158,6 +160,19 @@ describe('ISIS FacilityCycles table component', () => {
 
     expect(history.length).toBe(3);
     expect(history.location.search).toBe('?');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"name":"asc"}')}`,
+    });
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
+    });
   });
 
   it('updates sort query params on sort', () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -68,7 +68,6 @@ const ISISFacilityCyclesTable = (
             view
           ),
         filterComponent: textFilter,
-        defaultSort: 'asc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -4,7 +4,7 @@ import {
   parseSearchToQuery,
   useFacilityCycleCount,
   useFacilityCyclesInfinite,
-  usePushSort,
+  useSort,
   useTextFilter,
   useDateFilter,
   Table,
@@ -48,7 +48,7 @@ const ISISFacilityCyclesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const pushSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -68,12 +68,14 @@ const ISISFacilityCyclesTable = (
             view
           ),
         filterComponent: textFilter,
+        defaultSort: 'asc',
       },
       {
         icon: CalendarTodayIcon,
         label: t('facilitycycles.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.test.tsx
@@ -104,7 +104,7 @@ describe('ISIS Instruments table component', () => {
 
   it('calls useInstrumentsInfinite when loadMoreRows is called', () => {
     const fetchNextPage = jest.fn();
-    (useInstrumentsInfinite as jest.Mock).mockReturnValueOnce({
+    (useInstrumentsInfinite as jest.Mock).mockReturnValue({
       data: { pages: [rowData] },
       fetchNextPage,
     });
@@ -141,6 +141,16 @@ describe('ISIS Instruments table component', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"fullName":"asc"}')}`
+    );
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 
@@ -151,7 +161,7 @@ describe('ISIS Instruments table component', () => {
 
     expect(history.length).toBe(2);
     expect(history.location.search).toBe(
-      `?sort=${encodeURIComponent('{"fullName":"asc"}')}`
+      `?sort=${encodeURIComponent('{"fullName":"desc"}')}`
     );
   });
 

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
@@ -66,6 +66,7 @@ const ISISInstrumentsTable = (
           );
         },
         filterComponent: textFilter,
+        defaultSort: 'asc',
       },
     ];
   }, [t, textFilter, view, studyHierarchy]);

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
@@ -6,7 +6,7 @@ import {
   tableLink,
   useInstrumentCount,
   useInstrumentsInfinite,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import React from 'react';
@@ -42,7 +42,7 @@ const ISISInstrumentsTable = (
   );
 
   const textFilter = useTextFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -77,7 +77,7 @@ const ISISInstrumentsTable = (
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       detailsPanel={InstrumentDetailsPanel}
       columns={columns}
     />

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -49,6 +49,7 @@ describe('ISIS Investigations table component', () => {
   let state: StateType;
   let rowData: Investigation[];
   let history: History;
+  let replaceSpy: jest.SpyInstance;
 
   const createWrapper = (): ReactWrapper => {
     const store = mockStore(state);
@@ -102,6 +103,7 @@ describe('ISIS Investigations table component', () => {
       },
     ];
     history = createMemoryHistory();
+    replaceSpy = jest.spyOn(history, 'replace');
 
     mockStore = configureStore([thunk]);
     state = JSON.parse(
@@ -183,7 +185,7 @@ describe('ISIS Investigations table component', () => {
 
   it('calls useISISInvestigationsInfinite when loadMoreRows is called', () => {
     const fetchNextPage = jest.fn();
-    (useISISInvestigationsInfinite as jest.Mock).mockReturnValueOnce({
+    (useISISInvestigationsInfinite as jest.Mock).mockReturnValue({
       data: { pages: [rowData] },
       fetchNextPage,
     });
@@ -256,6 +258,19 @@ describe('ISIS Investigations table component', () => {
     expect(history.location.search).toBe('?');
   });
 
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"title":"asc"}')}`,
+    });
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
+    });
+  });
+
   it('updates sort query params on sort', () => {
     const wrapper = createWrapper();
 
@@ -272,7 +287,7 @@ describe('ISIS Investigations table component', () => {
 
   it('calls addToCart mutate function on unchecked checkbox click', () => {
     const addToCart = jest.fn();
-    (useAddToCart as jest.Mock).mockReturnValueOnce({
+    (useAddToCart as jest.Mock).mockReturnValue({
       mutate: addToCart,
       loading: false,
     });
@@ -284,7 +299,7 @@ describe('ISIS Investigations table component', () => {
   });
 
   it('calls removeFromCart mutate function on checked checkbox click', () => {
-    (useCart as jest.Mock).mockReturnValueOnce({
+    (useCart as jest.Mock).mockReturnValue({
       data: [
         {
           entityId: 1,
@@ -297,7 +312,7 @@ describe('ISIS Investigations table component', () => {
     });
 
     const removeFromCart = jest.fn();
-    (useRemoveFromCart as jest.Mock).mockReturnValueOnce({
+    (useRemoveFromCart as jest.Mock).mockReturnValue({
       mutate: removeFromCart,
       loading: false,
     });

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -270,9 +270,6 @@ describe('ISIS Investigations table component', () => {
 
     expect(history.length).toBe(1);
     expect(replaceSpy).toHaveBeenCalledWith({
-      search: `?sort=${encodeURIComponent('{"title":"asc"}')}`,
-    });
-    expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
   });

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -13,7 +13,7 @@ import {
   useCart,
   useDateFilter,
   useInvestigationSizes,
-  usePushSort,
+  useSort,
   useRemoveFromCart,
   useTextFilter,
   TableActionProps,
@@ -102,7 +102,7 @@ const ISISInvestigationsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -213,7 +213,7 @@ const ISISInvestigationsTable = (
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -141,7 +141,6 @@ const ISISInvestigationsTable = (
           );
         },
         filterComponent: textFilter,
-        defaultSort: 'asc',
       },
       {
         icon: FingerprintIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -141,6 +141,7 @@ const ISISInvestigationsTable = (
           );
         },
         filterComponent: textFilter,
+        defaultSort: 'asc',
       },
       {
         icon: FingerprintIcon,
@@ -194,6 +195,7 @@ const ISISInvestigationsTable = (
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
@@ -267,7 +267,7 @@ describe('ISIS MyData table component', () => {
     filterInput.instance().value = 'test';
     filterInput.simulate('change');
 
-    expect(history.length).toBe(3);
+    expect(history.length).toBe(2);
     expect(history.location.search).toBe(
       `?filters=${encodeURIComponent(
         '{"name":{"value":"test","type":"include"}}'
@@ -277,7 +277,7 @@ describe('ISIS MyData table component', () => {
     filterInput.instance().value = '';
     filterInput.simulate('change');
 
-    expect(history.length).toBe(4);
+    expect(history.length).toBe(3);
     expect(history.location.search).toBe('?');
   });
 
@@ -290,7 +290,7 @@ describe('ISIS MyData table component', () => {
     filterInput.instance().value = '2019-08-06';
     filterInput.simulate('change');
 
-    expect(history.length).toBe(3);
+    expect(history.length).toBe(2);
     expect(history.location.search).toBe(
       `?filters=${encodeURIComponent(
         '{"startDate":{"startDate":"2019-08-06"}}'
@@ -300,8 +300,18 @@ describe('ISIS MyData table component', () => {
     filterInput.instance().value = '';
     filterInput.simulate('change');
 
-    expect(history.length).toBe(4);
+    expect(history.length).toBe(3);
     expect(history.location.search).toBe('?');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"startDate":"desc"}')}`
+    );
   });
 
   it('updates sort query params on sort', () => {
@@ -312,7 +322,7 @@ describe('ISIS MyData table component', () => {
       .first()
       .simulate('click');
 
-    expect(history.length).toBe(3);
+    expect(history.length).toBe(2);
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"title":"asc"}')}`
     );

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -15,7 +15,7 @@ import {
   useInvestigationCount,
   useInvestigationsInfinite,
   useInvestigationSizes,
-  usePushSort,
+  useSort,
   useRemoveFromCart,
   useTextFilter,
 } from 'datagateway-common';
@@ -121,7 +121,7 @@ const ISISMyDataTable = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -132,7 +132,7 @@ const ISISMyDataTable = (): React.ReactElement => {
 
   React.useEffect(() => {
     // Sort and filter by startDate upon load.
-    if (!('startDate' in sort)) pushSort('startDate', 'desc');
+    if (!('startDate' in sort)) handleSort('startDate', 'desc', 'push');
     // we only want this to run on mount so ignore warning
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -286,7 +286,7 @@ const ISISMyDataTable = (): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       allIds={allIds}
       onCheck={addToCart}

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -130,13 +130,6 @@ const ISISMyDataTable = (): React.ReactElement => {
 
   const sizeQueries = useInvestigationSizes(data);
 
-  React.useEffect(() => {
-    // Sort and filter by startDate upon load.
-    if (!('startDate' in sort)) handleSort('startDate', 'desc', 'push');
-    // we only want this to run on mount so ignore warning
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const urlPrefix = React.useCallback(
     (investigationData: Investigation): string => {
       if (
@@ -268,6 +261,7 @@ const ISISMyDataTable = (): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.test.tsx
@@ -124,7 +124,7 @@ describe('ISIS Studies table component', () => {
 
   it('calls useStudiesInfinite when loadMoreRows is called', () => {
     const fetchNextPage = jest.fn();
-    (useStudiesInfinite as jest.Mock).mockReturnValueOnce({
+    (useStudiesInfinite as jest.Mock).mockReturnValue({
       data: { pages: [rowData] },
       fetchNextPage,
     });
@@ -181,6 +181,18 @@ describe('ISIS Studies table component', () => {
 
     expect(history.length).toBe(3);
     expect(history.location.search).toBe('?');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent(
+        '{"studyInvestigations.investigation.startDate":"desc"}'
+      )}`
+    );
   });
 
   it('updates sort query params on sort', () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -115,6 +115,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
           (cellProps.rowData as Study)?.studyInvestigations?.[0]?.investigation
             ?.startDate ?? '',
         filterComponent: dateFilter,
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -7,7 +7,7 @@ import {
   ColumnType,
   Study,
   useDateFilter,
-  usePushSort,
+  useSort,
   useTextFilter,
 } from 'datagateway-common';
 import React from 'react';
@@ -69,7 +69,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -134,7 +134,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       columns={columns}
     />
   );

--- a/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
@@ -14,7 +14,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   useAllFacilityCycles,
   useLuceneSearch,
@@ -74,7 +74,7 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -314,7 +314,7 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
@@ -20,7 +20,7 @@ import {
   usePushFilters,
   usePushPage,
   usePushResults,
-  usePushSort,
+  useSort,
   useTextFilter,
   useAllFacilityCycles,
   tableLink,
@@ -137,7 +137,7 @@ const InvestigationCardView = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
   const pushFilters = usePushFilters();
   const pushPage = usePushPage();
   const pushResults = usePushResults();
@@ -370,7 +370,7 @@ const InvestigationCardView = (
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilters}
-      onSort={pushSort}
+      onSort={handleSort}
       onResultsChange={pushResults}
       loadedData={!dataLoading}
       loadedCount={!countLoading}

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
@@ -25,7 +25,7 @@ import {
   useDateFilter,
   useIds,
   useLuceneSearch,
-  usePushSort,
+  useSort,
   useRemoveFromCart,
   useTextFilter,
 } from 'datagateway-common';
@@ -165,7 +165,7 @@ const DatafileSearchTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -335,7 +335,7 @@ const DatafileSearchTable = (
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       disableSelectAll={!selectAllSetting}
       allIds={allIds}

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -26,7 +26,7 @@ import {
   useDateFilter,
   useIds,
   useLuceneSearch,
-  usePushSort,
+  useSort,
   useRemoveFromCart,
   useTextFilter,
 } from 'datagateway-common';
@@ -158,7 +158,7 @@ const DatasetSearchTable = (props: DatasetTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -337,7 +337,7 @@ const DatasetSearchTable = (props: DatasetTableProps): React.ReactElement => {
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       selectedRows={selectedRows}
       disableSelectAll={!selectAllSetting}
       allIds={allIds}

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.tsx
@@ -23,7 +23,7 @@ import {
   useIds,
   useInvestigationCount,
   useInvestigationsInfinite,
-  usePushSort,
+  useSort,
   useRemoveFromCart,
   useTextFilter,
   useInvestigationsDatasetCount,
@@ -180,7 +180,7 @@ const InvestigationSearchTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = usePushSort();
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -368,7 +368,7 @@ const InvestigationSearchTable = (
       loadMoreRows={loadMoreRows}
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
-      onSort={pushSort}
+      onSort={handleSort}
       detailsPanel={InvestigationDetailsPanel}
       columns={columns}
       {...(hierarchy !== 'dls' && {


### PR DESCRIPTION
## Description
Adds sorting by default on table and card views by adding a new parameter `defaultSort` to the parameters taken by table and card components. I have also renamed the method `usePushSort` to `useSort` to resemble a previous change to `usePushView` which allows the sort parameters to be replaced in the URL to ensure back functionality works as expected. The default sorting behaviour matches that of Topcat in ISIS and DLS data views.

## Testing instructions
This is a draft as I still need to go through the e2e tests.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #931 
