### PR TITLE
Add message to search explaining only top 300 results are displayed (#937)

### DIFF
--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -24,7 +24,8 @@
       "ok": "OK",
       "cancel": "Cancel",
       "clear": "Clear"
-    }
+    },
+    "limited_results_message": "Please note: Only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile."
   },
   "searchPageTable": {
     "tabs_arialabel": "Search table",

--- a/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
@@ -71,7 +71,13 @@ exports[`SearchBoxContainer - Tests renders searchBoxContainer correctly 1`] = `
       </Styled(MuiBox)>
     </WithStyles(ForwardRef(Grid))>
   </WithStyles(ForwardRef(Grid))>
-  <WithStyles(ForwardRef(Typography))>
+  <WithStyles(ForwardRef(Typography))
+    style={
+      Object {
+        "margin": "10px",
+      }
+    }
+  >
     searchBox.limited_results_message
   </WithStyles(ForwardRef(Typography))>
 </div>

--- a/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
@@ -71,6 +71,9 @@ exports[`SearchBoxContainer - Tests renders searchBoxContainer correctly 1`] = `
       </Styled(MuiBox)>
     </WithStyles(ForwardRef(Grid))>
   </WithStyles(ForwardRef(Grid))>
+  <WithStyles(ForwardRef(Typography))>
+    searchBox.limited_results_message
+  </WithStyles(ForwardRef(Typography))>
 </div>
 `;
 

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Grid, Box } from '@material-ui/core';
+import { Grid, Box, Typography } from '@material-ui/core';
 
 import SelectDates from './search/datePicker.component';
 import CheckboxesGroup from './search/checkBoxes.component';
 import SearchButton from './search/searchButton.component';
 import SearchTextBox from './search/searchTextBox.component';
+import { useTranslation } from 'react-i18next';
 
 interface SearchBoxContainerProps {
   searchText: string;
@@ -17,6 +18,7 @@ const SearchBoxContainer = (
   props: SearchBoxContainerProps
 ): React.ReactElement => {
   const { searchText, initiateSearch, onSearchTextChange } = props;
+  const [t] = useTranslation();
 
   return (
     <Grid
@@ -55,6 +57,8 @@ const SearchBoxContainer = (
           </Box>
         </Grid>
       </Grid>
+
+      <Typography>{t('searchBox.limited_results_message')}</Typography>
     </Grid>
   );
 };

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -58,7 +58,9 @@ const SearchBoxContainer = (
         </Grid>
       </Grid>
 
-      <Typography>{t('searchBox.limited_results_message')}</Typography>
+      <Typography style={{ margin: '10px' }}>
+        {t('searchBox.limited_results_message')}
+      </Typography>
     </Grid>
   );
 };


### PR DESCRIPTION
## Description
Adds a message at the bottom of the search box container explaining that only the top 300 results are displayed. This message is the same as on Topcat only here it is at the top of the page instead of the bottom.

![image](https://user-images.githubusercontent.com/90245114/143020490-4a40ee0b-18f9-41de-9c92-3be33b3c4811.png)


## Testing instructions

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #937 
