### PR TITLE
Add no selections message in download #996

### DIFF
--- a/packages/datagateway-common/src/homePage/__snapshots__/homePage.component.test.tsx.snap
+++ b/packages/datagateway-common/src/homePage/__snapshots__/homePage.component.test.tsx.snap
@@ -76,19 +76,19 @@ exports[`Home page component homepage renders correctly 1`] = `
             className="makeStyles-paperContent-7"
           >
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
-              variant="h4"
+              className="makeStyles-paperMainHeading-10"
+              variant="h3"
             >
               home_page.browse.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.browse.description1
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               <Trans
@@ -133,10 +133,10 @@ exports[`Home page component homepage renders correctly 1`] = `
           xs={6}
         >
           <div
-            className="makeStyles-browseBackground-14"
+            className="makeStyles-browseBackground-15"
           >
             <div
-              className="makeStyles-browseDecal-15"
+              className="makeStyles-browseDecal-16"
             />
           </div>
         </WithStyles(ForwardRef(Grid))>
@@ -166,13 +166,13 @@ exports[`Home page component homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
+              className="makeStyles-paperHeading-11"
               variant="h4"
             >
               home_page.search.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.search.description
@@ -226,13 +226,13 @@ exports[`Home page component homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
+              className="makeStyles-paperHeading-11"
               variant="h4"
             >
               home_page.download.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.download.description
@@ -276,19 +276,19 @@ exports[`Home page component homepage renders correctly 1`] = `
           elevation={1}
         >
           <div
-            className="makeStyles-facilityDecal-16"
+            className="makeStyles-facilityDecal-17"
           >
             <Styled(MuiBox)
               className="makeStyles-paperContent-7"
             >
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperHeading-12"
+                className="makeStyles-bluePaperHeading-13"
                 variant="h4"
               >
                 home_page.facility.title
               </WithStyles(ForwardRef(Typography))>
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperDescription-13"
+                className="makeStyles-bluePaperDescription-14"
                 variant="body1"
               >
                 home_page.facility.description
@@ -297,7 +297,7 @@ exports[`Home page component homepage renders correctly 1`] = `
                 marginTop="auto"
               >
                 <WithStyles(ForwardRef(Button))
-                  className="makeStyles-lightBlueButton-17"
+                  className="makeStyles-lightBlueButton-18"
                   color="primary"
                   data-testid="facility-button"
                   href="home_page.facility.link"

--- a/packages/datagateway-common/src/homePage/homePage.component.tsx
+++ b/packages/datagateway-common/src/homePage/homePage.component.tsx
@@ -97,7 +97,7 @@ const useStyles = (props: HomePageProps) => {
         paperDescription: {
           textAlign: 'left',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          color: (theme as any).colours?.homePage?.description,
+          color: (theme as any).colours?.contrastGrey,
           marginBottom: theme.spacing(2),
         },
         bluePaperHeading: {

--- a/packages/datagateway-common/src/homePage/homePage.component.tsx
+++ b/packages/datagateway-common/src/homePage/homePage.component.tsx
@@ -88,8 +88,16 @@ const useStyles = (props: HomePageProps) => {
         avatarIcon: {
           transform: 'scale(1.75)',
         },
+        paperMainHeading: {
+          fontWeight: 'bold',
+          fontSize: '32px',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          color: (theme as any).colours?.homePage?.heading,
+          marginBottom: theme.spacing(2),
+        },
         paperHeading: {
           fontWeight: 'bold',
+          fontSize: '24px',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           color: (theme as any).colours?.homePage?.heading,
           marginBottom: theme.spacing(2),
@@ -102,6 +110,7 @@ const useStyles = (props: HomePageProps) => {
         },
         bluePaperHeading: {
           fontWeight: 'bold',
+          fontSize: '24px',
           color: '#FFFFFF',
           marginBottom: theme.spacing(2),
         },
@@ -195,7 +204,7 @@ const HomePage = (props: HomePageProps): React.ReactElement => {
           <Grid container style={{ height: '100%' }}>
             <Grid item xs={6}>
               <Box className={classes.paperContent}>
-                <Typography variant="h4" className={classes.paperHeading}>
+                <Typography variant="h3" className={classes.paperMainHeading}>
                   {t('home_page.browse.title')}
                 </Typography>
                 <Typography

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -222,7 +222,7 @@
     "search": {
       "title": "Search",
       "description": "Search for the experimental data according to different criteria.",
-      "link": "/search",
+      "link": "/search/data",
       "button": "Search data"
     },
     "download": {

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -37,6 +37,7 @@
       "instrument_scientists": {
         "label": "Instrument Scientists",
         "name": "Name",
+        "name_plural": "Names",
         "no_name": "No Scientists"
       }
     }
@@ -93,16 +94,19 @@
       "users": {
         "label": "Investigation Users",
         "name": "Name",
+        "name_plural": "Names",
         "no_name": "No Users"
       },
       "samples": {
         "label": "Investigation Samples",
         "name": "Sample",
+        "name_plural": "Samples",
         "no_samples": "No Samples"
       },
       "publications": {
         "label": "Publications",
         "reference": "Reference",
+        "reference_plural": "References",
         "no_publications": "No publications"
       },
       "type": {

--- a/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
@@ -76,19 +76,19 @@ exports[`HomePage translated homepage renders correctly 1`] = `
             className="makeStyles-paperContent-7"
           >
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
-              variant="h4"
+              className="makeStyles-paperMainHeading-10"
+              variant="h3"
             >
               home_page.browse.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.browse.description1
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               <Trans
@@ -133,10 +133,10 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           xs={6}
         >
           <div
-            className="makeStyles-browseBackground-14"
+            className="makeStyles-browseBackground-15"
           >
             <div
-              className="makeStyles-browseDecal-15"
+              className="makeStyles-browseDecal-16"
             />
           </div>
         </WithStyles(ForwardRef(Grid))>
@@ -166,13 +166,13 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
+              className="makeStyles-paperHeading-11"
               variant="h4"
             >
               home_page.search.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.search.description
@@ -226,13 +226,13 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
+              className="makeStyles-paperHeading-11"
               variant="h4"
             >
               home_page.download.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.download.description
@@ -276,19 +276,19 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           elevation={1}
         >
           <div
-            className="makeStyles-facilityDecal-16"
+            className="makeStyles-facilityDecal-17"
           >
             <Styled(MuiBox)
               className="makeStyles-paperContent-7"
             >
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperHeading-12"
+                className="makeStyles-bluePaperHeading-13"
                 variant="h4"
               >
                 home_page.facility.title
               </WithStyles(ForwardRef(Typography))>
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperDescription-13"
+                className="makeStyles-bluePaperDescription-14"
                 variant="body1"
               >
                 home_page.facility.description
@@ -297,7 +297,7 @@ exports[`HomePage translated homepage renders correctly 1`] = `
                 marginTop="auto"
               >
                 <WithStyles(ForwardRef(Button))
-                  className="makeStyles-lightBlueButton-17"
+                  className="makeStyles-lightBlueButton-18"
                   color="primary"
                   data-testid="facility-button"
                   href="home_page.facility.link"

--- a/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
@@ -76,19 +76,19 @@ exports[`HomePage translated homepage renders correctly 1`] = `
             className="makeStyles-paperContent-7"
           >
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
+              className="makeStyles-paperMainHeading-10"
               variant="h4"
             >
               home_page.browse.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.browse.description1
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               <Trans
@@ -133,10 +133,10 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           xs={6}
         >
           <div
-            className="makeStyles-browseBackground-14"
+            className="makeStyles-browseBackground-15"
           >
             <div
-              className="makeStyles-browseDecal-15"
+              className="makeStyles-browseDecal-16"
             />
           </div>
         </WithStyles(ForwardRef(Grid))>
@@ -166,13 +166,13 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
+              className="makeStyles-paperHeading-11"
               variant="h4"
             >
               home_page.search.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.search.description
@@ -226,13 +226,13 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-10"
+              className="makeStyles-paperHeading-11"
               variant="h4"
             >
               home_page.download.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-11"
+              className="makeStyles-paperDescription-12"
               variant="body1"
             >
               home_page.download.description
@@ -276,19 +276,19 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           elevation={1}
         >
           <div
-            className="makeStyles-facilityDecal-16"
+            className="makeStyles-facilityDecal-17"
           >
             <Styled(MuiBox)
               className="makeStyles-paperContent-7"
             >
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperHeading-12"
+                className="makeStyles-bluePaperHeading-13"
                 variant="h4"
               >
                 home_page.facility.title
               </WithStyles(ForwardRef(Typography))>
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperDescription-13"
+                className="makeStyles-bluePaperDescription-14"
                 variant="body1"
               >
                 home_page.facility.description
@@ -297,7 +297,7 @@ exports[`HomePage translated homepage renders correctly 1`] = `
                 marginTop="auto"
               >
                 <WithStyles(ForwardRef(Button))
-                  className="makeStyles-lightBlueButton-17"
+                  className="makeStyles-lightBlueButton-18"
                   color="primary"
                   data-testid="facility-button"
                   href="home_page.facility.link"

--- a/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/translatedHomePage.component.test.tsx.snap
@@ -76,19 +76,19 @@ exports[`HomePage translated homepage renders correctly 1`] = `
             className="makeStyles-paperContent-7"
           >
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperMainHeading-10"
+              className="makeStyles-paperHeading-10"
               variant="h4"
             >
               home_page.browse.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-12"
+              className="makeStyles-paperDescription-11"
               variant="body1"
             >
               home_page.browse.description1
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-12"
+              className="makeStyles-paperDescription-11"
               variant="body1"
             >
               <Trans
@@ -133,10 +133,10 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           xs={6}
         >
           <div
-            className="makeStyles-browseBackground-15"
+            className="makeStyles-browseBackground-14"
           >
             <div
-              className="makeStyles-browseDecal-16"
+              className="makeStyles-browseDecal-15"
             />
           </div>
         </WithStyles(ForwardRef(Grid))>
@@ -166,13 +166,13 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-11"
+              className="makeStyles-paperHeading-10"
               variant="h4"
             >
               home_page.search.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-12"
+              className="makeStyles-paperDescription-11"
               variant="body1"
             >
               home_page.search.description
@@ -226,13 +226,13 @@ exports[`HomePage translated homepage renders correctly 1`] = `
               />
             </WithStyles(ForwardRef(Avatar))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperHeading-11"
+              className="makeStyles-paperHeading-10"
               variant="h4"
             >
               home_page.download.title
             </WithStyles(ForwardRef(Typography))>
             <WithStyles(ForwardRef(Typography))
-              className="makeStyles-paperDescription-12"
+              className="makeStyles-paperDescription-11"
               variant="body1"
             >
               home_page.download.description
@@ -276,19 +276,19 @@ exports[`HomePage translated homepage renders correctly 1`] = `
           elevation={1}
         >
           <div
-            className="makeStyles-facilityDecal-17"
+            className="makeStyles-facilityDecal-16"
           >
             <Styled(MuiBox)
               className="makeStyles-paperContent-7"
             >
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperHeading-13"
+                className="makeStyles-bluePaperHeading-12"
                 variant="h4"
               >
                 home_page.facility.title
               </WithStyles(ForwardRef(Typography))>
               <WithStyles(ForwardRef(Typography))
-                className="makeStyles-bluePaperDescription-14"
+                className="makeStyles-bluePaperDescription-13"
                 variant="body1"
               >
                 home_page.facility.description
@@ -297,7 +297,7 @@ exports[`HomePage translated homepage renders correctly 1`] = `
                 marginTop="auto"
               >
                 <WithStyles(ForwardRef(Button))
-                  className="makeStyles-lightBlueButton-18"
+                  className="makeStyles-lightBlueButton-17"
                   color="primary"
                   data-testid="facility-button"
                   href="home_page.facility.link"

--- a/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -201,9 +201,9 @@ const VisitDetailsPanel = (
         >
           <Grid container className={classes.root} direction="column">
             <Typography variant="overline">
-              {investigationData.investigationUsers.length <= 1
-                ? t('investigations.details.users.name')
-                : t('investigations.details.users.name') + 's'}
+              {t('investigations.details.users.name', {
+                count: investigationData.investigationUsers.length,
+              })}
             </Typography>
             {investigationData.investigationUsers.length > 0 ? (
               investigationData.investigationUsers.map((investigationUser) => {
@@ -239,9 +239,9 @@ const VisitDetailsPanel = (
         >
           <Grid container className={classes.root} direction="column">
             <Typography variant="overline">
-              {investigationData.samples.length <= 1
-                ? t('investigations.details.samples.name')
-                : t('investigations.details.samples.name') + 's'}
+              {t('investigations.details.samples.name', {
+                count: investigationData.samples.length,
+              })}
             </Typography>
             {investigationData.samples.length > 0 ? (
               investigationData.samples.map((sample) => {
@@ -270,9 +270,9 @@ const VisitDetailsPanel = (
         >
           <Grid container className={classes.root} direction="column">
             <Typography variant="overline">
-              {investigationData.publications.length <= 1
-                ? t('investigations.details.publications.reference')
-                : t('investigations.details.publications.reference') + 's'}
+              {t('investigations.details.publications.reference', {
+                count: investigationData.publications.length,
+              })}
             </Typography>
             {investigationData.publications.length > 0 ? (
               investigationData.publications.map((publication) => {

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/instrumentDetailsPanel.component.tsx
@@ -131,9 +131,9 @@ const InstrumentDetailsPanel = (
         >
           <Grid container className={classes.root} direction="column">
             <Typography variant="overline">
-              {instrumentData.instrumentScientists.length <= 1
-                ? t('instruments.details.instrument_scientists.name')
-                : t('instruments.details.instrument_scientists.name') + 's'}
+              {t('instruments.details.instrument_scientists.name', {
+                count: instrumentData.instrumentScientists.length,
+              })}
             </Typography>
             {instrumentData.instrumentScientists.length > 0 ? (
               instrumentData.instrumentScientists.map((instrumentScientist) => {

--- a/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
+++ b/packages/datagateway-dataview/src/views/detailsPanels/isis/investigationDetailsPanel.component.tsx
@@ -221,9 +221,9 @@ const InvestigationDetailsPanel = (
         >
           <Grid container className={classes.root} direction="column">
             <Typography variant="overline">
-              {investigationData.investigationUsers.length <= 1
-                ? t('investigations.details.users.name')
-                : t('investigations.details.users.name') + 's'}
+              {t('investigations.details.users.name', {
+                count: investigationData.investigationUsers.length,
+              })}
             </Typography>
             {investigationData.investigationUsers.length > 0 ? (
               investigationData.investigationUsers.map((investigationUser) => {
@@ -259,9 +259,9 @@ const InvestigationDetailsPanel = (
         >
           <Grid container className={classes.root} direction="column">
             <Typography variant="overline">
-              {investigationData.samples.length <= 1
-                ? t('investigations.details.samples.name')
-                : t('investigations.details.samples.name') + 's'}
+              {t('investigations.details.samples.name', {
+                count: investigationData.samples.length,
+              })}
             </Typography>
             {investigationData.samples.length > 0 ? (
               investigationData.samples.map((sample) => {
@@ -290,9 +290,9 @@ const InvestigationDetailsPanel = (
         >
           <Grid container className={classes.root} direction="column">
             <Typography variant="overline">
-              {investigationData.publications.length <= 1
-                ? t('investigations.details.publications.reference')
-                : t('investigations.details.publications.reference') + 's'}
+              {t('investigations.details.publications.reference', {
+                count: investigationData.publications.length,
+              })}
             </Typography>
             {investigationData.publications.length > 0 ? (
               investigationData.publications.map((publication) => {

--- a/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.tsx
@@ -230,15 +230,13 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                       {field.icon}
                       {field.label}:
                     </Typography>
-                    <Typography className={classes.shortInfoValue}>
-                      <ArrowTooltip
-                        title={getTooltipText(field.content(data as Dataset))}
-                      >
-                        <Typography>
-                          {field.content(data as Dataset)}
-                        </Typography>
-                      </ArrowTooltip>
-                    </Typography>
+                    <ArrowTooltip
+                      title={getTooltipText(field.content(data as Dataset))}
+                    >
+                      <Typography className={classes.shortInfoValue}>
+                        {field.content(data as Dataset)}
+                      </Typography>
+                    </ArrowTooltip>
                   </div>
                 )
             )}

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -510,17 +510,15 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                       {field.icon}
                       {field.label}:
                     </Typography>
-                    <Typography className={classes.shortInfoValue}>
-                      <ArrowTooltip
-                        title={getTooltipText(
-                          field.content(data[0] as Investigation)
-                        )}
-                      >
-                        <Typography>
-                          {field.content(data[0] as Investigation)}
-                        </Typography>
-                      </ArrowTooltip>
-                    </Typography>
+                    <ArrowTooltip
+                      title={getTooltipText(
+                        field.content(data[0] as Investigation)
+                      )}
+                    >
+                      <Typography className={classes.shortInfoValue}>
+                        {field.content(data[0] as Investigation)}
+                      </Typography>
+                    </ArrowTooltip>
                   </div>
                 )
             )}

--- a/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisStudyLanding.component.tsx
@@ -510,15 +510,13 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                       {field.icon}
                       {field.label}:
                     </Typography>
-                    <Typography className={classes.shortInfoValue}>
-                      <ArrowTooltip
-                        title={getTooltipText(field.content(data[0] as Study))}
-                      >
-                        <Typography>
-                          {field.content(data[0] as Study)}
-                        </Typography>
-                      </ArrowTooltip>
-                    </Typography>
+                    <ArrowTooltip
+                      title={getTooltipText(field.content(data[0] as Study))}
+                    >
+                      <Typography className={classes.shortInfoValue}>
+                        {field.content(data[0] as Study)}
+                      </Typography>
+                    </ArrowTooltip>
                   </div>
                 )
             )}

--- a/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
@@ -124,7 +124,9 @@ describe('Download Cart', () => {
     cy.contains(/^DATASET 1$/).should('be.visible');
     cy.contains('Remove All').click();
     cy.contains(/^DATASET 1$/).should('not.exist');
-    cy.get('[aria-rowcount=0]').should('exist');
+
+    //Check no selections message is displayed
+    cy.get('[data-testid="no-selections-messsage"]').should('exist');
 
     cy.wait('@removeFromCart').then(
       (xhr) => expect(xhr.response.body.cartItems).to.be.empty

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -14,6 +14,7 @@
     "datagateway-common": "0.1.0",
     "date-fns": "^2.17.0",
     "date-fns-tz": "^1.1.6",
+    "history": "^4.10.1",
     "i18next": "^20.3.5",
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "^1.1.1",

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -80,6 +80,8 @@
     "download": "Download Selection",
     "number_of_files": "Number of files",
     "total_size": "Total size",
-    "no_selections": "No data selected. <2>Browse</2> or <6>search</6> for data."
+    "no_selections": "No data selected. <2>Browse</2> or <6>search</6> for data.",
+    "browse_link": "/browse/investigation",
+    "search_link": "/search/data"
   }
 }

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -79,6 +79,7 @@
     "remove_all": "Remove All",
     "download": "Download Selection",
     "number_of_files": "Number of files",
-    "total_size": "Total size"
+    "total_size": "Total size",
+    "no_selections": "No data selected. <2>Browse</2> or <6>search</6> for data."
   }
 }

--- a/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
@@ -1,150 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Download cart table component renders correctly 1`] = `
-<div>
-  <WithStyles(ForwardRef(Grid))
-    container={true}
-    direction="column"
-  >
+<div
+  className="tour-download-results"
+  data-testid="no-selections-messsage"
+  style={
+    Object {
+      "height": "calc(100vh - 64px - 48px - 48px - 48px)",
+      "minHeight": 230,
+      "overflowX": "auto",
+    }
+  }
+>
+  <WithStyles(ForwardRef(Paper))>
     <WithStyles(ForwardRef(Grid))
-      item={true}
-      xs={12}
-    >
-      <WithStyles(ForwardRef(LinearProgress))
-        color="secondary"
-      />
-    </WithStyles(ForwardRef(Grid))>
-    <WithStyles(ForwardRef(Grid))
-      item={true}
-    >
-      <WithStyles(ForwardRef(Paper))
-        className="tour-download-results"
-        style={
-          Object {
-            "height": "calc(100vh - 64px - 30px - 48px - 48px - 3rem - (1.75 * 0.875rem + 12px)",
-            "minHeight": 230,
-            "overflowX": "auto",
-          }
-        }
-      >
-        <WithStyles(VirtualizedTable)
-          actions={
-            Array [
-              [Function],
-            ]
-          }
-          columns={
-            Array [
-              Object {
-                "dataKey": "name",
-                "filterComponent": [Function],
-                "label": "downloadCart.name",
-              },
-              Object {
-                "dataKey": "entityType",
-                "filterComponent": [Function],
-                "label": "downloadCart.type",
-              },
-              Object {
-                "cellContentRenderer": [Function],
-                "dataKey": "size",
-                "label": "downloadCart.size",
-              },
-            ]
-          }
-          data={Array []}
-          loading={true}
-          onSort={[Function]}
-          sort={Object {}}
-        />
-      </WithStyles(ForwardRef(Paper))>
-    </WithStyles(ForwardRef(Grid))>
-    <WithStyles(ForwardRef(Grid))
-      alignItems="flex-end"
+      alignItems="center"
       container={true}
       direction="column"
-      item={true}
-      justify="space-between"
+      justify="center"
     >
       <WithStyles(ForwardRef(Grid))
-        alignContent="flex-end"
-        container={true}
-        direction="column"
         item={true}
-        style={
-          Object {
-            "marginRight": "1.2em",
-          }
-        }
-        xs={true}
       >
         <WithStyles(ForwardRef(Typography))
-          id="fileCountDisplay"
+          className="makeStyles-noSelectionsMessage-1"
         >
-          downloadCart.number_of_files
-          :
-           
-          0
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          id="totalSizeDisplay"
-        >
-          downloadCart.total_size
-          :
-           
-          0 B
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Grid))>
-      <WithStyles(ForwardRef(Grid))
-        container={true}
-        item={true}
-        justify="flex-end"
-        spacing={1}
-        style={
-          Object {
-            "marginRight": "1em",
-          }
-        }
-        xs={true}
-      >
-        <WithStyles(ForwardRef(Grid))
-          item={true}
-        >
-          <WithStyles(ForwardRef(Button))
-            className="tour-download-remove-button"
-            color="primary"
-            id="removeAllButton"
-            onClick={[Function]}
-            variant="contained"
+          <Trans
+            i18nKey="downloadCart.no_selections"
           >
-            downloadCart.remove_all
-          </WithStyles(ForwardRef(Button))>
-        </WithStyles(ForwardRef(Grid))>
-        <WithStyles(ForwardRef(Grid))
-          item={true}
-        >
-          <WithStyles(ForwardRef(Button))
-            className="tour-download-download-button"
-            color="primary"
-            disabled={true}
-            id="downloadCartButton"
-            onClick={[Function]}
-            variant="contained"
-          >
-            downloadCart.download
-          </WithStyles(ForwardRef(Button))>
-        </WithStyles(ForwardRef(Grid))>
+            No data selected.
+             
+            <WithStyles(ForwardRef(Link))
+              component={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
+                  "render": [Function],
+                }
+              }
+              to="downloadCart.browse_link"
+            >
+              Browse
+            </WithStyles(ForwardRef(Link))>
+             
+            or
+             
+            <WithStyles(ForwardRef(Link))
+              component={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
+                  "render": [Function],
+                }
+              }
+              to="downloadCart.search_link"
+            >
+              search
+            </WithStyles(ForwardRef(Link))>
+             
+            for data.
+          </Trans>
+        </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(Grid))>
     </WithStyles(ForwardRef(Grid))>
-  </WithStyles(ForwardRef(Grid))>
-  <WithStyles(DownloadConfirmDialog)
-    aria-labelledby="downloadCartConfirmation"
-    clearCart={[Function]}
-    isTwoLevel={false}
-    open={false}
-    redirectToStatusTab={[MockFunction]}
-    setClose={[Function]}
-    totalSize={0}
-  />
+  </WithStyles(ForwardRef(Paper))>
 </div>
 `;

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -12,12 +12,16 @@ import {
 } from '../downloadApi';
 import { act } from 'react-dom/test-utils';
 import { DownloadSettingsContext } from '../ConfigProvider';
+import { Router } from 'react-router-dom';
+import { ReactWrapper } from 'enzyme';
+import { createMemoryHistory } from 'history';
 
 jest.mock('../downloadApi');
 
 describe('Download cart table component', () => {
   let shallow;
   let mount;
+  let history;
 
   const cartItems: DownloadCartItem[] = [
     {
@@ -72,9 +76,22 @@ describe('Download cart table component', () => {
     },
   };
 
+  const createWrapper = (): ReactWrapper => {
+    return mount(
+      <div id="datagateway-download">
+        <Router history={history}>
+          <DownloadSettingsContext.Provider value={mockedSettings}>
+            <DownloadCartTable statusTabRedirect={jest.fn()} />
+          </DownloadSettingsContext.Provider>
+        </Router>
+      </div>
+    );
+  };
+
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'div' });
     mount = createMount();
+    history = createMemoryHistory();
     (fetchDownloadCartItems as jest.Mock).mockImplementation(() =>
       Promise.resolve(cartItems)
     );
@@ -110,13 +127,7 @@ describe('Download cart table component', () => {
   });
 
   it('fetches the download cart on load', async () => {
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
       await flushPromises();
@@ -128,9 +139,11 @@ describe('Download cart table component', () => {
 
   it('does not fetch the download cart on load if no dg-download element exists', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadCartTable statusTabRedirect={jest.fn()} />
-      </DownloadSettingsContext.Provider>
+      <Router history={history}>
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadCartTable statusTabRedirect={jest.fn()} />
+        </DownloadSettingsContext.Provider>
+      </Router>
     );
 
     await act(async () => {
@@ -142,13 +155,7 @@ describe('Download cart table component', () => {
   });
 
   it('calculates sizes once cart items have been fetched', async () => {
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
       await flushPromises();
@@ -165,13 +172,7 @@ describe('Download cart table component', () => {
   });
 
   it('calculates total file count once cart items have been fetched', async () => {
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
       await flushPromises();
@@ -185,17 +186,7 @@ describe('Download cart table component', () => {
   });
 
   it('loads cart confirmation dialog when Download Cart button is clicked', async () => {
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
-
-    expect(wrapper.find('button#downloadCartButton').prop('disabled')).toBe(
-      true
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
       await flushPromises();
@@ -236,15 +227,11 @@ describe('Download cart table component', () => {
   });
 
   it('removes all items from cart when Remove All button is clicked', async () => {
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
+      await flushPromises();
+      wrapper.update();
       await flushPromises();
       wrapper.update();
     });
@@ -255,24 +242,21 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
-    expect(removeAllDownloadCartItems).toHaveBeenCalled();
-    expect(wrapper.exists('[role="gridcell"]')).toBe(false);
-    expect(wrapper.exists('[aria-rowcount=0]')).toBe(true);
+    expect(wrapper.exists('[data-testid="no-selections-messsage"]')).toBe(true);
   });
 
   it("removes an item when said item's remove button is clicked", async () => {
     jest.useFakeTimers();
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
       await flushPromises();
       wrapper.update();
+    });
+
+    await act(async () => {
+      wrapper.update();
+      await flushPromises();
     });
 
     wrapper
@@ -308,17 +292,16 @@ describe('Download cart table component', () => {
   });
 
   it('sorts data when headers are clicked', async () => {
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
       await flushPromises();
       wrapper.update();
+    });
+
+    await act(async () => {
+      wrapper.update();
+      await flushPromises();
     });
 
     const firstNameCell = wrapper.find('[aria-colindex=1]').find('p').first();
@@ -353,17 +336,16 @@ describe('Download cart table component', () => {
   });
 
   it('filters data when text fields are typed into', async () => {
-    const wrapper = mount(
-      <div id="datagateway-download">
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadCartTable statusTabRedirect={jest.fn()} />
-        </DownloadSettingsContext.Provider>
-      </div>
-    );
+    const wrapper = createWrapper();
 
     await act(async () => {
       await flushPromises();
       wrapper.update();
+    });
+
+    await act(async () => {
+      wrapper.update();
+      await flushPromises();
     });
 
     const nameFilterInput = wrapper

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -252,8 +252,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
       className="tour-download-results"
       style={{
         //Table should take up page but leave room for: SG appbar, SG footer,
-        //tabs,table padding, and text above table (respectively).
-        height: 'calc(100vh - 64px - 30px - 48px - 48px)',
+        //tabs, table padding.
+        height: 'calc(100vh - 64px - 48px - 48px - 48px)',
         minHeight: 230,
         overflowX: 'auto',
       }}
@@ -264,11 +264,11 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             <Typography className={classes.noSelectionsMessage}>
               <Trans i18nKey="downloadCart.no_selections">
                 No data selected.{' '}
-                <Link component={RouterLink} to={'/browse/investigation'}>
+                <Link component={RouterLink} to={t('downloadCart.browse_link')}>
                   Browse
                 </Link>{' '}
                 or{' '}
-                <Link component={RouterLink} to={'/search'}>
+                <Link component={RouterLink} to={t('downloadCart.search_link')}>
                   search
                 </Link>{' '}
                 for data.
@@ -295,7 +295,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             className="tour-download-results"
             style={{
               height:
-                'calc(100vh - 64px - 30px - 48px - 48px - 3rem - (1.75 * 0.875rem + 12px)',
+                'calc(100vh - 64px - 48px - 48px - 48px - 3rem - (1.75 * 0.875rem + 12px)',
               minHeight: 230,
               overflowX: 'auto',
             }}

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -16,6 +16,10 @@ import {
   Typography,
   Button,
   LinearProgress,
+  createStyles,
+  makeStyles,
+  Theme,
+  Link,
 } from '@material-ui/core';
 import { RemoveCircle } from '@material-ui/icons';
 import {
@@ -30,7 +34,19 @@ import chunk from 'lodash.chunk';
 
 import DownloadConfirmDialog from '../downloadConfirmation/downloadConfirmDialog.component';
 import { DownloadSettingsContext } from '../ConfigProvider';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    noSelectionsMessage: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      color: (theme as any).colours?.homePage?.description,
+      paddingTop: theme.spacing(2),
+      paddingBottom: theme.spacing(2),
+    },
+  })
+);
 
 interface DownloadCartTableProps {
   statusTabRedirect: () => void;
@@ -39,6 +55,7 @@ interface DownloadCartTableProps {
 const DownloadCartTable: React.FC<DownloadCartTableProps> = (
   props: DownloadCartTableProps
 ) => {
+  const classes = useStyles();
   const settings = React.useContext(DownloadSettingsContext);
 
   const [sort, setSort] = React.useState<{ [column: string]: Order }>({});
@@ -230,7 +247,38 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
     return filteredData.sort(sortCartItems);
   }, [data, sort, filters]);
 
-  return (
+  return data.length === 0 ? (
+    <div
+      className="tour-download-results"
+      style={{
+        //Table should take up page but leave room for: SG appbar, SG footer,
+        //tabs,table padding, and text above table (respectively).
+        height: 'calc(100vh - 64px - 30px - 48px - 48px)',
+        minHeight: 230,
+        overflowX: 'auto',
+      }}
+    >
+      <Paper>
+        <Grid container direction="column" alignItems="center" justify="center">
+          <Grid item>
+            <Typography className={classes.noSelectionsMessage}>
+              <Trans i18nKey="downloadCart.no_selections">
+                No data selected.{' '}
+                <Link component={RouterLink} to={'/browse/investigation'}>
+                  Browse
+                </Link>{' '}
+                or{' '}
+                <Link component={RouterLink} to={'/search'}>
+                  search
+                </Link>{' '}
+                for data.
+              </Trans>
+            </Typography>
+          </Grid>
+        </Grid>
+      </Paper>
+    </div>
+  ) : (
     <div>
       <Grid container direction="column">
         {/* Show loading progress if data is still being loaded */}

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -250,6 +250,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
   return data.length === 0 ? (
     <div
       className="tour-download-results"
+      data-testid="no-selections-messsage"
       style={{
         //Table should take up page but leave room for: SG appbar, SG footer,
         //tabs, table padding.

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Admin Download Status Table renders correctly 1`] = `
           <WithStyles(ForwardRef(Paper))
             style={
               Object {
-                "height": "calc(100vh - 64px - 30px - 48px - 48px - (1.75rem + 40px))",
+                "height": "calc(100vh - 64px - 48px - 48px - 48px - (1.75rem + 40px))",
                 "minHeight": 230,
                 "overflowX": "auto",
               }

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Download Status Table renders correctly 1`] = `
     <WithStyles(ForwardRef(Paper))
       style={
         Object {
-          "height": "calc(100vh - 64px - 30px - 48px - 48px - (1.75rem + 40px))",
+          "height": "calc(100vh - 64px - 48px - 48px - 48px - (1.75rem + 40px))",
           "minHeight": 230,
           "overflowX": "auto",
         }

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -314,7 +314,7 @@ const AdminDownloadStatusTable: React.FC = () => {
               <Paper
                 style={{
                   height:
-                    'calc(100vh - 64px - 30px - 48px - 48px - (1.75rem + 40px))',
+                    'calc(100vh - 64px - 48px - 48px - 48px - (1.75rem + 40px))',
                   minHeight: 230,
                   overflowX: 'auto',
                 }}

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -247,7 +247,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
         <Paper
           style={{
             height:
-              'calc(100vh - 64px - 30px - 48px - 48px - (1.75rem + 40px))',
+              'calc(100vh - 64px - 48px - 48px - 48px - (1.75rem + 40px))',
             minHeight: 230,
             overflowX: 'auto',
           }}

--- a/packages/datagateway-download/src/downloadTab/downloadTab.component.test.tsx
+++ b/packages/datagateway-download/src/downloadTab/downloadTab.component.test.tsx
@@ -4,6 +4,8 @@ import DownloadTabs from './downloadTab.component';
 import { act } from 'react-dom/test-utils';
 import { flushPromises } from '../setupTests';
 import { DownloadSettingsContext } from '../ConfigProvider';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 
 // Create our mocked datagateway-download settings file.
 const mockedSettings = {
@@ -28,10 +30,12 @@ const mockedSettings = {
 describe('DownloadTab', () => {
   let shallow;
   let mount;
+  let history;
 
   beforeEach(() => {
     shallow = createShallow();
     mount = createMount();
+    history = createMemoryHistory();
   });
 
   afterEach(() => {
@@ -48,9 +52,11 @@ describe('DownloadTab', () => {
 
   it('renders the previously used tab based on sessionStorage', async () => {
     let wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadTabs />
-      </DownloadSettingsContext.Provider>
+      <Router history={history}>
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadTabs />
+        </DownloadSettingsContext.Provider>
+      </Router>
     );
 
     await act(async () => {
@@ -115,9 +121,11 @@ describe('DownloadTab', () => {
 
   it('shows the appropriate table when clicking between tabs', async () => {
     const wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadTabs />
-      </DownloadSettingsContext.Provider>
+      <Router history={history}>
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadTabs />
+        </DownloadSettingsContext.Provider>
+      </Router>
     );
 
     await act(async () => {


### PR DESCRIPTION
## Description
Adds a no selection message to download matching option 5 in https://preview.uxpin.com/ee9832eb8102ff6013aad58becab3ea162682ce9#/pages/145105838/documentation/sitemap.

![image](https://user-images.githubusercontent.com/90245114/146159191-26f63aa0-2336-437b-b335-b543589352d8.png)

Also makes a few other tweaks:
- Adjusts sizing in download to match the new footer
- Changes homepage search links in default.json to be '/search/data' as they should be
- Renames 'homePage.description' colour to 'contrastGrey' as it is now used in 2 places that are not the homepage
- Changed card details panels to use i18next for pluralisation of headings rather than `+ 's'`
- Changed homepage headings as described in https://github.com/ral-facilities/datagateway/issues/1007
- Fixed `validateDOMNesting` warnings on `isisDatasetLanding`, `isisInvestigationLanding` and `isisStudyLanding` components in dataview

The above changes to the homepage have also been done to SciGateway in https://github.com/ral-facilities/scigateway/pull/884.

## Testing instructions
This PR requires https://github.com/ral-facilities/scigateway/pull/884.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #996, Closes #1007
