### PR TITLE
Use react-router links and remove unnecessary aria labels on homepage (#988)

### DIFF
--- a/packages/datagateway-common/src/homePage/__snapshots__/homePage.component.test.tsx.snap
+++ b/packages/datagateway-common/src/homePage/__snapshots__/homePage.component.test.tsx.snap
@@ -104,9 +104,23 @@ exports[`Home page component homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home_page.browse.button_arialabel"
                 color="primary"
-                href="home_page.browse.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="browse-button"
+                to="home_page.browse.link"
                 variant="contained"
               >
                 home_page.browse.button
@@ -167,9 +181,23 @@ exports[`Home page component homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home_page.search.button_arialabel"
                 color="primary"
-                href="home_page.search.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="search-button"
+                to="home_page.search.link"
                 variant="contained"
               >
                 home_page.search.button
@@ -213,9 +241,23 @@ exports[`Home page component homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home_page.download.button_arialabel"
                 color="primary"
-                href="home_page.download.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="download-button"
+                to="home_page.download.link"
                 variant="contained"
               >
                 home_page.download.button
@@ -255,9 +297,9 @@ exports[`Home page component homepage renders correctly 1`] = `
                 marginTop="auto"
               >
                 <WithStyles(ForwardRef(Button))
-                  aria-label="home_page.facility.button_arialabel"
                   className="makeStyles-lightBlueButton-17"
                   color="primary"
+                  data-testid="facility-button"
                   href="home_page.facility.link"
                   variant="contained"
                 >

--- a/packages/datagateway-common/src/homePage/homePage.component.tsx
+++ b/packages/datagateway-common/src/homePage/homePage.component.tsx
@@ -15,6 +15,7 @@ import { StyleRules } from '@material-ui/core/styles';
 import SearchIcon from '@material-ui/icons/Search';
 import DownloadIcon from '@material-ui/icons/GetApp';
 import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 export interface HomePageProps {
   logo: string;
@@ -216,8 +217,9 @@ const HomePage = (props: HomePageProps): React.ReactElement => {
                   <Button
                     color="primary"
                     variant="contained"
-                    href={t('home_page.browse.link')}
-                    aria-label={t('home_page.browse.button_arialabel')}
+                    component={Link}
+                    to={t('home_page.browse.link')}
+                    data-testid="browse-button"
                   >
                     {t('home_page.browse.button')}
                   </Button>
@@ -251,8 +253,9 @@ const HomePage = (props: HomePageProps): React.ReactElement => {
                   <Button
                     color="primary"
                     variant="contained"
-                    href={t('home_page.search.link')}
-                    aria-label={t('home_page.search.button_arialabel')}
+                    component={Link}
+                    to={t('home_page.search.link')}
+                    data-testid="search-button"
                   >
                     {t('home_page.search.button')}
                   </Button>
@@ -279,8 +282,9 @@ const HomePage = (props: HomePageProps): React.ReactElement => {
                   <Button
                     color="primary"
                     variant="contained"
-                    href={t('home_page.download.link')}
-                    aria-label={t('home_page.download.button_arialabel')}
+                    component={Link}
+                    to={t('home_page.download.link')}
+                    data-testid="download-button"
                   >
                     {t('home_page.download.button')}
                   </Button>
@@ -307,7 +311,7 @@ const HomePage = (props: HomePageProps): React.ReactElement => {
                       variant="contained"
                       className={classes.lightBlueButton}
                       href={t('home_page.facility.link')}
-                      aria-label={t('home_page.facility.button_arialabel')}
+                      data-testid="facility-button"
                     >
                       {t('home_page.facility.button')}
                     </Button>

--- a/packages/datagateway-common/src/views/__snapshots__/selectionAlert.component.test.tsx.snap
+++ b/packages/datagateway-common/src/views/__snapshots__/selectionAlert.component.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SelectionAlert renders correctly 1`] = `
 <SelectionAlert
   marginSide="4px"
-  navigateToSelections={[Function]}
+  navigateToSelection={[Function]}
   selectedItems={
     Array [
       Object {
@@ -639,7 +639,7 @@ exports[`SelectionAlert renders correctly 1`] = `
 
 exports[`SelectionAlert renders correctly after animation finished 1`] = `
 <SelectionAlert
-  navigateToSelections={[Function]}
+  navigateToSelection={[Function]}
   selectedItems={
     Array [
       Object {

--- a/packages/datagateway-common/src/views/selectionAlert.component.test.tsx
+++ b/packages/datagateway-common/src/views/selectionAlert.component.test.tsx
@@ -42,7 +42,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={cart}
-        navigateToSelections={() => undefined}
+        navigateToSelection={() => undefined}
         width={'100px'}
         marginSide={'4px'}
       />
@@ -57,7 +57,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={cartItems}
-        navigateToSelections={() => undefined}
+        navigateToSelection={() => undefined}
       />
     );
     expect(
@@ -69,7 +69,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={cartItems}
-        navigateToSelections={() => undefined}
+        navigateToSelection={() => undefined}
       />
     );
     wrapper.setProps({ selectedItems: [cartItems[0], cartItems[1]] });
@@ -82,7 +82,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={cartItems}
-        navigateToSelections={() => undefined}
+        navigateToSelection={() => undefined}
       />
     );
     wrapper.setProps({ selectedItems: [] });
@@ -95,7 +95,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={[]}
-        navigateToSelections={() => undefined}
+        navigateToSelection={() => undefined}
       />
     );
     expect(wrapper.find('[aria-label="selection-alert"]').exists()).toBeFalsy();
@@ -105,7 +105,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={cartItems}
-        navigateToSelections={() => undefined}
+        navigateToSelection={() => undefined}
       />
     );
     wrapper
@@ -120,7 +120,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={cartItems}
-        navigateToSelections={() => undefined}
+        navigateToSelection={() => undefined}
       />
     );
     wrapper
@@ -131,7 +131,7 @@ describe('SelectionAlert', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('clicking link calls navigateToSelections', () => {
+  it('clicking link calls navigateToSelection', () => {
     let navigated = false;
     const navigate = (): void => {
       navigated = true;
@@ -139,7 +139,7 @@ describe('SelectionAlert', () => {
     const wrapper = mount(
       <SelectionAlert
         selectedItems={cartItems}
-        navigateToSelections={navigate}
+        navigateToSelection={navigate}
       />
     );
     wrapper

--- a/packages/datagateway-common/src/views/selectionAlert.component.tsx
+++ b/packages/datagateway-common/src/views/selectionAlert.component.tsx
@@ -83,7 +83,7 @@ const selectionAlertStyles = makeStyles<Theme, SelectionAlertProps>(
 const SelectionAlert = React.memo(
   (props: {
     selectedItems: DownloadCartItem[];
-    navigateToSelections: () => void;
+    navigateToSelection: () => void;
     width?: string;
     marginSide?: string;
   }): React.ReactElement | null => {
@@ -138,7 +138,7 @@ const SelectionAlert = React.memo(
                 cursor: 'pointer',
                 fontSize: '14px',
               }}
-              onClick={props.navigateToSelections}
+              onClick={props.navigateToSelection}
             >
               {t('selec_alert.link')}
             </button>

--- a/packages/datagateway-dataview/cypress/integration/card/pageContainer.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/pageContainer.spec.ts
@@ -205,7 +205,7 @@ describe('PageContainer Component', () => {
     cy.get('[aria-label="selection-alert-text"]')
       .invoke('text')
       .then((text) => {
-        expect(text.trim()).equal('1 item has been added to selections.');
+        expect(text.trim()).equal('1 item has been added to selection.');
       });
     cy.get('[aria-label="selection-alert-close"]').click();
     cy.get('[aria-label="selection-alert"]', { timeout: 10000 }).should(

--- a/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/cartSelection.spec.ts
@@ -35,7 +35,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="selection-alert-text"]')
           .invoke('text')
           .then((text) => {
-            expect(text.trim()).equal('1 item has been added to selections.');
+            expect(text.trim()).equal('1 item has been added to selection.');
           });
       });
 
@@ -52,7 +52,7 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '1 item has been removed from selections.'
+              '1 item has been removed from selection.'
             );
           });
       });
@@ -79,9 +79,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="selection-alert-text"]')
           .invoke('text')
           .then((text) => {
-            expect(text.trim()).equal(
-              '55 items have been added to selections.'
-            );
+            expect(text.trim()).equal('55 items have been added to selection.');
           });
       });
 
@@ -167,7 +165,7 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '55 items have been removed from selections.'
+              '55 items have been removed from selection.'
             );
           });
       });
@@ -191,7 +189,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="selection-alert-text"]')
           .invoke('text')
           .then((text) => {
-            expect(text.trim()).equal('5 items have been added to selections.');
+            expect(text.trim()).equal('5 items have been added to selection.');
           });
       });
 
@@ -222,12 +220,12 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '4 items have been removed from selections.'
+              '4 items have been removed from selection.'
             );
           });
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -397,7 +395,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 0"]').should('be.checked');
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -569,7 +567,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 0"]').should('be.checked');
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -605,7 +603,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="selection-alert-text"]')
           .invoke('text')
           .then((text) => {
-            expect(text.trim()).equal('1 item has been added to selections.');
+            expect(text.trim()).equal('1 item has been added to selection.');
           });
       });
 
