### PR TITLE
Configurable number of search results #948

### DIFF
--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -75,8 +75,6 @@ export const fetchLuceneData = async (
     maxCount: params.maxCount ? params.maxCount : 300,
   };
 
-  console.log(params.maxCount);
-
   return axios
     .get(`${settings.icatUrl}/lucene/data`, {
       params: queryParams,

--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -75,6 +75,8 @@ export const fetchLuceneData = async (
     maxCount: params.maxCount ? params.maxCount : 300,
   };
 
+  console.log(params.maxCount);
+
   return axios
     .get(`${settings.icatUrl}/lucene/data`, {
       params: queryParams,

--- a/packages/datagateway-search/public/datagateway-search-settings.example.json
+++ b/packages/datagateway-search/public/datagateway-search-settings.example.json
@@ -5,6 +5,8 @@
   "downloadApiUrl": "example.download.api.url",
   "icatUrl": "example.icat.url",
   "selectAllSetting": true,
+  "searchableEntities": ["investigation", "dataset", "datafile"],
+  "maxNumResults": 300,
   "helpSteps": [
     {
       "target": "#plugin-link--search-data",
@@ -27,7 +29,6 @@
       "content": "Select the type of search results to view"
     }
   ],
-  "searchableEntities": ["investigation", "dataset", "datafile"],
   "routes": [
     {
       "section": "Test",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -29,7 +29,7 @@
       "cancel": "Cancel",
       "clear": "Clear"
     },
-    "limited_results_message": "Please note: Only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. Click 'Advanced' to learn more."
+    "limited_results_message": "Please note: Only the top {{maxNumResults}} results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. Click 'Advanced' to learn more."
   },
   "searchPageTable": {
     "tabs_arialabel": "Search table",
@@ -161,7 +161,7 @@
     },
     "limited_search_results": {
       "title": "Limited results",
-      "description": "Due to technical and performance reasons, only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. If you find your search gives 300 results, try using a more specific query to find what you are looking for."
+      "description": "Due to technical and performance reasons, only the top {{maxNumResults}} results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. If you find your search gives {{maxNumResults}} results, try using a more specific query to find what you are looking for."
     },
     "footer": "Further information on searching can be found <2>here</2>."
   }

--- a/packages/datagateway-search/server/e2e-settings.json
+++ b/packages/datagateway-search/server/e2e-settings.json
@@ -4,6 +4,9 @@
   "apiUrl": "http://localhost:5000",
   "downloadApiUrl": "https://localhost:8181/topcat",
   "icatUrl": "https://localhost:8181/icat",
+  "selectAllSetting": true,
+  "searchableEntities": ["investigation", "dataset", "datafile"],
+  "maxNumResults": 300,
   "helpSteps": [
     {
       "target": "#plugin-link--search-data",

--- a/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`SearchBoxContainer - Tests renders searchBoxContainer correctly 1`] = `
       }
     }
   >
-    searchBox.limited_results_message
+    searchBox.limited_results_message {maxNumResults:{tabs:{datasetTab:false,datafileTab:false,investigationTab:false,currentTab:investigation},selectAllSetting:true,settingsLoaded:false,sideLayout:false,searchableEntities:[investigation,dataset,datafile],maxNumResults:300}}
   </WithStyles(ForwardRef(Typography))>
 </div>
 `;

--- a/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
@@ -135,12 +135,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -169,12 +170,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -233,12 +235,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -267,12 +270,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -293,23 +297,25 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Investigation",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Investigation",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -394,12 +400,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -428,12 +435,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -454,23 +462,25 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Dataset",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Dataset",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -555,12 +565,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -589,12 +600,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -615,23 +627,25 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Datafile",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Datafile",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -1755,7 +1769,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "status": "loading",
                   },
                 },
-                "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
+                "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -1820,12 +1834,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -1854,12 +1869,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -1880,23 +1896,25 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Datafile",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Datafile",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -1916,7 +1934,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "status": "idle",
                   },
                 },
-                "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
+                "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -1981,12 +1999,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2015,12 +2034,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2041,23 +2061,25 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Dataset",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Dataset",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -2077,7 +2099,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "status": "idle",
                   },
                 },
