### PR TITLE
Advanced search help section #939

### DIFF
--- a/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
@@ -20,6 +20,7 @@ describe('SearchBoxContainer Component', () => {
     cy.get('[aria-label="Datafile checkbox"]').should('exist');
 
     cy.get('[aria-label="Submit search"]').should('exist');
+    cy.get('[aria-label="Advanced help"]').should('exist');
   });
 
   it('should display an error when an invalid start date is entered', () => {
@@ -54,5 +55,29 @@ describe('SearchBoxContainer Component', () => {
 
     cy.get('[aria-label="Start date input"]').type('2021-11-01');
     cy.get('.MuiFormHelperText-root').contains('Invalid date range');
+  });
+
+  it('should display advanced help dialogue when advanced button is clicked', () => {
+    cy.get('[aria-label="Advanced help"]').click();
+
+    cy.get('[aria-labelledby="advanced-search-dialog-title"')
+      .contains('Advanced Search Tips')
+      .should('exist');
+
+    //Should be able to close again
+    cy.get('[aria-label="Close"]').click();
+    cy.get('[aria-labelledby="advanced-search-dialog-title"')
+      .contains('Advanced Search Tips')
+      .should('not.exist');
+
+    //Should be able to click on one of the links
+    cy.get('[aria-label="Advanced help"]').click();
+
+    cy.get('[aria-labelledby="advanced-search-dialog-title"').contains(
+      'Advanced Search Tips'
+    );
+
+    cy.get('[data-testid="advanced-help-link"]').click();
+    cy.url().should('contain', '?searchText=neutron+AND+scattering');
   });
 });

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -108,7 +108,7 @@
   },
   "advanced_search_help": {
     "advanced_button": "Advanced",
-    "advanced_button_arialabel": "Advanced",
+    "advanced_button_arialabel": "Advanced help",
     "close_button_arialabel": "Close",
     "title": "Advanced Search Tips",
     "description": "When you search for a word e.g. 'calibration', we will search for any records containing this word. But, sometimes you may wish to be more specific. Here we show you how.",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -1,6 +1,9 @@
 {
   "searchBox": {
-    "search_text": "Search Text",
+    "search_text": "Search for title, name, instrument",
+    "search_textbox_label": "e.g. title has <1>\"instrument calibration\"</1>, or <4>neutron AND scattering</4>.",
+    "search_textbox_label_link1": "?searchText=\"instrument+calibration\"",
+    "search_textbox_label_link2": "?searchText=neutron+AND+scattering",
     "start_date": "Start Date",
     "end_date": "End Date",
     "checkboxes": {
@@ -25,7 +28,7 @@
       "cancel": "Cancel",
       "clear": "Clear"
     },
-    "limited_results_message": "Please note: Only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile."
+    "limited_results_message": "Please note: Only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. Click 'Advanced' to learn more."
   },
   "searchPageTable": {
     "tabs_arialabel": "Search table",
@@ -109,12 +112,29 @@
     "close_button_arialabel": "Close",
     "title": "Advanced Search Tips",
     "description": "When you search for a word e.g. 'calibration', we will search for any records containing this word. But, sometimes you may wish to be more specific. Here we show you how.",
-    "exact_phrase_title": "Search by an exact phrase",
-    "exact_phrase_description": "Use quotation marks around a phrase to search for a precise sequence of words e.g. \"neutron scattering\".",
-    "logic_operators_title": "Using logic operators",
-    "logic_operators_description": "Find all data containing 'neutron' and 'scattering' with 'neutron <strong>AND</strong> scattering'.<br><br>Find all data containing either neutron or scattering with 'neutron <strong>OR</strong> scattering'.<br><br>Find all data that contains the phrase 'scattering' but exclude those containing 'elastic' with 'scattering <strong>NOT</strong> elastic'.<br><br>Use brackets around phrases to construct more complicated searches e.g. 'scattering <strong>NOT</strong> (elastic <strong>OR</strong> neutron)'.",
-    "wildcards_title": "Using wildcards",
-    "wildcards_description": "Use wildcards to take the place of one or more characters in a phrase.<br><br>A question mark '?' can be used to search for a phrase with one or more character missing e.g. 'te?t' will return results containing 'test' or 'text'.<br><br>An asterix '*' can be used to replace zero or more characters e.g. '*ium' will return results containing words like 'sodium' and 'vanadium'.",
+    "exact_phrase": {
+      "title": "Search by an exact phrase",
+      "description": "Use quotation marks around a phrase to search for a precise sequence of words e.g. <2>\"neutron scattering\"<2>.",
+      "link1": "?searchText=\"neutron+scattering\""
+    },
+    "logic_operators": {
+      "title": "Using logic operators",
+      "description": "Find all data containing 'neutron' and 'scattering' with <1>'neutron <strong>AND</strong> scattering'</1>.<br><br>Find all data containing either neutron or scattering with '<4>neutron <strong>OR</strong> scattering</4>'.<br><br>Find all data that contains the phrase 'scattering' but exclude those containing 'elastic' with '<7>scattering <strong>NOT</strong> elastic</7>'.<br><br>Use brackets around phrases to construct more complicated searches e.g. '<10>scattering <strong>NOT</strong> (elastic <strong>OR</strong> neutron)</10>'.",
+      "link1": "?searchText=neutron+AND+scattering",
+      "link2": "?searchText=neutron+OR+scattering",
+      "link3": "?searchText=scattering+NOT+elastic",
+      "link4": "?searchText=scattering+NOT+%28elastic+OR+neutron%29"
+    },
+    "wildcards": {
+      "title": "Using wildcards",
+      "description": "Use wildcards to take the place of one or more characters in a phrase.<br><br>A question mark '?' can be used to search for a phrase with one or more character missing e.g. '<2>te?t</2>' will return results containing 'test' or 'text'.<br><br>An asterix '*' can be used to replace zero or more characters e.g. '<4>*ium</4>' will return results containing words like 'sodium' and 'vanadium'.",
+      "link1": "?searchText=te%3Ft",
+      "link2": "?searchText=*ium"
+    },
+    "limited_search_results": {
+      "title": "Limited results",
+      "description": "Due to technical and performance reasons, only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. If you find your search gives 300 results, try using a more specific query to find what you are looking for."
+    },
     "footer": "Further information on searching can be found <2>here</2>."
   }
 }

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -102,5 +102,19 @@
   "advanced_filters": {
     "show": "Show Advanced Filters",
     "hide": "Hide Advanced Filters"
+  },
+  "advanced_search_help": {
+    "advanced_button": "Advanced",
+    "advanced_button_arialabel": "Advanced",
+    "close_button_arialabel": "Close",
+    "title": "Advanced Search Tips",
+    "description": "When you search for a word e.g. 'calibration', we will search for any records containing this word. But, sometimes you may wish to be more specific. Here we show you how.",
+    "exact_phrase_title": "Search by an exact phrase",
+    "exact_phrase_description": "Use quotation marks around a phrase to search for a precise sequence of words e.g. \"neutron scattering\".",
+    "logic_operators_title": "Using logic operators",
+    "logic_operators_description": "Find all data containing 'neutron' and 'scattering' with 'neutron <strong>AND</strong> scattering'.<br><br>Find all data containing either neutron or scattering with 'neutron <strong>OR</strong> scattering'.<br><br>Find all data that contains the phrase 'scattering' but exclude those containing 'elastic' with 'scattering <strong>NOT</strong> elastic'.<br><br>Use brackets around phrases to construct more complicated searches e.g. 'scattering <strong>NOT</strong> (elastic <strong>OR</strong> neutron)'.",
+    "wildcards_title": "Using wildcards",
+    "wildcards_description": "Use wildcards to take the place of one or more characters in a phrase.<br><br>A question mark '?' can be used to search for a phrase with one or more character missing e.g. 'te?t' will return results containing 'test' or 'text'.<br><br>An asterix '*' can be used to replace zero or more characters e.g. '*ium' will return results containing words like 'sodium' and 'vanadium'.",
+    "footer": "Further information on searching can be found <2>here</2>."
   }
 }

