### PR TITLE
Use specific DataGateway API version for CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           repository: ral-facilities/datagateway-api
           path: datagateway-api
+          ref: v1.0.1
 
       # DataGateway API file setup
       - name: Create log file
@@ -293,6 +294,7 @@ jobs:
         with:
           repository: ral-facilities/datagateway-api
           path: datagateway-api
+          ref: v1.0.1
 
       # DataGateway API file setup
       - name: Create log file
@@ -425,6 +427,7 @@ jobs:
         with:
           repository: ral-facilities/datagateway-api
           path: datagateway-api
+          ref: v1.0.1
 
       # DataGateway API file setup
       - name: Create log file


### PR DESCRIPTION
## Description
This should fix the CI issues seen earlier with 403s seen in the Cypress screenshots. A PR was merged on DataGateway API that contained a breaking change, hence causing the issue on this repo's CI.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
connect to #{issue number}