-                "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
+                "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -2142,12 +2164,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2176,12 +2199,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2240,12 +2264,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2274,12 +2299,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2300,23 +2326,25 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Investigation",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Investigation",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -2350,6 +2378,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
             datafileTab={true}
             datasetTab={true}
             investigationTab={true}
+            maxNumResults={300}
             setCurrentTab={[Function]}
           >
             <div>

--- a/packages/datagateway-search/src/__snapshots__/searchPageContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageContainer.component.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -175,6 +176,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -201,6 +203,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                       "Investigation",
                       Object {
                         "endDate": null,
+                        "maxCount": undefined,
                         "searchText": "",
                         "startDate": null,
                       },
@@ -212,6 +215,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                     "Investigation",
                     Object {
                       "endDate": null,
+                      "maxCount": undefined,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -302,6 +306,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -336,6 +341,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -362,6 +368,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                       "Dataset",
                       Object {
                         "endDate": null,
+                        "maxCount": undefined,
                         "searchText": "",
                         "startDate": null,
                       },
@@ -373,6 +380,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                     "Dataset",
                     Object {
                       "endDate": null,
+                      "maxCount": undefined,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -463,6 +471,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -497,6 +506,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -523,6 +533,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                       "Datafile",
                       Object {
                         "endDate": null,
+                        "maxCount": undefined,
                         "searchText": "",
                         "startDate": null,
                       },
@@ -534,6 +545,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                     "Datafile",
                     Object {
                       "endDate": null,
+                      "maxCount": undefined,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -890,6 +902,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -924,6 +937,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -950,6 +964,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                       "Datafile",
                       Object {
                         "endDate": null,
+                        "maxCount": undefined,
                         "searchText": "",
                         "startDate": null,
                       },
@@ -961,6 +976,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                     "Datafile",
                     Object {
                       "endDate": null,
+                      "maxCount": undefined,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -1051,6 +1067,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -1085,6 +1102,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -1111,6 +1129,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                       "Dataset",
                       Object {
                         "endDate": null,
+                        "maxCount": undefined,
                         "searchText": "",
                         "startDate": null,
                       },
@@ -1122,6 +1141,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                     "Dataset",
                     Object {
                       "endDate": null,
+                      "maxCount": undefined,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -1212,6 +1232,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -1246,6 +1267,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": undefined,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -1272,6 +1294,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                       "Investigation",
                       Object {
                         "endDate": null,
+                        "maxCount": undefined,
                         "searchText": "",
                         "startDate": null,
                       },
@@ -1283,6 +1306,7 @@ exports[`SearchPageContainer - Tests renders searchPageContainer correctly 1`] =
                     "Investigation",
                     Object {
                       "endDate": null,
+                      "maxCount": undefined,
                       "searchText": "",
                       "startDate": null,
                     },

--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
@@ -135,12 +135,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -169,12 +170,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -233,12 +235,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -267,12 +270,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -293,23 +297,25 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Investigation",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Investigation",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -394,12 +400,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -428,12 +435,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -454,23 +462,25 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Dataset",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Dataset",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -555,12 +565,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -589,12 +600,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -615,23 +627,25 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Datafile",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Datafile",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -2433,7 +2447,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "status": "loading",
                   },
                 },
-                "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
+                "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -2498,12 +2512,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2532,12 +2547,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Datafile",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2558,23 +2574,25 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Datafile",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Datafile\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Datafile",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -2594,7 +2612,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "status": "idle",
                   },
                 },
-                "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
+                "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -2659,12 +2677,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2693,12 +2712,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Dataset",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2719,23 +2739,25 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Dataset",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Dataset\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Dataset",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -2755,7 +2777,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "status": "idle",
                   },
                 },
-                "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
+                "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -2820,12 +2842,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2854,12 +2877,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2918,12 +2942,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2952,12 +2977,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                        "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                         "queryKey": Array [
                           "search",
                           "Investigation",
                           Object {
                             "endDate": null,
+                            "maxCount": 300,
                             "searchText": "",
                             "startDate": null,
                           },
@@ -2978,23 +3004,25 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                    "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                     "queryKey": Array [
                       "search",
                       "Investigation",
                       Object {
                         "endDate": null,
+                        "maxCount": 300,
                         "searchText": "",
                         "startDate": null,
                       },
                     ],
                   },
