### PR TITLE
Display No publications if there are no publications #982

### DIFF
--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -98,7 +98,8 @@
       },
       "publications": {
         "label": "Publications",
-        "reference": "Reference"
+        "reference": "Reference",
+        "no_publications": "No publications"
       },
       "type": {
         "id": "Type ID"

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.test.tsx
@@ -117,6 +117,16 @@ describe('Visit details panel component', () => {
     expect(wrapper.find('VisitDetailsPanel').props()).toMatchSnapshot();
   });
 
+  it('renders publication tab and text " NO publications" when no data is prsent', () => {
+    rowData.publications = [];
+    const wrapper = createWrapper();
+    expect(
+      wrapper
+        .find('[data-testid="visit-details-panel-no-publications"]')
+        .exists()
+    ).toBeTruthy();
+  });
+
   it('calls useInvestigationDetails and useInvestigationSize hooks on load', () => {
     createWrapper();
     expect(useInvestigationDetails).toHaveBeenCalledWith(rowData.id);

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -253,18 +253,24 @@ const VisitDetailsPanel = (
           hidden={value !== 'publications'}
         >
           <Grid container className={classes.root} direction="column">
-            {investigationData.publications.map((publication) => {
-              return (
-                <Grid key={publication.id} item xs>
-                  <Typography variant="overline">
-                    {t('investigations.details.publications.reference')}
-                  </Typography>
-                  <Typography>
-                    <b>{publication.fullReference}</b>
-                  </Typography>
-                </Grid>
-              );
-            })}
+            {investigationData.publications.length > 0 ? (
+              investigationData.publications.map((publication) => {
+                return (
+                  <Grid key={publication.id} item xs>
+                    <Typography variant="overline">
+                      {t('investigations.details.publications.reference')}
+                    </Typography>
+                    <Typography>
+                      <b>{publication.fullReference}</b>
+                    </Typography>
+                  </Grid>
+                );
+              })
+            ) : (
+              <Typography data-testid="visit-details-panel-no-publications">
+                {t('investigations.details.publications.no_publications')}
+              </Typography>
+            )}
           </Grid>
         </div>
       )}

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
@@ -118,6 +118,16 @@ describe('Investigation details panel component', () => {
     expect(wrapper.find('InvestigationDetailsPanel').props()).toMatchSnapshot();
   });
 
+  it('renders publication tab and text " NO publications" when no data is prsent', () => {
+    rowData.publications = [];
+    const wrapper = createWrapper();
+    expect(
+      wrapper
+        .find('[data-testid="visit-details-panel-no-publications"]')
+        .exists()
+    ).toBeTruthy();
+  });
+
   it('calls useInvestigationDetails hook on load', () => {
     createWrapper();
     expect(useInvestigationDetails).toHaveBeenCalledWith(rowData.id);

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
@@ -273,18 +273,24 @@ const InvestigationDetailsPanel = (
           hidden={value !== 'publications'}
         >
           <Grid container className={classes.root} direction="column">
-            {investigationData.publications.map((publication) => {
-              return (
-                <Grid key={publication.id} item xs>
-                  <Typography variant="overline">
-                    {t('investigations.details.publications.reference')}
-                  </Typography>
-                  <Typography>
-                    <b>{publication.fullReference}</b>
-                  </Typography>
-                </Grid>
-              );
-            })}
+            {investigationData.publications.length > 0 ? (
+              investigationData.publications.map((publication) => {
+                return (
+                  <Grid key={publication.id} item xs>
+                    <Typography variant="overline">
+                      {t('investigations.details.publications.reference')}
+                    </Typography>
+                    <Typography>
+                      <b>{publication.fullReference}</b>
+                    </Typography>
+                  </Grid>
+                );
+              })
+            ) : (
+              <Typography data-testid="visit-details-panel-no-publications">
+                {t('investigations.details.publications.no_publications')}
+              </Typography>
+            )}
           </Grid>
         </div>
       )}


### PR DESCRIPTION
## Description
Adding functinailty to allow the Publications tab to have "No publications" when they arent any publications.

## Testing instructions
Test this issue pointing at isis data as preprod data always has publications 

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #982