@@ -623,7 +621,7 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '1 item has been removed from selections.'
+              '1 item has been removed from selection.'
             );
           });
       });
@@ -642,7 +640,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="selection-alert-text"]')
           .invoke('text')
           .then((text) => {
-            expect(text.trim()).equal('2 items have been added to selections.');
+            expect(text.trim()).equal('2 items have been added to selection.');
           });
       });
 
@@ -666,12 +664,12 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '2 items have been removed from selections.'
+              '2 items have been removed from selection.'
             );
           });
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -740,7 +738,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -809,7 +807,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -844,7 +842,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="selection-alert-text"]')
           .invoke('text')
           .then((text) => {
-            expect(text.trim()).equal('1 item has been added to selections.');
+            expect(text.trim()).equal('1 item has been added to selection.');
           });
       });
 
@@ -861,7 +859,7 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '1 item has been removed from selections.'
+              '1 item has been removed from selection.'
             );
           });
       });
@@ -891,7 +889,7 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '239 items have been added to selections.'
+              '239 items have been added to selection.'
             );
           });
       });
@@ -975,7 +973,7 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '239 items have been removed from selections.'
+              '239 items have been removed from selection.'
             );
           });
       });
@@ -999,7 +997,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="selection-alert-text"]')
           .invoke('text')
           .then((text) => {
-            expect(text.trim()).equal('5 items have been added to selections.');
+            expect(text.trim()).equal('5 items have been added to selection.');
           });
       });
 
