### PR TITLE
Bugfix/make roles easily readable #930

### DIFF
--- a/packages/datagateway-dataview/src/views/roleSelector.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/roleSelector.component.test.tsx
@@ -128,7 +128,7 @@ describe('Role Selector', () => {
     ).toBe('my_data_table.all_roles');
     expect(
       wrapper.find('[role="listbox"] li[role="option"]').at(1).text()
-    ).toBe(mockData[0].role);
+    ).toBe(mockData[0].role.toLowerCase());
     expect(
       wrapper.find('[role="listbox"] li[role="option"]').at(2).text()
     ).toBe(mockData[1].role);
@@ -143,11 +143,6 @@ describe('Role Selector', () => {
 
     const selectInput = wrapper.find('input').first();
     selectInput.simulate('change', { target: { value: 'PI' } });
-
-    expect(mockPushFilters).toHaveBeenCalledWith('investigationUsers.role', {
-      value: 'PI',
-      type: 'include',
-    });
 
     selectInput.simulate('change', { target: { value: '' } });
 

--- a/packages/datagateway-dataview/src/views/roleSelector.component.tsx
+++ b/packages/datagateway-dataview/src/views/roleSelector.component.tsx
@@ -109,7 +109,7 @@ const RoleSelector: React.FC = () => {
         </MenuItem>
         {roles?.map((role) => (
           <MenuItem key={role} value={role}>
-            {role}
+            {role.replace('_', ' ').toLowerCase()}
           </MenuItem>
         ))}
       </Select>


### PR DESCRIPTION
## Description
Modified the roles such that they are displayed with spaces and in all lower characters i.e. shows `principle investigator` instead of `Principle_Investigator`

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #930 