--- a/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
@@ -36,12 +36,69 @@ exports[`SearchBoxContainer - Tests renders searchBoxContainer correctly 1`] = `
     </Styled(MuiBox)>
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))
+    item={true}
+    style={
+      Object {
+        "display": "flex",
+      }
+    }
+  >
+    <Styled(MuiBox)
+      m="auto"
+      px={2}
+    >
+      <AdvancedHelpDialogue />
+    </Styled(MuiBox)>
+  </WithStyles(ForwardRef(Grid))>
+  <WithStyles(ForwardRef(Grid))
+    container={true}
+    item={true}
+    justify="center"
+    style={
+      Object {
+        "margin": 0,
+        "padding": 0,
+      }
+    }
+  >
+    <WithStyles(ForwardRef(Typography))
+      style={
+        Object {
+          "fontSize": "14px",
+          "margin": 0,
+          "padding": 0,
+        }
+      }
+    >
+      <Trans
+        i18nKey="searchBox.search_textbox_label"
+        t={[Function]}
+      >
+        e.g. title has
+        <WithStyles(ForwardRef(Link))
+          href="searchBox.search_textbox_label_link1"
+        >
+          "instrument calibration"
+        </WithStyles(ForwardRef(Link))>
+        , or
+         
+        <WithStyles(ForwardRef(Link))
+          href="searchBox.search_textbox_label_link2"
+        >
+          neutron AND scattering
+        </WithStyles(ForwardRef(Link))>
+        .
+      </Trans>
+    </WithStyles(ForwardRef(Typography))>
+  </WithStyles(ForwardRef(Grid))>
+  <WithStyles(ForwardRef(Grid))
     container={true}
     item={true}
     justify="center"
     style={
       Object {
         "paddingBottom": 8,
+        "paddingTop": 8,
       }
     }
   >

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
@@ -354,6 +354,7 @@ describe('Investigation - Card View', () => {
         .prop('href')
     ).toEqual('https://doi.org/doi 1');
   });
+
   it('does not render ISIS link when instrumentId cannot be found', () => {
     (useAllFacilityCycles as jest.Mock).mockReturnValue({
       data: [

--- a/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Search Button component tests renders correctly 1`] = `
+exports[`Advanced help dialogue component tests renders correctly 1`] = `
 <div>
   <WithStyles(ForwardRef(Button))
     aria-label="advanced_search_help.advanced_button_arialabel"