@@ -1030,12 +1028,12 @@ describe('Add/remove from cart functionality', () => {
           .invoke('text')
           .then((text) => {
             expect(text.trim()).equal(
-              '4 items have been removed from selections.'
+              '4 items have been removed from selection.'
             );
           });
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -1108,7 +1106,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
       });
 
-      it('and navigate to selections using banner', () => {
+      it('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();
@@ -1179,7 +1177,7 @@ describe('Add/remove from cart functionality', () => {
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
       });
 
-      it.skip('and navigate to selections using banner', () => {
+      it.skip('and navigate to selection using banner', () => {
         cy.get('[aria-label="select row 0"]').check();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="selection-alert-link"]').click();

--- a/packages/datagateway-dataview/cypress/integration/homePage.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/homePage.spec.ts
@@ -5,23 +5,19 @@ describe('DataGateway HomePage', () => {
 
   it('should be able to use links on homepage to navigate', () => {
     //Headings
-    cy.get('[aria-label="Browse data"]').click();
+    cy.get('[data-testid="browse-button"]').click();
     cy.url().should('include', '/browse/investigation');
     cy.go('back');
 
-    cy.get('[aria-label="Search data"]').click();
+    cy.get('[data-testid="search-button"]').click();
     cy.url().should('include', '/search');
     cy.go('back');
 
-    cy.get('[aria-label="Search data"]').click();
-    cy.url().should('include', '/search');
-    cy.go('back');
-
-    cy.get('[aria-label="Download data"]').click();
+    cy.get('[data-testid="download-button"]').click();
     cy.url().should('include', '/download');
     cy.go('back');
 
-    cy.get('[aria-label="Read more"]').click();
+    cy.get('[data-testid="facility-button"]').click();
     cy.url().should('equal', 'https://www.isis.stfc.ac.uk/Pages/About.aspx');
     cy.go('back');
   });

--- a/packages/datagateway-dataview/cypress/integration/table/pageContainer.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/pageContainer.spec.ts
@@ -104,7 +104,7 @@ describe('PageContainer Component', () => {
     cy.get('[aria-label="selection-alert-text"]')
       .invoke('text')
       .then((text) => {
-        expect(text.trim()).equal('1 item has been added to selections.');
+        expect(text.trim()).equal('1 item has been added to selection.');
       });
     cy.get('[aria-label="selection-alert-close"]').click();
     cy.get('[aria-label="selection-alert"]', { timeout: 10000 }).should(

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -175,8 +175,8 @@
     "filter_message": "No results found with current filters applied, please modify filter settings and try again."
   },
   "buttons": {
-    "add_to_cart": "Add to selections",
-    "remove_from_cart": "Remove from selections",
+    "add_to_cart": "Add to selection",
+    "remove_from_cart": "Remove from selection",
     "download": "Download"
   },
   "advanced_filters": {
@@ -235,11 +235,11 @@
     }
   },
   "selec_alert": {
-    "added": "{{count}} item has been added to selections.",
-    "added_plural": "{{count}} items have been added to selections.",
-    "removed": "{{count}} item has been removed from selections.",
-    "removed_plural": "{{count}} items have been removed from selections.",
-    "link": "Go to selections."
+    "added": "{{count}} item has been added to selection.",
+    "added_plural": "{{count}} items have been added to selection.",
+    "removed": "{{count}} item has been removed from selection.",
+    "removed_plural": "{{count}} items have been removed from selection.",
+    "link": "Go to selection."
   },
   "doi_constants": {
     "keywords": [

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -213,29 +213,25 @@
       "description1": "Large scale facilities, such as synchrotrons, neutron and muon sources, lasers and accelerators, generate vast amounts of data that need to be managed in an efficient way, supporting data ingestion for long-term storage and archival, as well as data analysis and data publication workflows.",
       "description2": "<0>DataGateway</0> focuses on providing data discovery and data access functionality to the data.",
       "link": "/browse/investigation",
-      "button": "Browse data",
-      "button_arialabel": "Browse data"
+      "button": "Browse data"
     },
     "search": {
       "title": "Search",
       "description": "Search for the experimental data according to different criteria.",
       "link": "/search",
-      "button": "Search data",
-      "button_arialabel": "Search data"
+      "button": "Search data"
     },
     "download": {
       "title": "Download",
       "description": "Retrieve the experimental data using a variety of download methods.",
       "link": "/download",
-      "button": "Download data",
-      "button_arialabel": "Download data"
+      "button": "Download data"
     },
     "facility": {
       "title": "ISIS Neutron and Muon Source",
       "description": "World-leading centre for research giving unique insights into the properties of materials on the atomic scale.",
       "link": "https://www.isis.stfc.ac.uk/Pages/About.aspx",
-      "button": "Read more",
-      "button_arialabel": "Read more"
+      "button": "Read more"
     }
   },
   "selec_alert": {

--- a/packages/datagateway-dataview/server/e2e-settings.json
+++ b/packages/datagateway-dataview/server/e2e-settings.json
@@ -6,9 +6,9 @@
     "datasetGetSize": false,
     "datasetGetCount": true
   },
-  "idsUrl": "https://localhost:8181/ids",
-  "apiUrl": "http://localhost:5000",
-  "downloadApiUrl": "https://localhost:8181/topcat",
+  "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
+  "apiUrl": "https://scigateway-preprod.esc.rl.ac.uk/datagateway-api",
+  "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",
   "breadcrumbs": {
     "proposal": {
       "replaceEntity": "investigation",

--- a/packages/datagateway-dataview/server/e2e-settings.json
+++ b/packages/datagateway-dataview/server/e2e-settings.json
@@ -6,9 +6,9 @@
     "datasetGetSize": false,
     "datasetGetCount": true
   },
-  "idsUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/ids",
-  "apiUrl": "https://scigateway-preprod.esc.rl.ac.uk/datagateway-api",
-  "downloadApiUrl": "https://scigateway-preprod.esc.rl.ac.uk:8181/topcat",
+  "idsUrl": "https://localhost:8181/ids",
+  "apiUrl": "http://localhost:5000",
+  "downloadApiUrl": "https://localhost:8181/topcat",
   "breadcrumbs": {
     "proposal": {
       "replaceEntity": "investigation",

--- a/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
@@ -104,9 +104,23 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home_page.browse.button_arialabel"
                 color="primary"
-                href="home_page.browse.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="browse-button"
+                to="home_page.browse.link"
                 variant="contained"
               >
                 home_page.browse.button
@@ -167,9 +181,23 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home_page.search.button_arialabel"
                 color="primary"
-                href="home_page.search.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="search-button"
+                to="home_page.search.link"
                 variant="contained"
               >
                 home_page.search.button
@@ -213,9 +241,23 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home_page.download.button_arialabel"
                 color="primary"
-                href="home_page.download.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="download-button"
+                to="home_page.download.link"
                 variant="contained"
               >
                 home_page.download.button
@@ -255,9 +297,9 @@ exports[`HomePage translated homepage renders correctly 1`] = `
                 marginTop="auto"
               >
                 <WithStyles(ForwardRef(Button))
-                  aria-label="home_page.facility.button_arialabel"
                   className="makeStyles-lightBlueButton-17"
                   color="primary"
+                  data-testid="facility-button"
                   href="home_page.facility.link"
                   variant="contained"
                 >

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -663,7 +663,7 @@ const PageContainer: React.FC = () => {
                   <Grid item xs={true}>
                     <SelectionAlert
                       selectedItems={cartItems ?? []}
-                      navigateToSelections={navigateToDownload}
+                      navigateToSelection={navigateToDownload}
                       marginSide={'8px'}
                     />
                   </Grid>

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -347,7 +347,7 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
                   <Grid item xs={true}>
                     <SelectionAlert
                       selectedItems={cartItems ?? []}
-                      navigateToSelections={navigateToDownload}
+                      navigateToSelection={navigateToDownload}
                     />
                   </Grid>
                 </Grid>


### PR DESCRIPTION
## Description
Changes buttons on homepage to use react-router links to avoid unnecessary page reloading. Also removed some unnecessary aria-labels. The same changes were also applied to SciGateway: https://github.com/ral-facilities/scigateway/pull/863. Also changed all the 'selections' I could find to 'selection'.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #988, Closes #858