-                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
+                  "queryHash": "[\\"search\\",\\"Investigation\\",{\\"endDate\\":null,\\"maxCount\\":300,\\"searchText\\":\\"\\",\\"startDate\\":null}]",
                   "queryKey": Array [
                     "search",
                     "Investigation",
                     Object {
                       "endDate": null,
+                      "maxCount": 300,
                       "searchText": "",
                       "startDate": null,
                     },
@@ -3028,6 +3056,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
             datafileTab={true}
             datasetTab={true}
             investigationTab={true}
+            maxNumResults={300}
             setCurrentTab={[Function]}
           >
             <div>

--- a/packages/datagateway-search/src/card/datasetSearchCardView.component.test.tsx
+++ b/packages/datagateway-search/src/card/datasetSearchCardView.component.test.tsx
@@ -188,6 +188,7 @@ describe('Dataset - Card View', () => {
       searchText: '',
       startDate: null,
       endDate: null,
+      maxCount: 300,
     });
 
     expect(useDatasetCount).toHaveBeenCalledWith([

--- a/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
@@ -29,6 +29,8 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { createStyles, makeStyles, Theme } from '@material-ui/core';
+import { useSelector } from 'react-redux';
+import { StateType } from '../state/app.types';
 
 interface DatasetCardViewProps {
   hierarchy: string;
@@ -59,10 +61,15 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
   const { startDate, endDate } = queryParams;
   const searchText = queryParams.searchText ? queryParams.searchText : '';
 
+  const maxNumResults = useSelector(
+    (state: StateType) => state.dgsearch.maxNumResults
+  );
+
   const { data: luceneData } = useLuceneSearch('Dataset', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
 
   const [t] = useTranslation();

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.test.tsx
@@ -183,6 +183,7 @@ describe('Investigation - Card View', () => {
       searchText: '',
       startDate: null,
       endDate: null,
+      maxCount: 300,
     });
 
     expect(useInvestigationCount).toHaveBeenCalledWith([

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
@@ -39,6 +39,8 @@ import {
   createStyles,
   Theme,
 } from '@material-ui/core';
+import { useSelector } from 'react-redux';
+import { StateType } from '../state/app.types';
 
 interface InvestigationCardProps {
   hierarchy: string;
@@ -139,10 +141,15 @@ const InvestigationCardView = (
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  const maxNumResults = useSelector(
+    (state: StateType) => state.dgsearch.maxNumResults
+  );
+
   const { data: luceneData } = useLuceneSearch('Investigation', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
 
   const {

--- a/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
@@ -144,12 +144,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
         advanced_search_help.limited_search_results.title
       </WithStyles(WithStyles(ForwardRef(DialogTitle)))>
       <WithStyles(WithStyles(ForwardRef(DialogContent)))>
-        <Trans
-          i18nKey="advanced_search_help.limited_search_results.description"
-          t={[Function]}
-        >
-          Due to technical and performance reasons, only the top 300 results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. If you find your search gives 300 results, try using a more specific query to find what you are looking for.
-        </Trans>
+        advanced_search_help.limited_search_results.description {maxNumResults:{tabs:{datasetTab:false,datafileTab:false,investigationTab:false,currentTab:investigation},selectAllSetting:true,settingsLoaded:false,sideLayout:false,searchableEntities:[investigation,dataset,datafile],maxNumResults:300}}
       </WithStyles(WithStyles(ForwardRef(DialogContent)))>
     </WithStyles(ForwardRef(Paper))>
     <WithStyles(ForwardRef(Typography))

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
@@ -1,23 +1,56 @@
 import React from 'react';
-import { createShallow, createMount } from '@material-ui/core/test-utils';
+import { createMount, createShallow } from '@material-ui/core/test-utils';
 import AdvancedHelpDialogue from './advancedHelpDialogue';
+import { Provider, useSelector } from 'react-redux';
+import thunk from 'redux-thunk';
+import { dGCommonInitialState } from 'datagateway-common';
+import { initialState as dgSearchInitialState } from '../state/reducers/dgsearch.reducer';
+import configureStore from 'redux-mock-store';
+import { ReactWrapper } from 'enzyme';
+import { StateType } from '../state/app.types';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
 
 describe('Advanced help dialogue component tests', () => {
   let shallow;
   let mount;
+  let mockStore;
+  let state: StateType;
 
   beforeEach(() => {
-    shallow = createShallow({ untilSelector: 'div' });
+    shallow = createShallow();
     mount = createMount();
+    mockStore = configureStore([thunk]);
+    state = JSON.parse(
+      JSON.stringify({
+        dgcommon: dGCommonInitialState,
+        dgsearch: dgSearchInitialState,
+      })
+    );
   });
 
+  const createWrapper = (): ReactWrapper => {
+    return mount(
+      <Provider store={mockStore(state)}>
+        <AdvancedHelpDialogue />
+      </Provider>
+    );
+  };
+
   it('renders correctly', () => {
+    useSelector.mockImplementation(() => {
+      return dgSearchInitialState;
+    });
+
     const wrapper = shallow(<AdvancedHelpDialogue />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('can open and close help dialogue', () => {
-    const wrapper = mount(<AdvancedHelpDialogue />);
+    const wrapper = createWrapper();
     wrapper
       .find('[aria-label="advanced_search_help.advanced_button_arialabel"]')
       .first()

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.tsx
@@ -14,6 +14,8 @@ import CloseIcon from '@material-ui/icons/Close';
 import Typography from '@material-ui/core/Typography';
 import { Link, Paper } from '@material-ui/core';
 import { Trans, useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { StateType } from '../state/app.types';
 
 const useStyles = makeStyles((theme: Theme) => {
   return createStyles({
@@ -60,6 +62,10 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
   const [open, setOpen] = React.useState(false);
   const classes = useStyles();
   const [t] = useTranslation();
+
+  const maxNumResults = useSelector(
+    (state: StateType) => state.dgsearch.maxNumResults
+  );
 
   const handleClickOpen = (): void => {
     setOpen(true);
@@ -180,15 +186,9 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
             {t('advanced_search_help.limited_search_results.title')}
           </DialogueHeading>
           <DialogueContent>
-            <Trans
-              t={t}
-              i18nKey="advanced_search_help.limited_search_results.description"
-            >
-              Due to technical and performance reasons, only the top 300 results
-              will be displayed for each entity type i.e. Investigation, Dataset
-              or Datafile. If you find your search gives 300 results, try using
-              a more specific query to find what you are looking for.
-            </Trans>
+            {t('advanced_search_help.limited_search_results.description', {
+              maxNumResults,
+            })}
           </DialogueContent>
         </Paper>
         <Typography className={classes.root} gutterBottom>

--- a/packages/datagateway-search/src/searchBoxContainer.component.test.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.test.tsx
@@ -4,8 +4,15 @@ import { ReactWrapper } from 'enzyme';
 import { createShallow } from '@material-ui/core/test-utils';
 import SearchBoxContainer from './searchBoxContainer.component';
 import SearchBoxContainerSide from './searchBoxContainerSide.component';
+import { useSelector } from 'react-redux';
+import { initialState } from './state/reducers/dgsearch.reducer';
 
 jest.mock('loglevel');
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
 
 describe('SearchBoxContainer - Tests', () => {
   let shallow;
@@ -18,6 +25,9 @@ describe('SearchBoxContainer - Tests', () => {
 
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'Grid' });
+    useSelector.mockImplementation(() => {
+      return initialState;
+    });
   });
 
   it('renders searchBoxContainer correctly', () => {

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -8,6 +8,8 @@ import SearchButton from './search/searchButton.component';
 import SearchTextBox from './search/searchTextBox.component';
 import { Trans, useTranslation } from 'react-i18next';
 import AdvancedHelpDialogue from './search/advancedHelpDialogue';
+import { useSelector } from 'react-redux';
+import { StateType } from './state/app.types';
 
 interface SearchBoxContainerProps {
   searchText: string;
@@ -20,6 +22,10 @@ const SearchBoxContainer = (
 ): React.ReactElement => {
   const { searchText, initiateSearch, onSearchTextChange } = props;
   const [t] = useTranslation();
+
+  const maxNumResults = useSelector(
+    (state: StateType) => state.dgsearch.maxNumResults
+  );
 
   return (
     <Grid
@@ -87,7 +93,9 @@ const SearchBoxContainer = (
       </Grid>
 
       <Typography style={{ margin: '10px' }}>
-        {t('searchBox.limited_results_message')}
+        {t('searchBox.limited_results_message', {
+          maxNumResults,
+        })}
       </Typography>
     </Grid>
   );

--- a/packages/datagateway-search/src/searchPageCardView.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.tsx
@@ -40,6 +40,7 @@ interface SearchCardViewProps {
 }
 
 interface SearchCardViewStoreProps {
+  maxNumResults: number;
   datasetTab: boolean;
   datafileTab: boolean;
   investigationTab: boolean;
@@ -88,6 +89,7 @@ const SearchPageCardView = (
     SearchCardViewDispatchProps
 ): React.ReactElement => {
   const {
+    maxNumResults,
     investigationTab,
     datasetTab,
     datafileTab,
@@ -109,16 +111,19 @@ const SearchPageCardView = (
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const { data: dataset } = useLuceneSearch('Dataset', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const { data: datafile } = useLuceneSearch('Datafile', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
 
   // Setting a tab based on user selection and what tabs are available
@@ -299,6 +304,7 @@ const SearchPageCardView = (
 
 const mapStateToProps = (state: StateType): SearchCardViewStoreProps => {
   return {
+    maxNumResults: state.dgsearch.maxNumResults,
     datasetTab: state.dgsearch.tabs.datasetTab,
     datafileTab: state.dgsearch.tabs.datafileTab,
     investigationTab: state.dgsearch.tabs.investigationTab,

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -121,6 +121,7 @@ const ViewButton = (props: {
 interface SearchPageContainerStoreProps {
   sideLayout: boolean;
   searchableEntities: string[];
+  maxNumResults: number;
   datafileTab: boolean;
   datasetTab: boolean;
   investigationTab: boolean;
@@ -145,8 +146,11 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
     setInvestigationTab,
     sideLayout,
     searchableEntities,
+    maxNumResults,
     currentTab,
   } = props;
+
+  console.log(maxNumResults);
 
   const location = useLocation();
   const queryParams = React.useMemo(() => parseSearchToQuery(location.search), [
@@ -205,6 +209,7 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const {
     refetch: searchDatasets,
@@ -214,6 +219,7 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const {
     refetch: searchDatafiles,
@@ -223,6 +229,7 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
 
   const requestReceived =
@@ -404,6 +411,7 @@ const mapDispatchToProps = (
 const mapStateToProps = (state: StateType): SearchPageContainerStoreProps => ({
   sideLayout: state.dgsearch.sideLayout,
   searchableEntities: state.dgsearch.searchableEntities,
+  maxNumResults: state.dgsearch.maxNumResults,
   datafileTab: state.dgsearch.tabs.datafileTab,
   datasetTab: state.dgsearch.tabs.datasetTab,
   investigationTab: state.dgsearch.tabs.investigationTab,

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -150,8 +150,6 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
     currentTab,
   } = props;
 
-  console.log(maxNumResults);
-
   const location = useLocation();
   const queryParams = React.useMemo(() => parseSearchToQuery(location.search), [
     location.search,

--- a/packages/datagateway-search/src/searchPageTable.tsx
+++ b/packages/datagateway-search/src/searchPageTable.tsx
@@ -40,6 +40,7 @@ interface SearchTableProps {
 }
 
 interface SearchTableStoreProps {
+  maxNumResults: number;
   datasetTab: boolean;
   datafileTab: boolean;
   investigationTab: boolean;
@@ -86,6 +87,7 @@ const SearchPageTable = (
   props: SearchTableProps & SearchTableStoreProps & SearchTableDispatchProps
 ): React.ReactElement => {
   const {
+    maxNumResults,
     investigationTab,
     datasetTab,
     datafileTab,
@@ -107,16 +109,19 @@ const SearchPageTable = (
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const { data: dataset } = useLuceneSearch('Dataset', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const { data: datafile } = useLuceneSearch('Datafile', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
 
   // Setting a tab based on user selection and what tabs are available
@@ -313,6 +318,7 @@ const SearchPageTable = (
 
 const mapStateToProps = (state: StateType): SearchTableStoreProps => {
   return {
+    maxNumResults: state.dgsearch.maxNumResults,
     datasetTab: state.dgsearch.tabs.datasetTab,
     datafileTab: state.dgsearch.tabs.datafileTab,
     investigationTab: state.dgsearch.tabs.investigationTab,

--- a/packages/datagateway-search/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.types.tsx
@@ -8,6 +8,8 @@ export const ConfigureSelectAllSettingType =
   'datagateway_search:configure_select_all';
 export const ConfigureSearchableEntitiesType =
   'datagateway_search:configure_searchable_entities';
+export const ConfigureMaxNumResultsType =
+  'datagateway_search:configure_max_num_results';
 
 export interface TogglePayload {
   toggleOption: boolean;
@@ -23,4 +25,8 @@ export interface ConfigureSelectAllSettingPayload {
 
 export interface ConfigureSearchableEntitiesPayload {
   entities: string[];
+}
+
+export interface ConfigureMaxNumResultsPayload {
+  maxNumResults: number;
 }

--- a/packages/datagateway-search/src/state/actions/index.tsx
+++ b/packages/datagateway-search/src/state/actions/index.tsx
@@ -5,6 +5,8 @@ import {
   ConfigureSearchableEntitiesPayload,
   ConfigureSearchableEntitiesType,
   SettingsLoadedType,
+  ConfigureMaxNumResultsPayload,
+  ConfigureMaxNumResultsType,
 } from './actions.types';
 import {
   loadUrls,
@@ -39,6 +41,15 @@ export const loadSearchableEntitites = (
   type: ConfigureSearchableEntitiesType,
   payload: {
     entities: entities,
+  },
+});
+
+export const loadMaxNumResults = (
+  maxNumResults: number
+): ActionType<ConfigureMaxNumResultsPayload> => ({
+  type: ConfigureMaxNumResultsType,
+  payload: {
+    maxNumResults: maxNumResults,
   },
 });
 
@@ -90,6 +101,10 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
 
         if ('searchableEntities' in settings) {
           dispatch(loadSearchableEntitites(settings['searchableEntities']));
+        }
+
+        if ('maxNumResults' in settings) {
+          dispatch(loadMaxNumResults(settings['maxNumResults']));
         }
 
         if (Array.isArray(settings['routes']) && settings['routes'].length) {

--- a/packages/datagateway-search/src/state/app.types.tsx
+++ b/packages/datagateway-search/src/state/app.types.tsx
@@ -13,6 +13,7 @@ export interface DGSearchState {
   settingsLoaded: boolean;
   sideLayout: boolean;
   searchableEntities: string[];
+  maxNumResults: number;
 }
 
 export type StateType = {

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.test.tsx
@@ -7,6 +7,7 @@ import {
   setCurrentTab,
 } from '../actions/actions';
 import {
+  loadMaxNumResults,
   loadSearchableEntitites,
   loadSelectAllSetting,
   settingsLoaded,
@@ -86,5 +87,13 @@ describe('dgsearch reducer', () => {
     );
 
     expect(updatedState.searchableEntities).toEqual(['dataset']);
+  });
+
+  it('should set maxNumResults property when configuring action is sent', () => {
+    expect(state.maxNumResults).toEqual(300);
+
+    const updatedState = DGSearchReducer(state, loadMaxNumResults(200));
+
+    expect(updatedState.maxNumResults).toEqual(200);
   });
 });

--- a/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
+++ b/packages/datagateway-search/src/state/reducers/dgsearch.reducer.tsx
@@ -12,6 +12,8 @@ import {
   ConfigureSelectAllSettingPayload,
   ConfigureSearchableEntitiesPayload,
   ConfigureSearchableEntitiesType,
+  ConfigureMaxNumResultsPayload,
+  ConfigureMaxNumResultsType,
 } from '../actions/actions.types';
 
 export const initialState: DGSearchState = {
@@ -25,6 +27,7 @@ export const initialState: DGSearchState = {
   settingsLoaded: false,
   sideLayout: false,
   searchableEntities: ['investigation', 'dataset', 'datafile'],
+  maxNumResults: 300,
 };
 
 export function handleSettingsLoaded(state: DGSearchState): DGSearchState {
@@ -106,6 +109,16 @@ export function handleConfigureSearchableEntities(
   };
 }
 
+export function handleConfigureMaxNumResults(
+  state: DGSearchState,
+  payload: ConfigureMaxNumResultsPayload
+): DGSearchState {
+  return {
+    ...state,
+    maxNumResults: payload.maxNumResults,
+  };
+}
+
 const DGSearchReducer = createReducer(initialState, {
   [SetDatasetTabType]: handleSetDatasetTab,
   [SetDatafileTabType]: handleSetDatafileTab,
@@ -114,6 +127,7 @@ const DGSearchReducer = createReducer(initialState, {
   [SetCurrentTabType]: handleSetCurrentTab,
   [ConfigureSelectAllSettingType]: handleConfigureSelectAllSetting,
   [ConfigureSearchableEntitiesType]: handleConfigureSearchableEntities,
+  [ConfigureMaxNumResultsType]: handleConfigureMaxNumResults,
 });
 
 export default DGSearchReducer;

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.test.tsx
@@ -191,6 +191,7 @@ describe('Datafile search table component', () => {
       searchText: '',
       startDate: null,
       endDate: null,
+      maxCount: 300,
     });
 
     expect(useDatafileCount).toHaveBeenCalledWith([

--- a/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datafileSearchTable.component.tsx
@@ -103,10 +103,15 @@ const DatafileSearchTable = (
     (state: StateType) => state.dgsearch.selectAllSetting
   );
 
+  const maxNumResults = useSelector(
+    (state: StateType) => state.dgsearch.maxNumResults
+  );
+
   const { data: luceneData } = useLuceneSearch('Datafile', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const [t] = useTranslation();
 

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.test.tsx
@@ -205,6 +205,7 @@ describe('Dataset table component', () => {
       searchText: '',
       startDate: null,
       endDate: null,
+      maxCount: 300,
     });
 
     expect(useDatasetCount).toHaveBeenCalledWith([

--- a/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/datasetSearchTable.component.tsx
@@ -96,10 +96,15 @@ const DatasetSearchTable = (props: DatasetTableProps): React.ReactElement => {
     (state: StateType) => state.dgsearch.selectAllSetting
   );
 
+  const maxNumResults = useSelector(
+    (state: StateType) => state.dgsearch.maxNumResults
+  );
+
   const { data: luceneData } = useLuceneSearch('Dataset', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
   const [t] = useTranslation();
 

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.test.tsx
@@ -212,6 +212,7 @@ describe('Investigation Search Table component', () => {
       searchText: '',
       startDate: null,
       endDate: null,
+      maxCount: 300,
     });
 
     expect(useInvestigationCount).toHaveBeenCalledWith([

--- a/packages/datagateway-search/src/table/investigationSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/investigationSearchTable.component.tsx
@@ -117,10 +117,15 @@ const InvestigationSearchTable = (
     (state: StateType) => state.dgsearch.selectAllSetting
   );
 
+  const maxNumResults = useSelector(
+    (state: StateType) => state.dgsearch.maxNumResults
+  );
+
   const { data: luceneData } = useLuceneSearch('Investigation', {
     searchText,
     startDate,
     endDate,
+    maxCount: maxNumResults,
   });
 
   const [t] = useTranslation();


### PR DESCRIPTION
## Description
Adds a setting `maxNumResults` in search to make the maximum number of search results returned configurable. This value is also used in the text presented to the user.

![image](https://user-images.githubusercontent.com/90245114/145827574-b16b12c2-d269-4341-8635-e65fe8ad1e02.png)
![image](https://user-images.githubusercontent.com/90245114/145827600-1eeacc42-4975-43a7-9d8a-f74fdc91f083.png)


## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
connect to #948