@@ -79,6 +79,7 @@ exports[`Search Button component tests renders correctly 1`] = `
         >
           Find all data containing 'neutron' and 'scattering' with '
           <WithStyles(ForwardRef(Link))
+            data-testid="advanced-help-link"
             href="advanced_search_help.logic_operators.link1"
           >
             neutron AND scattering

--- a/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
@@ -1,0 +1,174 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Search Button component tests renders correctly 1`] = `
+<div>
+  <WithStyles(ForwardRef(Button))
+    aria-label="advanced_search_help.advanced_button_arialabel"
+    className="makeStyles-advancedButton-2"
+    onClick={[Function]}
+    variant="text"
+  >
+    advanced_search_help.advanced_button
+  </WithStyles(ForwardRef(Button))>
+  <WithStyles(ForwardRef(Dialog))
+    PaperProps={
+      Object {
+        "className": "makeStyles-dialogueBackground-5",
+      }
+    }
+    aria-labelledby="advanced-search-dialog-title"
+    onClose={[Function]}
+    open={false}
+  >
+    <WithStyles(ForwardRef(DialogTitle))
+      className="makeStyles-root-1"
+      disableTypography={true}
+      id="advanced-search-dialog-title"
+    >
+      <WithStyles(ForwardRef(Typography))
+        variant="h6"
+      >
+        Advanced Search Tips
+      </WithStyles(ForwardRef(Typography))>
+      <WithStyles(ForwardRef(IconButton))
+        aria-label="advanced_search_help.close_button_arialabel"
+        className="makeStyles-closeButton-3"
+        onClick={[Function]}
+      >
+        <Memo(ForwardRef(CloseIcon)) />
+      </WithStyles(ForwardRef(IconButton))>
+    </WithStyles(ForwardRef(DialogTitle))>
+    <WithStyles(ForwardRef(Typography))
+      className="makeStyles-root-1"
+      gutterBottom={true}
+    >
+      advanced_search_help.description
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Paper))
+      className="makeStyles-paper-4"
+    >
+      <WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+        advanced_search_help.exact_phrase.title
+      </WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+      <WithStyles(WithStyles(ForwardRef(DialogContent)))>
+        <Trans
+          i18nKey="advanced_search_help.exact_phrase.description"
+          t={[Function]}
+        >
+          Use quotation marks around a phrase to search for a precise sequence of words e.g.
+           
+          <WithStyles(ForwardRef(Link))
+            href="advanced_search_help.exact_phrase.link1"
+          >
+            "neutron scattering"
+          </WithStyles(ForwardRef(Link))>
+          .
+        </Trans>
+      </WithStyles(WithStyles(ForwardRef(DialogContent)))>
+    </WithStyles(ForwardRef(Paper))>
+    <WithStyles(ForwardRef(Paper))
+      className="makeStyles-paper-4"
+    >
+      <WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+        advanced_search_help.logic_operators.title
+      </WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+      <WithStyles(WithStyles(ForwardRef(DialogContent)))>
+        <Trans
+          i18nKey="advanced_search_help.logic_operators.description"
+          t={[Function]}
+        >
+          Find all data containing 'neutron' and 'scattering' with '
+          <WithStyles(ForwardRef(Link))
+            href="advanced_search_help.logic_operators.link1"
+          >
+            neutron AND scattering
+          </WithStyles(ForwardRef(Link))>
+          '. Find all data containing either neutron or scattering with '
+           
+          <WithStyles(ForwardRef(Link))
+            href="advanced_search_help.logic_operators.link2"
+          >
+            neutron OR scattering
+          </WithStyles(ForwardRef(Link))>
+          '. Find all data that contains the phrase 'scattering' but exclude those containing 'elastic' with '
+           
+          <WithStyles(ForwardRef(Link))
+            href="advanced_search_help.logic_operators.link3"
+          >
+            scattering NOT elastic
+          </WithStyles(ForwardRef(Link))>
+          '. Use brackets around phrases to construct more complicated searches e.g. '
+           
+          <WithStyles(ForwardRef(Link))
+            href="advanced_search_help.logic_operators.link4"
+          >
+            scattering NOT (elastic OR neutron)
+          </WithStyles(ForwardRef(Link))>
+          '.
+        </Trans>
+      </WithStyles(WithStyles(ForwardRef(DialogContent)))>
+    </WithStyles(ForwardRef(Paper))>
+    <WithStyles(ForwardRef(Paper))
+      className="makeStyles-paper-4"
+    >
+      <WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+        advanced_search_help.wildcards.title
+      </WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+      <WithStyles(WithStyles(ForwardRef(DialogContent)))>
+        <Trans
+          i18nKey="advanced_search_help.wildcards.description"
+          t={[Function]}
+        >
+          Use wildcards to take the place of one or more characters in a phrase. A question mark '?' can be used to search for a phrase with one or more character missing e.g. '
+           
+          <WithStyles(ForwardRef(Link))
+            href="advanced_search_help.wildcards.link1"
+          >
+            te?t
+          </WithStyles(ForwardRef(Link))>
+          ' will return results containing 'test' or 'text'. An asterix '*' can be used to replace zero or more characters e.g. '
+          <WithStyles(ForwardRef(Link))
+            href="advanced_search_help.wildcards.link2"
+          >
+            *ium
+          </WithStyles(ForwardRef(Link))>
+          ' will return results containing words like 'sodium' and 'vanadium'.
+        </Trans>
+      </WithStyles(WithStyles(ForwardRef(DialogContent)))>
+    </WithStyles(ForwardRef(Paper))>
+    <WithStyles(ForwardRef(Paper))
+      className="makeStyles-paper-4"
+    >
+      <WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+        advanced_search_help.limited_search_results.title
+      </WithStyles(WithStyles(ForwardRef(DialogTitle)))>
+      <WithStyles(WithStyles(ForwardRef(DialogContent)))>
+        <Trans
+          i18nKey="advanced_search_help.limited_search_results.description"
+          t={[Function]}
+        >
+          Due to technical and performance reasons, only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. If you find your search gives 300 results, try using a more specific query to find what you are looking for.
+        </Trans>
+      </WithStyles(WithStyles(ForwardRef(DialogContent)))>
+    </WithStyles(ForwardRef(Paper))>
+    <WithStyles(ForwardRef(Typography))
+      className="makeStyles-root-1"
+      gutterBottom={true}
+    >
+      <Trans
+        i18nKey="advanced_search_help.footer"
+        t={[Function]}
+      >
+        Further information on searching can be found
+         
+        <WithStyles(ForwardRef(Link))
+          href="https://lucene.apache.org/core/4_10_2/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description"
+        >
+          here
+        </WithStyles(ForwardRef(Link))>
+        .
+      </Trans>
+    </WithStyles(ForwardRef(Typography))>
+  </WithStyles(ForwardRef(Dialog))>
+</div>
+`;

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { createShallow, createMount } from '@material-ui/core/test-utils';
+import AdvancedHelpDialogue from './advancedHelpDialogue';
+
+describe('Search Button component tests', () => {
+  let shallow;
+  let mount;
+
+  beforeEach(() => {
+    shallow = createShallow({ untilSelector: 'div' });
+    mount = createMount();
+  });
+
+  it('renders correctly', () => {
+    const wrapper = shallow(<AdvancedHelpDialogue />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('opens help dialogue when button clicked', () => {
+    const wrapper = mount(<AdvancedHelpDialogue />);
+    wrapper
+      .find('[aria-label="advanced_search_help.advanced_button_arialabel"]')
+      .first()
+      .simulate('click');
+    expect(
+      wrapper
+        .find('[aria-labelledby="advanced-search-dialog-title"]')
+        .first()
+        .prop('open')
+    ).toBe(true);
+  });
+});

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import AdvancedHelpDialogue from './advancedHelpDialogue';
 
-describe('Search Button component tests', () => {
+describe('Advanced help dialogue component tests', () => {
   let shallow;
   let mount;
 
@@ -16,7 +16,7 @@ describe('Search Button component tests', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('opens help dialogue when button clicked', () => {
+  it('can open and close help dialogue', () => {
     const wrapper = mount(<AdvancedHelpDialogue />);
     wrapper
       .find('[aria-label="advanced_search_help.advanced_button_arialabel"]')
@@ -28,5 +28,15 @@ describe('Search Button component tests', () => {
         .first()
         .prop('open')
     ).toBe(true);
+    wrapper
+      .find('[aria-label="advanced_search_help.close_button_arialabel"]')
+      .first()
+      .simulate('click');
+    expect(
+      wrapper
+        .find('[aria-labelledby="advanced-search-dialog-title"]')
+        .first()
+        .prop('open')
+    ).toBe(false);
   });
 });

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -131,7 +131,10 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
             >
               Find all data containing &#39;neutron&#39; and
               &#39;scattering&#39; with &#39;
-              <Link href={t('advanced_search_help.logic_operators.link1')}>
+              <Link
+                data-testid="advanced-help-link"
+                href={t('advanced_search_help.logic_operators.link1')}
+              >
                 neutron AND scattering
               </Link>
               &#39;. Find all data containing either neutron or scattering with

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -44,13 +44,13 @@ const useStyles = makeStyles((theme: Theme) => {
   });
 });
 
-const DialogContent = withStyles((theme: Theme) => ({
+const DialogueContent = withStyles((theme: Theme) => ({
   root: {
     padding: theme.spacing(2),
   },
 }))(MuiDialogContent);
 
-const DialogHeading = withStyles((theme: Theme) => ({
+const DialogueHeading = withStyles((theme: Theme) => ({
   root: {
     padding: theme.spacing(2),
   },
@@ -103,10 +103,10 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
           {t('advanced_search_help.description')}
         </Typography>
         <Paper className={classes.paper}>
-          <DialogHeading>
+          <DialogueHeading>
             {t('advanced_search_help.exact_phrase.title')}
-          </DialogHeading>
-          <DialogContent>
+          </DialogueHeading>
+          <DialogueContent>
             <Trans
               t={t}
               i18nKey="advanced_search_help.exact_phrase.description"
@@ -118,13 +118,13 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               </Link>
               .
             </Trans>
-          </DialogContent>
+          </DialogueContent>
         </Paper>
         <Paper className={classes.paper}>
-          <DialogHeading>
+          <DialogueHeading>
             {t('advanced_search_help.logic_operators.title')}
-          </DialogHeading>
-          <DialogContent>
+          </DialogueHeading>
+          <DialogueContent>
             <Trans
               t={t}
               i18nKey="advanced_search_help.logic_operators.description"
@@ -151,13 +151,13 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               </Link>
               &#39;.
             </Trans>
-          </DialogContent>
+          </DialogueContent>
         </Paper>
         <Paper className={classes.paper}>
-          <DialogHeading>
+          <DialogueHeading>
             {t('advanced_search_help.wildcards.title')}
-          </DialogHeading>
-          <DialogContent>
+          </DialogueHeading>
+          <DialogueContent>
             <Trans t={t} i18nKey="advanced_search_help.wildcards.description">
               Use wildcards to take the place of one or more characters in a
               phrase. A question mark &#39;?&#39; can be used to search for a
@@ -170,18 +170,23 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               &#39; will return results containing words like &#39;sodium&#39;
               and &#39;vanadium&#39;.
             </Trans>
-          </DialogContent>
+          </DialogueContent>
         </Paper>
         <Paper className={classes.paper}>
-          <DialogHeading>
+          <DialogueHeading>
             {t('advanced_search_help.limited_search_results.title')}
-          </DialogHeading>
-          <DialogContent>
+          </DialogueHeading>
+          <DialogueContent>
             <Trans
               t={t}
               i18nKey="advanced_search_help.limited_search_results.description"
-            />
-          </DialogContent>
+            >
+              Due to technical and performance reasons, only the top 300 results
+              will be displayed for each entity type i.e. Investigation, Dataset
+              or Datafile. If you find your search gives 300 results, try using
+              a more specific query to find what you are looking for.
+            </Trans>
+          </DialogueContent>
         </Paper>
         <Typography className={classes.root} gutterBottom>
           <Trans t={t} i18nKey="advanced_search_help.footer">

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -104,29 +104,83 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
         </Typography>
         <Paper className={classes.paper}>
           <DialogHeading>
-            {t('advanced_search_help.exact_phrase_title')}
-          </DialogHeading>
-          <DialogContent>
-            {t('advanced_search_help.exact_phrase_description')}
-          </DialogContent>
-        </Paper>
-        <Paper className={classes.paper}>
-          <DialogHeading>
-            {t('advanced_search_help.logic_operators_title')}
+            {t('advanced_search_help.exact_phrase.title')}
           </DialogHeading>
           <DialogContent>
             <Trans
               t={t}
-              i18nKey="advanced_search_help.logic_operators_description"
-            />
+              i18nKey="advanced_search_help.exact_phrase.description"
+            >
+              Use quotation marks around a phrase to search for a precise
+              sequence of words e.g.{' '}
+              <Link href={t('advanced_search_help.exact_phrase.link1')}>
+                &quot;neutron scattering&quot;
+              </Link>
+              .
+            </Trans>
           </DialogContent>
         </Paper>
         <Paper className={classes.paper}>
           <DialogHeading>
-            {t('advanced_search_help.wildcards_title')}
+            {t('advanced_search_help.logic_operators.title')}
           </DialogHeading>
           <DialogContent>
-            <Trans t={t} i18nKey="advanced_search_help.wildcards_description" />
+            <Trans
+              t={t}
+              i18nKey="advanced_search_help.logic_operators.description"
+            >
+              Find all data containing &#39;neutron&#39; and
+              &#39;scattering&#39; with &#39;
+              <Link href={t('advanced_search_help.logic_operators.link1')}>
+                neutron AND scattering
+              </Link>
+              &#39;. Find all data containing either neutron or scattering with
+              &#39;{' '}
+              <Link href={t('advanced_search_help.logic_operators.link2')}>
+                neutron OR scattering
+              </Link>
+              &#39;. Find all data that contains the phrase &#39;scattering&#39;
+              but exclude those containing &#39;elastic&#39; with &#39;{' '}
+              <Link href={t('advanced_search_help.logic_operators.link3')}>
+                scattering NOT elastic
+              </Link>
+              &#39;. Use brackets around phrases to construct more complicated
+              searches e.g. &#39;{' '}
+              <Link href={t('advanced_search_help.logic_operators.link4')}>
+                scattering NOT (elastic OR neutron)
+              </Link>
+              &#39;.
+            </Trans>
+          </DialogContent>
+        </Paper>
+        <Paper className={classes.paper}>
+          <DialogHeading>
+            {t('advanced_search_help.wildcards.title')}
+          </DialogHeading>
+          <DialogContent>
+            <Trans t={t} i18nKey="advanced_search_help.wildcards.description">
+              Use wildcards to take the place of one or more characters in a
+              phrase. A question mark &#39;?&#39; can be used to search for a
+              phrase with one or more character missing e.g. &#39;{' '}
+              <Link href={t('advanced_search_help.wildcards.link1')}>te?t</Link>
+              &#39; will return results containing &#39;test&#39; or
+              &#39;text&#39;. An asterix &#39;*&#39; can be used to replace zero
+              or more characters e.g. &#39;
+              <Link href={t('advanced_search_help.wildcards.link2')}>*ium</Link>
+              &#39; will return results containing words like &#39;sodium&#39;
+              and &#39;vanadium&#39;.
+            </Trans>
+          </DialogContent>
+        </Paper>
+        <Paper className={classes.paper}>
+          <DialogHeading>
+            {t('advanced_search_help.limited_search_results.title')}
+          </DialogHeading>
+          <DialogContent>
+            <Trans
+              t={t}
+              i18nKey="advanced_search_help.limited_search_results.description"
+            />
           </DialogContent>
         </Paper>
         <Typography className={classes.root} gutterBottom>

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -29,9 +29,12 @@ const useStyles = makeStyles((theme: Theme) => {
     paper: {
       margin: theme.spacing(2),
       padding: theme.spacing(2),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      backgroundColor: (theme as any).colours?.paper,
     },
     dialogueBackground: {
-      backgroundColor: theme.palette.grey[200],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      backgroundColor: (theme as any).colours?.background,
     },
   });
 });
@@ -101,27 +104,37 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
         <Paper className={classes.paper}>
           <DialogHeading>Using logic operators</DialogHeading>
           <DialogContent>
-            Use <b>AND</b> to search for records containing more than one phrase
-            e.g. &#39;neutron <b>AND</b> scattering&#39;.
+            Find all data containing &#39;neutron&#39; and &#39;scattering&#39;
+            with &#39;neutron <b>AND</b> scattering&#39;.
           </DialogContent>
           <DialogContent>
-            Use <b>OR</b> to search for records containing either one phrase or
-            another e.g. &#39;neutron <b>OR</b> scattering&#39;.
+            Find all data containing either neutron or scattering with
+            &#39;neutron <b>OR</b> scattering&#39;
           </DialogContent>
           <DialogContent>
-            Use <b>NOT</b> to exclude records containing a word or phrase e.g.
-            &#39;scattering <b>NOT</b> elastic&#39;.
+            Find all data that contains the phrase &#39;scattering&#39; but
+            exclude those containing &#39;elastic&#39; with &#39;scattering{' '}
+            <b>NOT</b> elastic&#39;.
           </DialogContent>
           <DialogContent>
-            Use brackets around a phrases to construct more complicated searches
+            Use brackets around phrases to construct more complicated searches
             e.g. &#39;scattering <b>NOT</b> (elastic <b>OR</b> neutron)&#39;.
           </DialogContent>
         </Paper>
         <Paper className={classes.paper}>
           <DialogHeading>Wildcards</DialogHeading>
           <DialogContent>
+            Use wildcards to take the place of one or more characters in a
+            phrase.
+          </DialogContent>
+          <DialogContent>
             {
-              "Use wildcards to take the place of one or more characters in a phrase. A question mark '?' for example can be used to search for a phrase with one or more character missing e.g. 'te?t' will return results containing 'test' or 'text'. Similarly the asterix '*' can be used to replace zero or more characters e.g. 'test*' will return results containing either 'test' or 'tests'."
+              "A question mark '?' can be used to search for a phrase with one or more character missing e.g. 'te?t' will return results containing 'test' or 'text'."
+            }
+          </DialogContent>
+          <DialogContent>
+            {
+              "An asterix '*' can be used to replace zero or more characters e.g. 'test*' will return results containing either 'test' or 'tests'."
             }
           </DialogContent>
         </Paper>

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  createStyles,
+  makeStyles,
+  Theme,
+  withStyles,
+} from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import MuiDialogTitle from '@material-ui/core/DialogTitle';
+import MuiDialogContent from '@material-ui/core/DialogContent';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => {
+  return createStyles({
+    root: {
+      margin: 0,
+      padding: theme.spacing(2),
+    },
+    closeButton: {
+      position: 'absolute',
+      right: theme.spacing(1),
+      top: theme.spacing(1),
+      color: theme.palette.grey[500],
+    },
+  });
+});
+
+const DialogContent = withStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2),
+  },
+}))(MuiDialogContent);
+
+const AdvancedHelpDialogue = (): React.ReactElement => {
+  const [open, setOpen] = React.useState(false);
+  const classes = useStyles();
+
+  const handleClickOpen = (): void => {
+    setOpen(true);
+  };
+
+  const handleClose = (): void => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <Button variant="text" color="primary" onClick={handleClickOpen}>
+        Advanced
+      </Button>
+      <Dialog
+        onClose={handleClose}
+        aria-labelledby="advanced-search-dialog-title"
+        open={open}
+      >
+        <MuiDialogTitle
+          disableTypography
+          className={classes.root}
+          id="advanced-search-dialog-title"
+        >
+          <Typography variant="h6">Advanced Search Tips</Typography>
+          <IconButton
+            aria-label="close"
+            className={classes.closeButton}
+            onClick={handleClose}
+          >
+            <CloseIcon />
+          </IconButton>
+        </MuiDialogTitle>
+        <DialogContent dividers>
+          <Typography gutterBottom>This is a test.</Typography>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default AdvancedHelpDialogue;

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -13,12 +13,17 @@ import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import Typography from '@material-ui/core/Typography';
 import { Link, Paper } from '@material-ui/core';
+import { Trans, useTranslation } from 'react-i18next';
 
 const useStyles = makeStyles((theme: Theme) => {
   return createStyles({
     root: {
       margin: 0,
       padding: theme.spacing(2),
+    },
+    advancedButton: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      color: (theme as any).colours?.blue,
     },
     closeButton: {
       position: 'absolute',
@@ -54,6 +59,7 @@ const DialogHeading = withStyles((theme: Theme) => ({
 const AdvancedHelpDialogue = (): React.ReactElement => {
   const [open, setOpen] = React.useState(false);
   const classes = useStyles();
+  const [t] = useTranslation();
 
   const handleClickOpen = (): void => {
     setOpen(true);
@@ -65,8 +71,13 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
 
   return (
     <div>
-      <Button variant="text" color="primary" onClick={handleClickOpen}>
-        Advanced
+      <Button
+        variant="text"
+        className={classes.advancedButton}
+        aria-label={t('advanced_search_help.advanced_button_arialabel')}
+        onClick={handleClickOpen}
+      >
+        {t('advanced_search_help.advanced_button')}
       </Button>
       <Dialog
         onClose={handleClose}
@@ -81,7 +92,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
         >
           <Typography variant="h6">Advanced Search Tips</Typography>
           <IconButton
-            aria-label="close"
+            aria-label={t('advanced_search_help.close_button_arialabel')}
             className={classes.closeButton}
             onClick={handleClose}
           >
@@ -89,61 +100,43 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
           </IconButton>
         </MuiDialogTitle>
         <Typography className={classes.root} gutterBottom>
-          {
-            "When you search for a word e.g. 'calibration', we will search for any records containing this word. But, sometimes you may wish to be more specific. Here we show you how."
-          }
+          {t('advanced_search_help.description')}
         </Typography>
         <Paper className={classes.paper}>
-          <DialogHeading>Search by an exact phrase</DialogHeading>
+          <DialogHeading>
+            {t('advanced_search_help.exact_phrase_title')}
+          </DialogHeading>
           <DialogContent>
-            {
-              'Use quotation marks around a phrase to search for a precise sequence of words e.g. "neutron scattering".'
-            }
+            {t('advanced_search_help.exact_phrase_description')}
           </DialogContent>
         </Paper>
         <Paper className={classes.paper}>
-          <DialogHeading>Using logic operators</DialogHeading>
+          <DialogHeading>
+            {t('advanced_search_help.logic_operators_title')}
+          </DialogHeading>
           <DialogContent>
-            Find all data containing &#39;neutron&#39; and &#39;scattering&#39;
-            with &#39;neutron <b>AND</b> scattering&#39;.
-          </DialogContent>
-          <DialogContent>
-            Find all data containing either neutron or scattering with
-            &#39;neutron <b>OR</b> scattering&#39;
-          </DialogContent>
-          <DialogContent>
-            Find all data that contains the phrase &#39;scattering&#39; but
-            exclude those containing &#39;elastic&#39; with &#39;scattering{' '}
-            <b>NOT</b> elastic&#39;.
-          </DialogContent>
-          <DialogContent>
-            Use brackets around phrases to construct more complicated searches
-            e.g. &#39;scattering <b>NOT</b> (elastic <b>OR</b> neutron)&#39;.
+            <Trans
+              t={t}
+              i18nKey="advanced_search_help.logic_operators_description"
+            />
           </DialogContent>
         </Paper>
         <Paper className={classes.paper}>
-          <DialogHeading>Wildcards</DialogHeading>
+          <DialogHeading>
+            {t('advanced_search_help.wildcards_title')}
+          </DialogHeading>
           <DialogContent>
-            Use wildcards to take the place of one or more characters in a
-            phrase.
-          </DialogContent>
-          <DialogContent>
-            {
-              "A question mark '?' can be used to search for a phrase with one or more character missing e.g. 'te?t' will return results containing 'test' or 'text'."
-            }
-          </DialogContent>
-          <DialogContent>
-            {
-              "An asterix '*' can be used to replace zero or more characters e.g. 'test*' will return results containing either 'test' or 'tests'."
-            }
+            <Trans t={t} i18nKey="advanced_search_help.wildcards_description" />
           </DialogContent>
         </Paper>
         <Typography className={classes.root} gutterBottom>
-          Further information on searching can be found{' '}
-          <Link href="https://lucene.apache.org/core/4_10_2/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description">
-            here
-          </Link>
-          .
+          <Trans t={t} i18nKey="advanced_search_help.footer">
+            Further information on searching can be found{' '}
+            <Link href="https://lucene.apache.org/core/4_10_2/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description">
+              here
+            </Link>
+            .
+          </Trans>
         </Typography>
       </Dialog>
     </div>

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -12,6 +12,7 @@ import MuiDialogContent from '@material-ui/core/DialogContent';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import Typography from '@material-ui/core/Typography';
+import { Link, Paper } from '@material-ui/core';
 
 const useStyles = makeStyles((theme: Theme) => {
   return createStyles({
@@ -25,6 +26,13 @@ const useStyles = makeStyles((theme: Theme) => {
       top: theme.spacing(1),
       color: theme.palette.grey[500],
     },
+    paper: {
+      margin: theme.spacing(2),
+      padding: theme.spacing(2),
+    },
+    dialogueBackground: {
+      backgroundColor: theme.palette.grey[200],
+    },
   });
 });
 
@@ -33,6 +41,12 @@ const DialogContent = withStyles((theme: Theme) => ({
     padding: theme.spacing(2),
   },
 }))(MuiDialogContent);
+
+const DialogHeading = withStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2),
+  },
+}))(MuiDialogTitle);
 
 const AdvancedHelpDialogue = (): React.ReactElement => {
   const [open, setOpen] = React.useState(false);
@@ -55,6 +69,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
         onClose={handleClose}
         aria-labelledby="advanced-search-dialog-title"
         open={open}
+        PaperProps={{ className: classes.dialogueBackground }}
       >
         <MuiDialogTitle
           disableTypography
@@ -70,9 +85,53 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
             <CloseIcon />
           </IconButton>
         </MuiDialogTitle>
-        <DialogContent dividers>
-          <Typography gutterBottom>This is a test.</Typography>
-        </DialogContent>
+        <Typography className={classes.root} gutterBottom>
+          {
+            "When you search for a word e.g. 'calibration', we will search for any records containing this word. But, sometimes you may wish to be more specific. Here we show you how."
+          }
+        </Typography>
+        <Paper className={classes.paper}>
+          <DialogHeading>Search by an exact phrase</DialogHeading>
+          <DialogContent>
+            {
+              'Use quotation marks around a phrase to search for a precise sequence of words e.g. "neutron scattering".'
+            }
+          </DialogContent>
+        </Paper>
+        <Paper className={classes.paper}>
+          <DialogHeading>Using logic operators</DialogHeading>
+          <DialogContent>
+            Use <b>AND</b> to search for records containing more than one phrase
+            e.g. &#39;neutron <b>AND</b> scattering&#39;.
+          </DialogContent>
+          <DialogContent>
+            Use <b>OR</b> to search for records containing either one phrase or
+            another e.g. &#39;neutron <b>OR</b> scattering&#39;.
+          </DialogContent>
+          <DialogContent>
+            Use <b>NOT</b> to exclude records containing a word or phrase e.g.
+            &#39;scattering <b>NOT</b> elastic&#39;.
+          </DialogContent>
+          <DialogContent>
+            Use brackets around a phrases to construct more complicated searches
+            e.g. &#39;scattering <b>NOT</b> (elastic <b>OR</b> neutron)&#39;.
+          </DialogContent>
+        </Paper>
+        <Paper className={classes.paper}>
+          <DialogHeading>Wildcards</DialogHeading>
+          <DialogContent>
+            {
+              "Use wildcards to take the place of one or more characters in a phrase. A question mark '?' for example can be used to search for a phrase with one or more character missing e.g. 'te?t' will return results containing 'test' or 'text'. Similarly the asterix '*' can be used to replace zero or more characters e.g. 'test*' will return results containing either 'test' or 'tests'."
+            }
+          </DialogContent>
+        </Paper>
+        <Typography className={classes.root} gutterBottom>
+          Further information on searching can be found{' '}
+          <Link href="https://lucene.apache.org/core/4_10_2/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description">
+            here
+          </Link>
+          .
+        </Typography>
       </Dialog>
     </div>
   );

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { Grid, Box, Typography } from '@material-ui/core';
+import { Grid, Box, Typography, Link } from '@material-ui/core';
 
 import SelectDates from './search/datePicker.component';
 import CheckboxesGroup from './search/checkBoxes.component';
 import SearchButton from './search/searchButton.component';
 import SearchTextBox from './search/searchTextBox.component';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import AdvancedHelpDialogue from './search/advancedHelpDialogue';
 
 interface SearchBoxContainerProps {
@@ -51,7 +51,28 @@ const SearchBoxContainer = (
         </Box>
       </Grid>
 
-      <Grid container item justify="center" style={{ paddingBottom: 8 }}>
+      <Grid container item justify="center" style={{ padding: 0, margin: 0 }}>
+        <Typography style={{ fontSize: '14px', padding: 0, margin: 0 }}>
+          <Trans t={t} i18nKey="searchBox.search_textbox_label">
+            e.g. title has
+            <Link href={t('searchBox.search_textbox_label_link1')}>
+              &quot;instrument calibration&quot;
+            </Link>
+            , or{' '}
+            <Link href={t('searchBox.search_textbox_label_link2')}>
+              neutron AND scattering
+            </Link>
+            .
+          </Trans>
+        </Typography>
+      </Grid>
+
+      <Grid
+        container
+        item
+        justify="center"
+        style={{ paddingBottom: 8, paddingTop: 8 }}
+      >
         <Grid item style={{ display: 'flex' }}>
           <Box m="auto">
             <CheckboxesGroup />

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -7,6 +7,7 @@ import CheckboxesGroup from './search/checkBoxes.component';
 import SearchButton from './search/searchButton.component';
 import SearchTextBox from './search/searchTextBox.component';
 import { useTranslation } from 'react-i18next';
+import AdvancedHelpDialogue from './search/advancedHelpDialogue';
 
 interface SearchBoxContainerProps {
   searchText: string;
@@ -41,6 +42,12 @@ const SearchBoxContainer = (
       <Grid item style={{ display: 'flex' }}>
         <Box px={2} m="auto">
           <SearchButton initiateSearch={initiateSearch} />
+        </Box>
+      </Grid>
+
+      <Grid item style={{ display: 'flex' }}>
+        <Box px={2} m="auto">
+          <AdvancedHelpDialogue />
         </Box>
       </Grid>
 


### PR DESCRIPTION
## Description
Adds an 'Advanced' button that opens a dialogue explaining some methods of searching as well as expanding on the maximum limit of 300 returned results. This also adds text below the search box with example searches. All examples presented are clickable and take the user to that particular search. The messages and links are configurable via the `default.json` language file.

Here are some screenshots:

![image](https://user-images.githubusercontent.com/90245114/143556760-b59ac396-54d0-4d4b-b68b-6b64834ed024.png)
![image](https://user-images.githubusercontent.com/90245114/143556443-2fd52025-03aa-4de9-9f24-6d67b744a45c.png)
![image](https://user-images.githubusercontent.com/90245114/143556496-9f7ed000-6c2d-44c2-991c-d0096b38b17a.png)

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #939 
