### PR TITLE
Change tab indicator colour in search to be more visible (#1005)

### DIFF
--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -49,13 +49,15 @@ const usePaperStyles = makeStyles(
     createStyles({
       cardPaper: { backgroundColor: 'inherit' },
       tablePaper: {
-        height: 'calc(100vh - 180px)',
+        //Footer is 48px
+        height: 'calc(100vh - 180px - 48px)',
         width: '100%',
         backgroundColor: 'inherit',
         overflowX: 'auto',
       },
       tablePaperMessage: {
-        height: 'calc(100vh - 244px - 4rem)',
+        //Footer is 48px
+        height: 'calc(100vh - 244px - 4rem - 48px)',
         width: '100%',
         backgroundColor: 'inherit',
         overflowX: 'auto',

--- a/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadCart/__snapshots__/downloadCartTable.component.test.tsx.snap
@@ -45,6 +45,11 @@ exports[`Download cart table component renders correctly 1`] = `
                   "render": [Function],
                 }
               }
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
               to="downloadCart.browse_link"
             >
               Browse
@@ -65,6 +70,11 @@ exports[`Download cart table component renders correctly 1`] = `
                     "to": [Function],
                   },
                   "render": [Function],
+                }
+              }
+              style={
+                Object {
+                  "fontWeight": "bold",
                 }
               }
               to="downloadCart.search_link"

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -265,11 +265,19 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             <Typography className={classes.noSelectionsMessage}>
               <Trans i18nKey="downloadCart.no_selections">
                 No data selected.{' '}
-                <Link component={RouterLink} to={t('downloadCart.browse_link')}>
+                <Link
+                  component={RouterLink}
+                  to={t('downloadCart.browse_link')}
+                  style={{ fontWeight: 'bold' }}
+                >
                   Browse
                 </Link>{' '}
                 or{' '}
-                <Link component={RouterLink} to={t('downloadCart.search_link')}>
+                <Link
+                  component={RouterLink}
+                  to={t('downloadCart.search_link')}
+                  style={{ fontWeight: 'bold' }}
+                >
                   search
                 </Link>{' '}
                 for data.

--- a/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
@@ -2450,102 +2450,69 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                       <header
                         className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation4"
                       >
-                        <WithStyles(ForwardRef(Tabs))
+                        <WithStyles(WithStyles(ForwardRef(Tabs)))
                           aria-label="searchPageCardView.tabs_arialabel"
                           className="tour-search-tab-select"
                           onChange={[Function]}
                           value="investigation"
                         >
-                          <ForwardRef(Tabs)
+                          <WithStyles(ForwardRef(Tabs))
                             aria-label="searchPageCardView.tabs_arialabel"
                             className="tour-search-tab-select"
                             classes={
                               Object {
-                                "centered": "MuiTabs-centered",
-                                "fixed": "MuiTabs-fixed",
-                                "flexContainer": "MuiTabs-flexContainer",
-                                "flexContainerVertical": "MuiTabs-flexContainerVertical",
-                                "indicator": "MuiTabs-indicator",
-                                "root": "MuiTabs-root",
-                                "scrollButtons": "MuiTabs-scrollButtons",
-                                "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
-                                "scrollable": "MuiTabs-scrollable",
-                                "scroller": "MuiTabs-scroller",
-                                "vertical": "MuiTabs-vertical",
+                                "indicator": "WithStyles(ForwardRef(Tabs))-indicator-1",
                               }
                             }
                             onChange={[Function]}
                             value="investigation"
                           >
-                            <div
-                              className="MuiTabs-root tour-search-tab-select"
+                            <ForwardRef(Tabs)
+                              aria-label="searchPageCardView.tabs_arialabel"
+                              className="tour-search-tab-select"
+                              classes={
+                                Object {
+                                  "centered": "MuiTabs-centered",
+                                  "fixed": "MuiTabs-fixed",
+                                  "flexContainer": "MuiTabs-flexContainer",
+                                  "flexContainerVertical": "MuiTabs-flexContainerVertical",
+                                  "indicator": "MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1",
+                                  "root": "MuiTabs-root",
+                                  "scrollButtons": "MuiTabs-scrollButtons",
+                                  "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
+                                  "scrollable": "MuiTabs-scrollable",
+                                  "scroller": "MuiTabs-scroller",
+                                  "vertical": "MuiTabs-vertical",
+                                }
+                              }
+                              onChange={[Function]}
+                              value="investigation"
                             >
                               <div
-                                className="MuiTabs-scroller MuiTabs-fixed"
-                                onScroll={[Function]}
-                                style={
-                                  Object {
-                                    "marginBottom": null,
-                                    "overflow": "hidden",
-                                  }
-                                }
+                                className="MuiTabs-root tour-search-tab-select"
                               >
                                 <div
-                                  aria-label="searchPageCardView.tabs_arialabel"
-                                  className="MuiTabs-flexContainer"
-                                  onKeyDown={[Function]}
-                                  role="tablist"
-                                >
-                                  <WithStyles(ForwardRef(Tab))
-                                    aria-controls="simple-tabpanel-investigation"
-                                    fullWidth={false}
-                                    id="simple-tab-investigation"
-                                    indicator={false}
-                                    key=".0"
-                                    label={
-                                      <WithStyles(WithStyles(ForwardRef(Badge)))
-                                        badgeContent={0}
-                                        id="investigation-badge"
-                                        max={999}
-                                        showZero={true}
-                                      >
-                                        <span
-                                          style={
-                                            Object {
-                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                              "marginRight": "calc(0.5 * 1ch + 6px)",
-                                              "paddingRight": "1ch",
-                                            }
-                                          }
-                                        >
-                                          tabs.investigation
-                                        </span>
-                                      </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                  className="MuiTabs-scroller MuiTabs-fixed"
+                                  onScroll={[Function]}
+                                  style={
+                                    Object {
+                                      "marginBottom": null,
+                                      "overflow": "hidden",
                                     }
-                                    onChange={[Function]}
-                                    selected={true}
-                                    textColor="inherit"
-                                    value="investigation"
+                                  }
+                                >
+                                  <div
+                                    aria-label="searchPageCardView.tabs_arialabel"
+                                    className="MuiTabs-flexContainer"
+                                    onKeyDown={[Function]}
+                                    role="tablist"
                                   >
-                                    <ForwardRef(Tab)
+                                    <WithStyles(ForwardRef(Tab))
                                       aria-controls="simple-tabpanel-investigation"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "fullWidth": "MuiTab-fullWidth",
-                                          "labelIcon": "MuiTab-labelIcon",
-                                          "root": "MuiTab-root",
-                                          "selected": "Mui-selected",
-                                          "textColorInherit": "MuiTab-textColorInherit",
-                                          "textColorPrimary": "MuiTab-textColorPrimary",
-                                          "textColorSecondary": "MuiTab-textColorSecondary",
-                                          "wrapped": "MuiTab-wrapped",
-                                          "wrapper": "MuiTab-wrapper",
-                                        }
-                                      }
                                       fullWidth={false}
                                       id="simple-tab-investigation"
                                       indicator={false}
+                                      key=".0"
                                       label={
                                         <WithStyles(WithStyles(ForwardRef(Badge)))
                                           badgeContent={0}
@@ -2571,29 +2538,54 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                       textColor="inherit"
                                       value="investigation"
                                     >
-                                      <WithStyles(ForwardRef(ButtonBase))
+                                      <ForwardRef(Tab)
                                         aria-controls="simple-tabpanel-investigation"
-                                        aria-selected={true}
-                                        className="MuiTab-root MuiTab-textColorInherit Mui-selected"
-                                        disabled={false}
-                                        focusRipple={true}
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "fullWidth": "MuiTab-fullWidth",
+                                            "labelIcon": "MuiTab-labelIcon",
+                                            "root": "MuiTab-root",
+                                            "selected": "Mui-selected",
+                                            "textColorInherit": "MuiTab-textColorInherit",
+                                            "textColorPrimary": "MuiTab-textColorPrimary",
+                                            "textColorSecondary": "MuiTab-textColorSecondary",
+                                            "wrapped": "MuiTab-wrapped",
+                                            "wrapper": "MuiTab-wrapper",
+                                          }
+                                        }
+                                        fullWidth={false}
                                         id="simple-tab-investigation"
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        role="tab"
-                                        tabIndex={0}
+                                        indicator={false}
+                                        label={
+                                          <WithStyles(WithStyles(ForwardRef(Badge)))
+                                            badgeContent={0}
+                                            id="investigation-badge"
+                                            max={999}
+                                            showZero={true}
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                  "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                  "paddingRight": "1ch",
+                                                }
+                                              }
+                                            >
+                                              tabs.investigation
+                                            </span>
+                                          </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                        }
+                                        onChange={[Function]}
+                                        selected={true}
+                                        textColor="inherit"
+                                        value="investigation"
                                       >
-                                        <ForwardRef(ButtonBase)
+                                        <WithStyles(ForwardRef(ButtonBase))
                                           aria-controls="simple-tabpanel-investigation"
                                           aria-selected={true}
                                           className="MuiTab-root MuiTab-textColorInherit Mui-selected"
-                                          classes={
-                                            Object {
-                                              "disabled": "Mui-disabled",
-                                              "focusVisible": "Mui-focusVisible",
-                                              "root": "MuiButtonBase-root",
-                                            }
-                                          }
                                           disabled={false}
                                           focusRipple={true}
                                           id="simple-tab-investigation"
@@ -2602,181 +2594,156 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                           role="tab"
                                           tabIndex={0}
                                         >
-                                          <button
+                                          <ForwardRef(ButtonBase)
                                             aria-controls="simple-tabpanel-investigation"
                                             aria-selected={true}
-                                            className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                            className="MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                            classes={
+                                              Object {
+                                                "disabled": "Mui-disabled",
+                                                "focusVisible": "Mui-focusVisible",
+                                                "root": "MuiButtonBase-root",
+                                              }
+                                            }
                                             disabled={false}
+                                            focusRipple={true}
                                             id="simple-tab-investigation"
-                                            onBlur={[Function]}
                                             onClick={[Function]}
-                                            onDragLeave={[Function]}
                                             onFocus={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            onMouseDown={[Function]}
-                                            onMouseLeave={[Function]}
-                                            onMouseUp={[Function]}
-                                            onTouchEnd={[Function]}
-                                            onTouchMove={[Function]}
-                                            onTouchStart={[Function]}
                                             role="tab"
                                             tabIndex={0}
-                                            type="button"
                                           >
-                                            <span
-                                              className="MuiTab-wrapper"
+                                            <button
+                                              aria-controls="simple-tabpanel-investigation"
+                                              aria-selected={true}
+                                              className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                              disabled={false}
+                                              id="simple-tab-investigation"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onDragLeave={[Function]}
+                                              onFocus={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              onMouseDown={[Function]}
+                                              onMouseLeave={[Function]}
+                                              onMouseUp={[Function]}
+                                              onTouchEnd={[Function]}
+                                              onTouchMove={[Function]}
+                                              onTouchStart={[Function]}
+                                              role="tab"
+                                              tabIndex={0}
+                                              type="button"
                                             >
-                                              <WithStyles(WithStyles(ForwardRef(Badge)))
-                                                badgeContent={0}
-                                                id="investigation-badge"
-                                                max={999}
-                                                showZero={true}
+                                              <span
+                                                className="MuiTab-wrapper"
                                               >
-                                                <WithStyles(ForwardRef(Badge))
+                                                <WithStyles(WithStyles(ForwardRef(Badge)))
                                                   badgeContent={0}
-                                                  classes={
-                                                    Object {
-                                                      "badge": "WithStyles(ForwardRef(Badge))-badge-1",
-                                                    }
-                                                  }
                                                   id="investigation-badge"
                                                   max={999}
                                                   showZero={true}
                                                 >
-                                                  <ForwardRef(Badge)
+                                                  <WithStyles(ForwardRef(Badge))
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                        "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                        "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                        "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                        "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                        "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                        "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                        "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                        "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1",
-                                                        "colorError": "MuiBadge-colorError",
-                                                        "colorPrimary": "MuiBadge-colorPrimary",
-                                                        "colorSecondary": "MuiBadge-colorSecondary",
-                                                        "dot": "MuiBadge-dot",
-                                                        "invisible": "MuiBadge-invisible",
-                                                        "root": "MuiBadge-root",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
                                                       }
                                                     }
                                                     id="investigation-badge"
                                                     max={999}
                                                     showZero={true}
                                                   >
-                                                    <span
-                                                      className="MuiBadge-root"
+                                                    <ForwardRef(Badge)
+                                                      badgeContent={0}
+                                                      classes={
+                                                        Object {
+                                                          "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
+                                                          "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
+                                                          "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
+                                                          "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
+                                                          "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
+                                                          "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
+                                                          "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
+                                                          "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "colorError": "MuiBadge-colorError",
+                                                          "colorPrimary": "MuiBadge-colorPrimary",
+                                                          "colorSecondary": "MuiBadge-colorSecondary",
+                                                          "dot": "MuiBadge-dot",
+                                                          "invisible": "MuiBadge-invisible",
+                                                          "root": "MuiBadge-root",
+                                                        }
+                                                      }
                                                       id="investigation-badge"
+                                                      max={999}
+                                                      showZero={true}
                                                     >
                                                       <span
-                                                        style={
-                                                          Object {
-                                                            "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                                            "marginRight": "calc(0.5 * 1ch + 6px)",
-                                                            "paddingRight": "1ch",
+                                                        className="MuiBadge-root"
+                                                        id="investigation-badge"
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                              "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                              "paddingRight": "1ch",
+                                                            }
                                                           }
-                                                        }
-                                                      >
-                                                        tabs.investigation
+                                                        >
+                                                          tabs.investigation
+                                                        </span>
+                                                        <span
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                        >
+                                                          0
+                                                        </span>
                                                       </span>
-                                                      <span
-                                                        className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1 MuiBadge-anchorOriginTopRightRectangle"
-                                                      >
-                                                        0
-                                                      </span>
-                                                    </span>
-                                                  </ForwardRef(Badge)>
-                                                </WithStyles(ForwardRef(Badge))>
-                                              </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                            </span>
-                                            <WithStyles(memo)
-                                              center={false}
-                                            >
-                                              <ForwardRef(TouchRipple)
+                                                    </ForwardRef(Badge)>
+                                                  </WithStyles(ForwardRef(Badge))>
+                                                </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                              </span>
+                                              <WithStyles(memo)
                                                 center={false}
-                                                classes={
-                                                  Object {
-                                                    "child": "MuiTouchRipple-child",
-                                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                                    "ripple": "MuiTouchRipple-ripple",
-                                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                    "root": "MuiTouchRipple-root",
-                                                  }
-                                                }
                                               >
-                                                <span
-                                                  className="MuiTouchRipple-root"
+                                                <ForwardRef(TouchRipple)
+                                                  center={false}
+                                                  classes={
+                                                    Object {
+                                                      "child": "MuiTouchRipple-child",
+                                                      "childLeaving": "MuiTouchRipple-childLeaving",
+                                                      "childPulsate": "MuiTouchRipple-childPulsate",
+                                                      "ripple": "MuiTouchRipple-ripple",
+                                                      "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                      "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                      "root": "MuiTouchRipple-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <TransitionGroup
-                                                    childFactory={[Function]}
-                                                    component={null}
-                                                    exit={true}
-                                                  />
-                                                </span>
-                                              </ForwardRef(TouchRipple)>
-                                            </WithStyles(memo)>
-                                          </button>
-                                        </ForwardRef(ButtonBase)>
-                                      </WithStyles(ForwardRef(ButtonBase))>
-                                    </ForwardRef(Tab)>
-                                  </WithStyles(ForwardRef(Tab))>
-                                  <WithStyles(ForwardRef(Tab))
-                                    aria-controls="simple-tabpanel-dataset"
-                                    fullWidth={false}
-                                    id="simple-tab-dataset"
-                                    indicator={false}
-                                    key=".1"
-                                    label={
-                                      <WithStyles(WithStyles(ForwardRef(Badge)))
-                                        badgeContent={0}
-                                        id="dataset-badge"
-                                        max={999}
-                                        showZero={true}
-                                      >
-                                        <span
-                                          style={
-                                            Object {
-                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                              "marginRight": "calc(0.5 * 1ch + 6px)",
-                                              "paddingRight": "1ch",
-                                            }
-                                          }
-                                        >
-                                          tabs.dataset
-                                        </span>
-                                      </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                    }
-                                    onChange={[Function]}
-                                    selected={false}
-                                    textColor="inherit"
-                                    value="dataset"
-                                  >
-                                    <ForwardRef(Tab)
+                                                  <span
+                                                    className="MuiTouchRipple-root"
+                                                  >
+                                                    <TransitionGroup
+                                                      childFactory={[Function]}
+                                                      component={null}
+                                                      exit={true}
+                                                    />
+                                                  </span>
+                                                </ForwardRef(TouchRipple)>
+                                              </WithStyles(memo)>
+                                            </button>
+                                          </ForwardRef(ButtonBase)>
+                                        </WithStyles(ForwardRef(ButtonBase))>
+                                      </ForwardRef(Tab)>
+                                    </WithStyles(ForwardRef(Tab))>
+                                    <WithStyles(ForwardRef(Tab))
                                       aria-controls="simple-tabpanel-dataset"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "fullWidth": "MuiTab-fullWidth",
-                                          "labelIcon": "MuiTab-labelIcon",
-                                          "root": "MuiTab-root",
-                                          "selected": "Mui-selected",
-                                          "textColorInherit": "MuiTab-textColorInherit",
-                                          "textColorPrimary": "MuiTab-textColorPrimary",
-                                          "textColorSecondary": "MuiTab-textColorSecondary",
-                                          "wrapped": "MuiTab-wrapped",
-                                          "wrapper": "MuiTab-wrapper",
-                                        }
-                                      }
                                       fullWidth={false}
                                       id="simple-tab-dataset"
                                       indicator={false}
+                                      key=".1"
                                       label={
                                         <WithStyles(WithStyles(ForwardRef(Badge)))
                                           badgeContent={0}
@@ -2802,29 +2769,54 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                       textColor="inherit"
                                       value="dataset"
                                     >
-                                      <WithStyles(ForwardRef(ButtonBase))
+                                      <ForwardRef(Tab)
                                         aria-controls="simple-tabpanel-dataset"
-                                        aria-selected={false}
-                                        className="MuiTab-root MuiTab-textColorInherit"
-                                        disabled={false}
-                                        focusRipple={true}
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "fullWidth": "MuiTab-fullWidth",
+                                            "labelIcon": "MuiTab-labelIcon",
+                                            "root": "MuiTab-root",
+                                            "selected": "Mui-selected",
+                                            "textColorInherit": "MuiTab-textColorInherit",
+                                            "textColorPrimary": "MuiTab-textColorPrimary",
+                                            "textColorSecondary": "MuiTab-textColorSecondary",
+                                            "wrapped": "MuiTab-wrapped",
+                                            "wrapper": "MuiTab-wrapper",
+                                          }
+                                        }
+                                        fullWidth={false}
                                         id="simple-tab-dataset"
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        role="tab"
-                                        tabIndex={-1}
+                                        indicator={false}
+                                        label={
+                                          <WithStyles(WithStyles(ForwardRef(Badge)))
+                                            badgeContent={0}
+                                            id="dataset-badge"
+                                            max={999}
+                                            showZero={true}
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                  "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                  "paddingRight": "1ch",
+                                                }
+                                              }
+                                            >
+                                              tabs.dataset
+                                            </span>
+                                          </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                        }
+                                        onChange={[Function]}
+                                        selected={false}
+                                        textColor="inherit"
+                                        value="dataset"
                                       >
-                                        <ForwardRef(ButtonBase)
+                                        <WithStyles(ForwardRef(ButtonBase))
                                           aria-controls="simple-tabpanel-dataset"
                                           aria-selected={false}
                                           className="MuiTab-root MuiTab-textColorInherit"
-                                          classes={
-                                            Object {
-                                              "disabled": "Mui-disabled",
-                                              "focusVisible": "Mui-focusVisible",
-                                              "root": "MuiButtonBase-root",
-                                            }
-                                          }
                                           disabled={false}
                                           focusRipple={true}
                                           id="simple-tab-dataset"
@@ -2833,181 +2825,156 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                           role="tab"
                                           tabIndex={-1}
                                         >
-                                          <button
+                                          <ForwardRef(ButtonBase)
                                             aria-controls="simple-tabpanel-dataset"
                                             aria-selected={false}
-                                            className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                            className="MuiTab-root MuiTab-textColorInherit"
+                                            classes={
+                                              Object {
+                                                "disabled": "Mui-disabled",
+                                                "focusVisible": "Mui-focusVisible",
+                                                "root": "MuiButtonBase-root",
+                                              }
+                                            }
                                             disabled={false}
+                                            focusRipple={true}
                                             id="simple-tab-dataset"
-                                            onBlur={[Function]}
                                             onClick={[Function]}
-                                            onDragLeave={[Function]}
                                             onFocus={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            onMouseDown={[Function]}
-                                            onMouseLeave={[Function]}
-                                            onMouseUp={[Function]}
-                                            onTouchEnd={[Function]}
-                                            onTouchMove={[Function]}
-                                            onTouchStart={[Function]}
                                             role="tab"
                                             tabIndex={-1}
-                                            type="button"
                                           >
-                                            <span
-                                              className="MuiTab-wrapper"
+                                            <button
+                                              aria-controls="simple-tabpanel-dataset"
+                                              aria-selected={false}
+                                              className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                              disabled={false}
+                                              id="simple-tab-dataset"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onDragLeave={[Function]}
+                                              onFocus={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              onMouseDown={[Function]}
+                                              onMouseLeave={[Function]}
+                                              onMouseUp={[Function]}
+                                              onTouchEnd={[Function]}
+                                              onTouchMove={[Function]}
+                                              onTouchStart={[Function]}
+                                              role="tab"
+                                              tabIndex={-1}
+                                              type="button"
                                             >
-                                              <WithStyles(WithStyles(ForwardRef(Badge)))
-                                                badgeContent={0}
-                                                id="dataset-badge"
-                                                max={999}
-                                                showZero={true}
+                                              <span
+                                                className="MuiTab-wrapper"
                                               >
-                                                <WithStyles(ForwardRef(Badge))
+                                                <WithStyles(WithStyles(ForwardRef(Badge)))
                                                   badgeContent={0}
-                                                  classes={
-                                                    Object {
-                                                      "badge": "WithStyles(ForwardRef(Badge))-badge-1",
-                                                    }
-                                                  }
                                                   id="dataset-badge"
                                                   max={999}
                                                   showZero={true}
                                                 >
-                                                  <ForwardRef(Badge)
+                                                  <WithStyles(ForwardRef(Badge))
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                        "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                        "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                        "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                        "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                        "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                        "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                        "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                        "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1",
-                                                        "colorError": "MuiBadge-colorError",
-                                                        "colorPrimary": "MuiBadge-colorPrimary",
-                                                        "colorSecondary": "MuiBadge-colorSecondary",
-                                                        "dot": "MuiBadge-dot",
-                                                        "invisible": "MuiBadge-invisible",
-                                                        "root": "MuiBadge-root",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
                                                       }
                                                     }
                                                     id="dataset-badge"
                                                     max={999}
                                                     showZero={true}
                                                   >
-                                                    <span
-                                                      className="MuiBadge-root"
+                                                    <ForwardRef(Badge)
+                                                      badgeContent={0}
+                                                      classes={
+                                                        Object {
+                                                          "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
+                                                          "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
+                                                          "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
+                                                          "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
+                                                          "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
+                                                          "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
+                                                          "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
+                                                          "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "colorError": "MuiBadge-colorError",
+                                                          "colorPrimary": "MuiBadge-colorPrimary",
+                                                          "colorSecondary": "MuiBadge-colorSecondary",
+                                                          "dot": "MuiBadge-dot",
+                                                          "invisible": "MuiBadge-invisible",
+                                                          "root": "MuiBadge-root",
+                                                        }
+                                                      }
                                                       id="dataset-badge"
+                                                      max={999}
+                                                      showZero={true}
                                                     >
                                                       <span
-                                                        style={
-                                                          Object {
-                                                            "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                                            "marginRight": "calc(0.5 * 1ch + 6px)",
-                                                            "paddingRight": "1ch",
+                                                        className="MuiBadge-root"
+                                                        id="dataset-badge"
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                              "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                              "paddingRight": "1ch",
+                                                            }
                                                           }
-                                                        }
-                                                      >
-                                                        tabs.dataset
+                                                        >
+                                                          tabs.dataset
+                                                        </span>
+                                                        <span
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                        >
+                                                          0
+                                                        </span>
                                                       </span>
-                                                      <span
-                                                        className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1 MuiBadge-anchorOriginTopRightRectangle"
-                                                      >
-                                                        0
-                                                      </span>
-                                                    </span>
-                                                  </ForwardRef(Badge)>
-                                                </WithStyles(ForwardRef(Badge))>
-                                              </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                            </span>
-                                            <WithStyles(memo)
-                                              center={false}
-                                            >
-                                              <ForwardRef(TouchRipple)
+                                                    </ForwardRef(Badge)>
+                                                  </WithStyles(ForwardRef(Badge))>
+                                                </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                              </span>
+                                              <WithStyles(memo)
                                                 center={false}
-                                                classes={
-                                                  Object {
-                                                    "child": "MuiTouchRipple-child",
-                                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                                    "ripple": "MuiTouchRipple-ripple",
-                                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                    "root": "MuiTouchRipple-root",
-                                                  }
-                                                }
                                               >
-                                                <span
-                                                  className="MuiTouchRipple-root"
+                                                <ForwardRef(TouchRipple)
+                                                  center={false}
+                                                  classes={
+                                                    Object {
+                                                      "child": "MuiTouchRipple-child",
+                                                      "childLeaving": "MuiTouchRipple-childLeaving",
+                                                      "childPulsate": "MuiTouchRipple-childPulsate",
+                                                      "ripple": "MuiTouchRipple-ripple",
+                                                      "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                      "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                      "root": "MuiTouchRipple-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <TransitionGroup
-                                                    childFactory={[Function]}
-                                                    component={null}
-                                                    exit={true}
-                                                  />
-                                                </span>
-                                              </ForwardRef(TouchRipple)>
-                                            </WithStyles(memo)>
-                                          </button>
-                                        </ForwardRef(ButtonBase)>
-                                      </WithStyles(ForwardRef(ButtonBase))>
-                                    </ForwardRef(Tab)>
-                                  </WithStyles(ForwardRef(Tab))>
-                                  <WithStyles(ForwardRef(Tab))
-                                    aria-controls="simple-tabpanel-datafile"
-                                    fullWidth={false}
-                                    id="simple-tab-datafile"
-                                    indicator={false}
-                                    key=".2"
-                                    label={
-                                      <WithStyles(WithStyles(ForwardRef(Badge)))
-                                        badgeContent={0}
-                                        id="datafile-badge"
-                                        max={999}
-                                        showZero={true}
-                                      >
-                                        <span
-                                          style={
-                                            Object {
-                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                              "marginRight": "calc(0.5 * 1ch + 6px)",
-                                              "paddingRight": "1ch",
-                                            }
-                                          }
-                                        >
-                                          tabs.datafile
-                                        </span>
-                                      </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                    }
-                                    onChange={[Function]}
-                                    selected={false}
-                                    textColor="inherit"
-                                    value="datafile"
-                                  >
-                                    <ForwardRef(Tab)
+                                                  <span
+                                                    className="MuiTouchRipple-root"
+                                                  >
+                                                    <TransitionGroup
+                                                      childFactory={[Function]}
+                                                      component={null}
+                                                      exit={true}
+                                                    />
+                                                  </span>
+                                                </ForwardRef(TouchRipple)>
+                                              </WithStyles(memo)>
+                                            </button>
+                                          </ForwardRef(ButtonBase)>
+                                        </WithStyles(ForwardRef(ButtonBase))>
+                                      </ForwardRef(Tab)>
+                                    </WithStyles(ForwardRef(Tab))>
+                                    <WithStyles(ForwardRef(Tab))
                                       aria-controls="simple-tabpanel-datafile"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "fullWidth": "MuiTab-fullWidth",
-                                          "labelIcon": "MuiTab-labelIcon",
-                                          "root": "MuiTab-root",
-                                          "selected": "Mui-selected",
-                                          "textColorInherit": "MuiTab-textColorInherit",
-                                          "textColorPrimary": "MuiTab-textColorPrimary",
-                                          "textColorSecondary": "MuiTab-textColorSecondary",
-                                          "wrapped": "MuiTab-wrapped",
-                                          "wrapper": "MuiTab-wrapper",
-                                        }
-                                      }
                                       fullWidth={false}
                                       id="simple-tab-datafile"
                                       indicator={false}
+                                      key=".2"
                                       label={
                                         <WithStyles(WithStyles(ForwardRef(Badge)))
                                           badgeContent={0}
@@ -3033,29 +3000,54 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                       textColor="inherit"
                                       value="datafile"
                                     >
-                                      <WithStyles(ForwardRef(ButtonBase))
+                                      <ForwardRef(Tab)
                                         aria-controls="simple-tabpanel-datafile"
-                                        aria-selected={false}
-                                        className="MuiTab-root MuiTab-textColorInherit"
-                                        disabled={false}
-                                        focusRipple={true}
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "fullWidth": "MuiTab-fullWidth",
+                                            "labelIcon": "MuiTab-labelIcon",
+                                            "root": "MuiTab-root",
+                                            "selected": "Mui-selected",
+                                            "textColorInherit": "MuiTab-textColorInherit",
+                                            "textColorPrimary": "MuiTab-textColorPrimary",
+                                            "textColorSecondary": "MuiTab-textColorSecondary",
+                                            "wrapped": "MuiTab-wrapped",
+                                            "wrapper": "MuiTab-wrapper",
+                                          }
+                                        }
+                                        fullWidth={false}
                                         id="simple-tab-datafile"
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        role="tab"
-                                        tabIndex={-1}
+                                        indicator={false}
+                                        label={
+                                          <WithStyles(WithStyles(ForwardRef(Badge)))
+                                            badgeContent={0}
+                                            id="datafile-badge"
+                                            max={999}
+                                            showZero={true}
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                  "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                  "paddingRight": "1ch",
+                                                }
+                                              }
+                                            >
+                                              tabs.datafile
+                                            </span>
+                                          </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                        }
+                                        onChange={[Function]}
+                                        selected={false}
+                                        textColor="inherit"
+                                        value="datafile"
                                       >
-                                        <ForwardRef(ButtonBase)
+                                        <WithStyles(ForwardRef(ButtonBase))
                                           aria-controls="simple-tabpanel-datafile"
                                           aria-selected={false}
                                           className="MuiTab-root MuiTab-textColorInherit"
-                                          classes={
-                                            Object {
-                                              "disabled": "Mui-disabled",
-                                              "focusVisible": "Mui-focusVisible",
-                                              "root": "MuiButtonBase-root",
-                                            }
-                                          }
                                           disabled={false}
                                           focusRipple={true}
                                           id="simple-tab-datafile"
@@ -3064,153 +3056,153 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                           role="tab"
                                           tabIndex={-1}
                                         >
-                                          <button
+                                          <ForwardRef(ButtonBase)
                                             aria-controls="simple-tabpanel-datafile"
                                             aria-selected={false}
-                                            className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                            className="MuiTab-root MuiTab-textColorInherit"
+                                            classes={
+                                              Object {
+                                                "disabled": "Mui-disabled",
+                                                "focusVisible": "Mui-focusVisible",
+                                                "root": "MuiButtonBase-root",
+                                              }
+                                            }
                                             disabled={false}
+                                            focusRipple={true}
                                             id="simple-tab-datafile"
-                                            onBlur={[Function]}
                                             onClick={[Function]}
-                                            onDragLeave={[Function]}
                                             onFocus={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            onMouseDown={[Function]}
-                                            onMouseLeave={[Function]}
-                                            onMouseUp={[Function]}
-                                            onTouchEnd={[Function]}
-                                            onTouchMove={[Function]}
-                                            onTouchStart={[Function]}
                                             role="tab"
                                             tabIndex={-1}
-                                            type="button"
                                           >
-                                            <span
-                                              className="MuiTab-wrapper"
+                                            <button
+                                              aria-controls="simple-tabpanel-datafile"
+                                              aria-selected={false}
+                                              className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                              disabled={false}
+                                              id="simple-tab-datafile"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onDragLeave={[Function]}
+                                              onFocus={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              onMouseDown={[Function]}
+                                              onMouseLeave={[Function]}
+                                              onMouseUp={[Function]}
+                                              onTouchEnd={[Function]}
+                                              onTouchMove={[Function]}
+                                              onTouchStart={[Function]}
+                                              role="tab"
+                                              tabIndex={-1}
+                                              type="button"
                                             >
-                                              <WithStyles(WithStyles(ForwardRef(Badge)))
-                                                badgeContent={0}
-                                                id="datafile-badge"
-                                                max={999}
-                                                showZero={true}
+                                              <span
+                                                className="MuiTab-wrapper"
                                               >
-                                                <WithStyles(ForwardRef(Badge))
+                                                <WithStyles(WithStyles(ForwardRef(Badge)))
                                                   badgeContent={0}
-                                                  classes={
-                                                    Object {
-                                                      "badge": "WithStyles(ForwardRef(Badge))-badge-1",
-                                                    }
-                                                  }
                                                   id="datafile-badge"
                                                   max={999}
                                                   showZero={true}
                                                 >
-                                                  <ForwardRef(Badge)
+                                                  <WithStyles(ForwardRef(Badge))
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                        "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                        "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                        "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                        "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                        "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                        "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                        "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                        "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1",
-                                                        "colorError": "MuiBadge-colorError",
-                                                        "colorPrimary": "MuiBadge-colorPrimary",
-                                                        "colorSecondary": "MuiBadge-colorSecondary",
-                                                        "dot": "MuiBadge-dot",
-                                                        "invisible": "MuiBadge-invisible",
-                                                        "root": "MuiBadge-root",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
                                                       }
                                                     }
                                                     id="datafile-badge"
                                                     max={999}
                                                     showZero={true}
                                                   >
-                                                    <span
-                                                      className="MuiBadge-root"
+                                                    <ForwardRef(Badge)
+                                                      badgeContent={0}
+                                                      classes={
+                                                        Object {
+                                                          "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
+                                                          "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
+                                                          "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
+                                                          "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
+                                                          "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
+                                                          "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
+                                                          "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
+                                                          "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "colorError": "MuiBadge-colorError",
+                                                          "colorPrimary": "MuiBadge-colorPrimary",
+                                                          "colorSecondary": "MuiBadge-colorSecondary",
+                                                          "dot": "MuiBadge-dot",
+                                                          "invisible": "MuiBadge-invisible",
+                                                          "root": "MuiBadge-root",
+                                                        }
+                                                      }
                                                       id="datafile-badge"
+                                                      max={999}
+                                                      showZero={true}
                                                     >
                                                       <span
-                                                        style={
-                                                          Object {
-                                                            "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                                            "marginRight": "calc(0.5 * 1ch + 6px)",
-                                                            "paddingRight": "1ch",
+                                                        className="MuiBadge-root"
+                                                        id="datafile-badge"
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                              "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                              "paddingRight": "1ch",
+                                                            }
                                                           }
-                                                        }
-                                                      >
-                                                        tabs.datafile
+                                                        >
+                                                          tabs.datafile
+                                                        </span>
+                                                        <span
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                        >
+                                                          0
+                                                        </span>
                                                       </span>
-                                                      <span
-                                                        className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1 MuiBadge-anchorOriginTopRightRectangle"
-                                                      >
-                                                        0
-                                                      </span>
-                                                    </span>
-                                                  </ForwardRef(Badge)>
-                                                </WithStyles(ForwardRef(Badge))>
-                                              </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                            </span>
-                                            <WithStyles(memo)
-                                              center={false}
-                                            >
-                                              <ForwardRef(TouchRipple)
+                                                    </ForwardRef(Badge)>
+                                                  </WithStyles(ForwardRef(Badge))>
+                                                </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                              </span>
+                                              <WithStyles(memo)
                                                 center={false}
-                                                classes={
-                                                  Object {
-                                                    "child": "MuiTouchRipple-child",
-                                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                                    "ripple": "MuiTouchRipple-ripple",
-                                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                    "root": "MuiTouchRipple-root",
-                                                  }
-                                                }
                                               >
-                                                <span
-                                                  className="MuiTouchRipple-root"
+                                                <ForwardRef(TouchRipple)
+                                                  center={false}
+                                                  classes={
+                                                    Object {
+                                                      "child": "MuiTouchRipple-child",
+                                                      "childLeaving": "MuiTouchRipple-childLeaving",
+                                                      "childPulsate": "MuiTouchRipple-childPulsate",
+                                                      "ripple": "MuiTouchRipple-ripple",
+                                                      "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                      "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                      "root": "MuiTouchRipple-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <TransitionGroup
-                                                    childFactory={[Function]}
-                                                    component={null}
-                                                    exit={true}
-                                                  />
-                                                </span>
-                                              </ForwardRef(TouchRipple)>
-                                            </WithStyles(memo)>
-                                          </button>
-                                        </ForwardRef(ButtonBase)>
-                                      </WithStyles(ForwardRef(ButtonBase))>
-                                    </ForwardRef(Tab)>
-                                  </WithStyles(ForwardRef(Tab))>
-                                </div>
-                                <WithStyles(ForwardRef(TabIndicator))
-                                  className="MuiTabs-indicator"
-                                  color="secondary"
-                                  orientation="horizontal"
-                                  style={
-                                    Object {
-                                      "left": 0,
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <ForwardRef(TabIndicator)
-                                    className="MuiTabs-indicator"
-                                    classes={
-                                      Object {
-                                        "colorPrimary": "PrivateTabIndicator-colorPrimary-3",
-                                        "colorSecondary": "PrivateTabIndicator-colorSecondary-4",
-                                        "root": "PrivateTabIndicator-root-2",
-                                        "vertical": "PrivateTabIndicator-vertical-5",
-                                      }
-                                    }
+                                                  <span
+                                                    className="MuiTouchRipple-root"
+                                                  >
+                                                    <TransitionGroup
+                                                      childFactory={[Function]}
+                                                      component={null}
+                                                      exit={true}
+                                                    />
+                                                  </span>
+                                                </ForwardRef(TouchRipple)>
+                                              </WithStyles(memo)>
+                                            </button>
+                                          </ForwardRef(ButtonBase)>
+                                        </WithStyles(ForwardRef(ButtonBase))>
+                                      </ForwardRef(Tab)>
+                                    </WithStyles(ForwardRef(Tab))>
+                                  </div>
+                                  <WithStyles(ForwardRef(TabIndicator))
+                                    className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
                                     color="secondary"
                                     orientation="horizontal"
                                     style={
@@ -3220,21 +3212,41 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                       }
                                     }
                                   >
-                                    <span
-                                      className="PrivateTabIndicator-root-2 PrivateTabIndicator-colorSecondary-4 MuiTabs-indicator"
+                                    <ForwardRef(TabIndicator)
+                                      className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                      classes={
+                                        Object {
+                                          "colorPrimary": "PrivateTabIndicator-colorPrimary-4",
+                                          "colorSecondary": "PrivateTabIndicator-colorSecondary-5",
+                                          "root": "PrivateTabIndicator-root-3",
+                                          "vertical": "PrivateTabIndicator-vertical-6",
+                                        }
+                                      }
+                                      color="secondary"
+                                      orientation="horizontal"
                                       style={
                                         Object {
                                           "left": 0,
                                           "width": 0,
                                         }
                                       }
-                                    />
-                                  </ForwardRef(TabIndicator)>
-                                </WithStyles(ForwardRef(TabIndicator))>
+                                    >
+                                      <span
+                                        className="PrivateTabIndicator-root-3 PrivateTabIndicator-colorSecondary-5 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                        style={
+                                          Object {
+                                            "left": 0,
+                                            "width": 0,
+                                          }
+                                        }
+                                      />
+                                    </ForwardRef(TabIndicator)>
+                                  </WithStyles(ForwardRef(TabIndicator))>
+                                </div>
                               </div>
-                            </div>
-                          </ForwardRef(Tabs)>
-                        </WithStyles(ForwardRef(Tabs))>
+                            </ForwardRef(Tabs)>
+                          </WithStyles(ForwardRef(Tabs))>
+                        </WithStyles(WithStyles(ForwardRef(Tabs)))>
                       </header>
                     </ForwardRef(Paper)>
                   </WithStyles(ForwardRef(Paper))>
@@ -3254,7 +3266,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                 >
                   <div
                     aria-labelledby="simple-tab-investigation"
-                    className="MuiBox-root MuiBox-root-6"
+                    className="MuiBox-root MuiBox-root-7"
                     hidden={false}
                     id="simple-tabpanel-investigation"
                     role="tabpanel"
@@ -3263,7 +3275,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                       p={3}
                     >
                       <div
-                        className="MuiBox-root MuiBox-root-7"
+                        className="MuiBox-root MuiBox-root-8"
                       >
                         <InvestigationCardView>
                           <mockConstructor

--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.test.tsx.snap
@@ -3128,102 +3128,69 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       <header
                         className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation4"
                       >
-                        <WithStyles(ForwardRef(Tabs))
+                        <WithStyles(WithStyles(ForwardRef(Tabs)))
                           aria-label="searchPageTable.tabs_arialabel"
                           className="tour-search-tab-select"
                           onChange={[Function]}
                           value="investigation"
                         >
-                          <ForwardRef(Tabs)
+                          <WithStyles(ForwardRef(Tabs))
                             aria-label="searchPageTable.tabs_arialabel"
                             className="tour-search-tab-select"
                             classes={
                               Object {
-                                "centered": "MuiTabs-centered",
-                                "fixed": "MuiTabs-fixed",
-                                "flexContainer": "MuiTabs-flexContainer",
-                                "flexContainerVertical": "MuiTabs-flexContainerVertical",
-                                "indicator": "MuiTabs-indicator",
-                                "root": "MuiTabs-root",
-                                "scrollButtons": "MuiTabs-scrollButtons",
-                                "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
-                                "scrollable": "MuiTabs-scrollable",
-                                "scroller": "MuiTabs-scroller",
-                                "vertical": "MuiTabs-vertical",
+                                "indicator": "WithStyles(ForwardRef(Tabs))-indicator-1",
                               }
                             }
                             onChange={[Function]}
                             value="investigation"
                           >
-                            <div
-                              className="MuiTabs-root tour-search-tab-select"
+                            <ForwardRef(Tabs)
+                              aria-label="searchPageTable.tabs_arialabel"
+                              className="tour-search-tab-select"
+                              classes={
+                                Object {
+                                  "centered": "MuiTabs-centered",
+                                  "fixed": "MuiTabs-fixed",
+                                  "flexContainer": "MuiTabs-flexContainer",
+                                  "flexContainerVertical": "MuiTabs-flexContainerVertical",
+                                  "indicator": "MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1",
+                                  "root": "MuiTabs-root",
+                                  "scrollButtons": "MuiTabs-scrollButtons",
+                                  "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
+                                  "scrollable": "MuiTabs-scrollable",
+                                  "scroller": "MuiTabs-scroller",
+                                  "vertical": "MuiTabs-vertical",
+                                }
+                              }
+                              onChange={[Function]}
+                              value="investigation"
                             >
                               <div
-                                className="MuiTabs-scroller MuiTabs-fixed"
-                                onScroll={[Function]}
-                                style={
-                                  Object {
-                                    "marginBottom": null,
-                                    "overflow": "hidden",
-                                  }
-                                }
+                                className="MuiTabs-root tour-search-tab-select"
                               >
                                 <div
-                                  aria-label="searchPageTable.tabs_arialabel"
-                                  className="MuiTabs-flexContainer"
-                                  onKeyDown={[Function]}
-                                  role="tablist"
-                                >
-                                  <WithStyles(ForwardRef(Tab))
-                                    aria-controls="simple-tabpanel-investigation"
-                                    fullWidth={false}
-                                    id="simple-tab-investigation"
-                                    indicator={false}
-                                    key=".0"
-                                    label={
-                                      <WithStyles(WithStyles(ForwardRef(Badge)))
-                                        badgeContent={0}
-                                        id="investigation-badge"
-                                        max={999}
-                                        showZero={true}
-                                      >
-                                        <span
-                                          style={
-                                            Object {
-                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                              "marginRight": "calc(0.5 * 1ch + 6px)",
-                                              "paddingRight": "1ch",
-                                            }
-                                          }
-                                        >
-                                          tabs.investigation
-                                        </span>
-                                      </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                  className="MuiTabs-scroller MuiTabs-fixed"
+                                  onScroll={[Function]}
+                                  style={
+                                    Object {
+                                      "marginBottom": null,
+                                      "overflow": "hidden",
                                     }
-                                    onChange={[Function]}
-                                    selected={true}
-                                    textColor="inherit"
-                                    value="investigation"
+                                  }
+                                >
+                                  <div
+                                    aria-label="searchPageTable.tabs_arialabel"
+                                    className="MuiTabs-flexContainer"
+                                    onKeyDown={[Function]}
+                                    role="tablist"
                                   >
-                                    <ForwardRef(Tab)
+                                    <WithStyles(ForwardRef(Tab))
                                       aria-controls="simple-tabpanel-investigation"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "fullWidth": "MuiTab-fullWidth",
-                                          "labelIcon": "MuiTab-labelIcon",
-                                          "root": "MuiTab-root",
-                                          "selected": "Mui-selected",
-                                          "textColorInherit": "MuiTab-textColorInherit",
-                                          "textColorPrimary": "MuiTab-textColorPrimary",
-                                          "textColorSecondary": "MuiTab-textColorSecondary",
-                                          "wrapped": "MuiTab-wrapped",
-                                          "wrapper": "MuiTab-wrapper",
-                                        }
-                                      }
                                       fullWidth={false}
                                       id="simple-tab-investigation"
                                       indicator={false}
+                                      key=".0"
                                       label={
                                         <WithStyles(WithStyles(ForwardRef(Badge)))
                                           badgeContent={0}
@@ -3249,29 +3216,54 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                       textColor="inherit"
                                       value="investigation"
                                     >
-                                      <WithStyles(ForwardRef(ButtonBase))
+                                      <ForwardRef(Tab)
                                         aria-controls="simple-tabpanel-investigation"
-                                        aria-selected={true}
-                                        className="MuiTab-root MuiTab-textColorInherit Mui-selected"
-                                        disabled={false}
-                                        focusRipple={true}
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "fullWidth": "MuiTab-fullWidth",
+                                            "labelIcon": "MuiTab-labelIcon",
+                                            "root": "MuiTab-root",
+                                            "selected": "Mui-selected",
+                                            "textColorInherit": "MuiTab-textColorInherit",
+                                            "textColorPrimary": "MuiTab-textColorPrimary",
+                                            "textColorSecondary": "MuiTab-textColorSecondary",
+                                            "wrapped": "MuiTab-wrapped",
+                                            "wrapper": "MuiTab-wrapper",
+                                          }
+                                        }
+                                        fullWidth={false}
                                         id="simple-tab-investigation"
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        role="tab"
-                                        tabIndex={0}
+                                        indicator={false}
+                                        label={
+                                          <WithStyles(WithStyles(ForwardRef(Badge)))
+                                            badgeContent={0}
+                                            id="investigation-badge"
+                                            max={999}
+                                            showZero={true}
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                  "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                  "paddingRight": "1ch",
+                                                }
+                                              }
+                                            >
+                                              tabs.investigation
+                                            </span>
+                                          </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                        }
+                                        onChange={[Function]}
+                                        selected={true}
+                                        textColor="inherit"
+                                        value="investigation"
                                       >
-                                        <ForwardRef(ButtonBase)
+                                        <WithStyles(ForwardRef(ButtonBase))
                                           aria-controls="simple-tabpanel-investigation"
                                           aria-selected={true}
                                           className="MuiTab-root MuiTab-textColorInherit Mui-selected"
-                                          classes={
-                                            Object {
-                                              "disabled": "Mui-disabled",
-                                              "focusVisible": "Mui-focusVisible",
-                                              "root": "MuiButtonBase-root",
-                                            }
-                                          }
                                           disabled={false}
                                           focusRipple={true}
                                           id="simple-tab-investigation"
@@ -3280,181 +3272,156 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                           role="tab"
                                           tabIndex={0}
                                         >
-                                          <button
+                                          <ForwardRef(ButtonBase)
                                             aria-controls="simple-tabpanel-investigation"
                                             aria-selected={true}
-                                            className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                            className="MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                            classes={
+                                              Object {
+                                                "disabled": "Mui-disabled",
+                                                "focusVisible": "Mui-focusVisible",
+                                                "root": "MuiButtonBase-root",
+                                              }
+                                            }
                                             disabled={false}
+                                            focusRipple={true}
                                             id="simple-tab-investigation"
-                                            onBlur={[Function]}
                                             onClick={[Function]}
-                                            onDragLeave={[Function]}
                                             onFocus={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            onMouseDown={[Function]}
-                                            onMouseLeave={[Function]}
-                                            onMouseUp={[Function]}
-                                            onTouchEnd={[Function]}
-                                            onTouchMove={[Function]}
-                                            onTouchStart={[Function]}
                                             role="tab"
                                             tabIndex={0}
-                                            type="button"
                                           >
-                                            <span
-                                              className="MuiTab-wrapper"
+                                            <button
+                                              aria-controls="simple-tabpanel-investigation"
+                                              aria-selected={true}
+                                              className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                              disabled={false}
+                                              id="simple-tab-investigation"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onDragLeave={[Function]}
+                                              onFocus={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              onMouseDown={[Function]}
+                                              onMouseLeave={[Function]}
+                                              onMouseUp={[Function]}
+                                              onTouchEnd={[Function]}
+                                              onTouchMove={[Function]}
+                                              onTouchStart={[Function]}
+                                              role="tab"
+                                              tabIndex={0}
+                                              type="button"
                                             >
-                                              <WithStyles(WithStyles(ForwardRef(Badge)))
-                                                badgeContent={0}
-                                                id="investigation-badge"
-                                                max={999}
-                                                showZero={true}
+                                              <span
+                                                className="MuiTab-wrapper"
                                               >
-                                                <WithStyles(ForwardRef(Badge))
+                                                <WithStyles(WithStyles(ForwardRef(Badge)))
                                                   badgeContent={0}
-                                                  classes={
-                                                    Object {
-                                                      "badge": "WithStyles(ForwardRef(Badge))-badge-1",
-                                                    }
-                                                  }
                                                   id="investigation-badge"
                                                   max={999}
                                                   showZero={true}
                                                 >
-                                                  <ForwardRef(Badge)
+                                                  <WithStyles(ForwardRef(Badge))
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                        "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                        "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                        "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                        "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                        "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                        "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                        "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                        "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1",
-                                                        "colorError": "MuiBadge-colorError",
-                                                        "colorPrimary": "MuiBadge-colorPrimary",
-                                                        "colorSecondary": "MuiBadge-colorSecondary",
-                                                        "dot": "MuiBadge-dot",
-                                                        "invisible": "MuiBadge-invisible",
-                                                        "root": "MuiBadge-root",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
                                                       }
                                                     }
                                                     id="investigation-badge"
                                                     max={999}
                                                     showZero={true}
                                                   >
-                                                    <span
-                                                      className="MuiBadge-root"
+                                                    <ForwardRef(Badge)
+                                                      badgeContent={0}
+                                                      classes={
+                                                        Object {
+                                                          "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
+                                                          "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
+                                                          "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
+                                                          "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
+                                                          "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
+                                                          "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
+                                                          "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
+                                                          "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "colorError": "MuiBadge-colorError",
+                                                          "colorPrimary": "MuiBadge-colorPrimary",
+                                                          "colorSecondary": "MuiBadge-colorSecondary",
+                                                          "dot": "MuiBadge-dot",
+                                                          "invisible": "MuiBadge-invisible",
+                                                          "root": "MuiBadge-root",
+                                                        }
+                                                      }
                                                       id="investigation-badge"
+                                                      max={999}
+                                                      showZero={true}
                                                     >
                                                       <span
-                                                        style={
-                                                          Object {
-                                                            "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                                            "marginRight": "calc(0.5 * 1ch + 6px)",
-                                                            "paddingRight": "1ch",
+                                                        className="MuiBadge-root"
+                                                        id="investigation-badge"
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                              "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                              "paddingRight": "1ch",
+                                                            }
                                                           }
-                                                        }
-                                                      >
-                                                        tabs.investigation
+                                                        >
+                                                          tabs.investigation
+                                                        </span>
+                                                        <span
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                        >
+                                                          0
+                                                        </span>
                                                       </span>
-                                                      <span
-                                                        className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1 MuiBadge-anchorOriginTopRightRectangle"
-                                                      >
-                                                        0
-                                                      </span>
-                                                    </span>
-                                                  </ForwardRef(Badge)>
-                                                </WithStyles(ForwardRef(Badge))>
-                                              </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                            </span>
-                                            <WithStyles(memo)
-                                              center={false}
-                                            >
-                                              <ForwardRef(TouchRipple)
+                                                    </ForwardRef(Badge)>
+                                                  </WithStyles(ForwardRef(Badge))>
+                                                </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                              </span>
+                                              <WithStyles(memo)
                                                 center={false}
-                                                classes={
-                                                  Object {
-                                                    "child": "MuiTouchRipple-child",
-                                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                                    "ripple": "MuiTouchRipple-ripple",
-                                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                    "root": "MuiTouchRipple-root",
-                                                  }
-                                                }
                                               >
-                                                <span
-                                                  className="MuiTouchRipple-root"
+                                                <ForwardRef(TouchRipple)
+                                                  center={false}
+                                                  classes={
+                                                    Object {
+                                                      "child": "MuiTouchRipple-child",
+                                                      "childLeaving": "MuiTouchRipple-childLeaving",
+                                                      "childPulsate": "MuiTouchRipple-childPulsate",
+                                                      "ripple": "MuiTouchRipple-ripple",
+                                                      "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                      "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                      "root": "MuiTouchRipple-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <TransitionGroup
-                                                    childFactory={[Function]}
-                                                    component={null}
-                                                    exit={true}
-                                                  />
-                                                </span>
-                                              </ForwardRef(TouchRipple)>
-                                            </WithStyles(memo)>
-                                          </button>
-                                        </ForwardRef(ButtonBase)>
-                                      </WithStyles(ForwardRef(ButtonBase))>
-                                    </ForwardRef(Tab)>
-                                  </WithStyles(ForwardRef(Tab))>
-                                  <WithStyles(ForwardRef(Tab))
-                                    aria-controls="simple-tabpanel-dataset"
-                                    fullWidth={false}
-                                    id="simple-tab-dataset"
-                                    indicator={false}
-                                    key=".1"
-                                    label={
-                                      <WithStyles(WithStyles(ForwardRef(Badge)))
-                                        badgeContent={0}
-                                        id="dataset-badge"
-                                        max={999}
-                                        showZero={true}
-                                      >
-                                        <span
-                                          style={
-                                            Object {
-                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                              "marginRight": "calc(0.5 * 1ch + 6px)",
-                                              "paddingRight": "1ch",
-                                            }
-                                          }
-                                        >
-                                          tabs.dataset
-                                        </span>
-                                      </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                    }
-                                    onChange={[Function]}
-                                    selected={false}
-                                    textColor="inherit"
-                                    value="dataset"
-                                  >
-                                    <ForwardRef(Tab)
+                                                  <span
+                                                    className="MuiTouchRipple-root"
+                                                  >
+                                                    <TransitionGroup
+                                                      childFactory={[Function]}
+                                                      component={null}
+                                                      exit={true}
+                                                    />
+                                                  </span>
+                                                </ForwardRef(TouchRipple)>
+                                              </WithStyles(memo)>
+                                            </button>
+                                          </ForwardRef(ButtonBase)>
+                                        </WithStyles(ForwardRef(ButtonBase))>
+                                      </ForwardRef(Tab)>
+                                    </WithStyles(ForwardRef(Tab))>
+                                    <WithStyles(ForwardRef(Tab))
                                       aria-controls="simple-tabpanel-dataset"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "fullWidth": "MuiTab-fullWidth",
-                                          "labelIcon": "MuiTab-labelIcon",
-                                          "root": "MuiTab-root",
-                                          "selected": "Mui-selected",
-                                          "textColorInherit": "MuiTab-textColorInherit",
-                                          "textColorPrimary": "MuiTab-textColorPrimary",
-                                          "textColorSecondary": "MuiTab-textColorSecondary",
-                                          "wrapped": "MuiTab-wrapped",
-                                          "wrapper": "MuiTab-wrapper",
-                                        }
-                                      }
                                       fullWidth={false}
                                       id="simple-tab-dataset"
                                       indicator={false}
+                                      key=".1"
                                       label={
                                         <WithStyles(WithStyles(ForwardRef(Badge)))
                                           badgeContent={0}
@@ -3480,29 +3447,54 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                       textColor="inherit"
                                       value="dataset"
                                     >
-                                      <WithStyles(ForwardRef(ButtonBase))
+                                      <ForwardRef(Tab)
                                         aria-controls="simple-tabpanel-dataset"
-                                        aria-selected={false}
-                                        className="MuiTab-root MuiTab-textColorInherit"
-                                        disabled={false}
-                                        focusRipple={true}
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "fullWidth": "MuiTab-fullWidth",
+                                            "labelIcon": "MuiTab-labelIcon",
+                                            "root": "MuiTab-root",
+                                            "selected": "Mui-selected",
+                                            "textColorInherit": "MuiTab-textColorInherit",
+                                            "textColorPrimary": "MuiTab-textColorPrimary",
+                                            "textColorSecondary": "MuiTab-textColorSecondary",
+                                            "wrapped": "MuiTab-wrapped",
+                                            "wrapper": "MuiTab-wrapper",
+                                          }
+                                        }
+                                        fullWidth={false}
                                         id="simple-tab-dataset"
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        role="tab"
-                                        tabIndex={-1}
+                                        indicator={false}
+                                        label={
+                                          <WithStyles(WithStyles(ForwardRef(Badge)))
+                                            badgeContent={0}
+                                            id="dataset-badge"
+                                            max={999}
+                                            showZero={true}
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                  "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                  "paddingRight": "1ch",
+                                                }
+                                              }
+                                            >
+                                              tabs.dataset
+                                            </span>
+                                          </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                        }
+                                        onChange={[Function]}
+                                        selected={false}
+                                        textColor="inherit"
+                                        value="dataset"
                                       >
-                                        <ForwardRef(ButtonBase)
+                                        <WithStyles(ForwardRef(ButtonBase))
                                           aria-controls="simple-tabpanel-dataset"
                                           aria-selected={false}
                                           className="MuiTab-root MuiTab-textColorInherit"
-                                          classes={
-                                            Object {
-                                              "disabled": "Mui-disabled",
-                                              "focusVisible": "Mui-focusVisible",
-                                              "root": "MuiButtonBase-root",
-                                            }
-                                          }
                                           disabled={false}
                                           focusRipple={true}
                                           id="simple-tab-dataset"
@@ -3511,181 +3503,156 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                           role="tab"
                                           tabIndex={-1}
                                         >
-                                          <button
+                                          <ForwardRef(ButtonBase)
                                             aria-controls="simple-tabpanel-dataset"
                                             aria-selected={false}
-                                            className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                            className="MuiTab-root MuiTab-textColorInherit"
+                                            classes={
+                                              Object {
+                                                "disabled": "Mui-disabled",
+                                                "focusVisible": "Mui-focusVisible",
+                                                "root": "MuiButtonBase-root",
+                                              }
+                                            }
                                             disabled={false}
+                                            focusRipple={true}
                                             id="simple-tab-dataset"
-                                            onBlur={[Function]}
                                             onClick={[Function]}
-                                            onDragLeave={[Function]}
                                             onFocus={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            onMouseDown={[Function]}
-                                            onMouseLeave={[Function]}
-                                            onMouseUp={[Function]}
-                                            onTouchEnd={[Function]}
-                                            onTouchMove={[Function]}
-                                            onTouchStart={[Function]}
                                             role="tab"
                                             tabIndex={-1}
-                                            type="button"
                                           >
-                                            <span
-                                              className="MuiTab-wrapper"
+                                            <button
+                                              aria-controls="simple-tabpanel-dataset"
+                                              aria-selected={false}
+                                              className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                              disabled={false}
+                                              id="simple-tab-dataset"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onDragLeave={[Function]}
+                                              onFocus={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              onMouseDown={[Function]}
+                                              onMouseLeave={[Function]}
+                                              onMouseUp={[Function]}
+                                              onTouchEnd={[Function]}
+                                              onTouchMove={[Function]}
+                                              onTouchStart={[Function]}
+                                              role="tab"
+                                              tabIndex={-1}
+                                              type="button"
                                             >
-                                              <WithStyles(WithStyles(ForwardRef(Badge)))
-                                                badgeContent={0}
-                                                id="dataset-badge"
-                                                max={999}
-                                                showZero={true}
+                                              <span
+                                                className="MuiTab-wrapper"
                                               >
-                                                <WithStyles(ForwardRef(Badge))
+                                                <WithStyles(WithStyles(ForwardRef(Badge)))
                                                   badgeContent={0}
-                                                  classes={
-                                                    Object {
-                                                      "badge": "WithStyles(ForwardRef(Badge))-badge-1",
-                                                    }
-                                                  }
                                                   id="dataset-badge"
                                                   max={999}
                                                   showZero={true}
                                                 >
-                                                  <ForwardRef(Badge)
+                                                  <WithStyles(ForwardRef(Badge))
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                        "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                        "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                        "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                        "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                        "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                        "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                        "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                        "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1",
-                                                        "colorError": "MuiBadge-colorError",
-                                                        "colorPrimary": "MuiBadge-colorPrimary",
-                                                        "colorSecondary": "MuiBadge-colorSecondary",
-                                                        "dot": "MuiBadge-dot",
-                                                        "invisible": "MuiBadge-invisible",
-                                                        "root": "MuiBadge-root",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
                                                       }
                                                     }
                                                     id="dataset-badge"
                                                     max={999}
                                                     showZero={true}
                                                   >
-                                                    <span
-                                                      className="MuiBadge-root"
+                                                    <ForwardRef(Badge)
+                                                      badgeContent={0}
+                                                      classes={
+                                                        Object {
+                                                          "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
+                                                          "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
+                                                          "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
+                                                          "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
+                                                          "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
+                                                          "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
+                                                          "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
+                                                          "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "colorError": "MuiBadge-colorError",
+                                                          "colorPrimary": "MuiBadge-colorPrimary",
+                                                          "colorSecondary": "MuiBadge-colorSecondary",
+                                                          "dot": "MuiBadge-dot",
+                                                          "invisible": "MuiBadge-invisible",
+                                                          "root": "MuiBadge-root",
+                                                        }
+                                                      }
                                                       id="dataset-badge"
+                                                      max={999}
+                                                      showZero={true}
                                                     >
                                                       <span
-                                                        style={
-                                                          Object {
-                                                            "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                                            "marginRight": "calc(0.5 * 1ch + 6px)",
-                                                            "paddingRight": "1ch",
+                                                        className="MuiBadge-root"
+                                                        id="dataset-badge"
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                              "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                              "paddingRight": "1ch",
+                                                            }
                                                           }
-                                                        }
-                                                      >
-                                                        tabs.dataset
+                                                        >
+                                                          tabs.dataset
+                                                        </span>
+                                                        <span
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                        >
+                                                          0
+                                                        </span>
                                                       </span>
-                                                      <span
-                                                        className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1 MuiBadge-anchorOriginTopRightRectangle"
-                                                      >
-                                                        0
-                                                      </span>
-                                                    </span>
-                                                  </ForwardRef(Badge)>
-                                                </WithStyles(ForwardRef(Badge))>
-                                              </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                            </span>
-                                            <WithStyles(memo)
-                                              center={false}
-                                            >
-                                              <ForwardRef(TouchRipple)
+                                                    </ForwardRef(Badge)>
+                                                  </WithStyles(ForwardRef(Badge))>
+                                                </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                              </span>
+                                              <WithStyles(memo)
                                                 center={false}
-                                                classes={
-                                                  Object {
-                                                    "child": "MuiTouchRipple-child",
-                                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                                    "ripple": "MuiTouchRipple-ripple",
-                                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                    "root": "MuiTouchRipple-root",
-                                                  }
-                                                }
                                               >
-                                                <span
-                                                  className="MuiTouchRipple-root"
+                                                <ForwardRef(TouchRipple)
+                                                  center={false}
+                                                  classes={
+                                                    Object {
+                                                      "child": "MuiTouchRipple-child",
+                                                      "childLeaving": "MuiTouchRipple-childLeaving",
+                                                      "childPulsate": "MuiTouchRipple-childPulsate",
+                                                      "ripple": "MuiTouchRipple-ripple",
+                                                      "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                      "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                      "root": "MuiTouchRipple-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <TransitionGroup
-                                                    childFactory={[Function]}
-                                                    component={null}
-                                                    exit={true}
-                                                  />
-                                                </span>
-                                              </ForwardRef(TouchRipple)>
-                                            </WithStyles(memo)>
-                                          </button>
-                                        </ForwardRef(ButtonBase)>
-                                      </WithStyles(ForwardRef(ButtonBase))>
-                                    </ForwardRef(Tab)>
-                                  </WithStyles(ForwardRef(Tab))>
-                                  <WithStyles(ForwardRef(Tab))
-                                    aria-controls="simple-tabpanel-datafile"
-                                    fullWidth={false}
-                                    id="simple-tab-datafile"
-                                    indicator={false}
-                                    key=".2"
-                                    label={
-                                      <WithStyles(WithStyles(ForwardRef(Badge)))
-                                        badgeContent={0}
-                                        id="datafile-badge"
-                                        max={999}
-                                        showZero={true}
-                                      >
-                                        <span
-                                          style={
-                                            Object {
-                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                              "marginRight": "calc(0.5 * 1ch + 6px)",
-                                              "paddingRight": "1ch",
-                                            }
-                                          }
-                                        >
-                                          tabs.datafile
-                                        </span>
-                                      </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                    }
-                                    onChange={[Function]}
-                                    selected={false}
-                                    textColor="inherit"
-                                    value="datafile"
-                                  >
-                                    <ForwardRef(Tab)
+                                                  <span
+                                                    className="MuiTouchRipple-root"
+                                                  >
+                                                    <TransitionGroup
+                                                      childFactory={[Function]}
+                                                      component={null}
+                                                      exit={true}
+                                                    />
+                                                  </span>
+                                                </ForwardRef(TouchRipple)>
+                                              </WithStyles(memo)>
+                                            </button>
+                                          </ForwardRef(ButtonBase)>
+                                        </WithStyles(ForwardRef(ButtonBase))>
+                                      </ForwardRef(Tab)>
+                                    </WithStyles(ForwardRef(Tab))>
+                                    <WithStyles(ForwardRef(Tab))
                                       aria-controls="simple-tabpanel-datafile"
-                                      classes={
-                                        Object {
-                                          "disabled": "Mui-disabled",
-                                          "fullWidth": "MuiTab-fullWidth",
-                                          "labelIcon": "MuiTab-labelIcon",
-                                          "root": "MuiTab-root",
-                                          "selected": "Mui-selected",
-                                          "textColorInherit": "MuiTab-textColorInherit",
-                                          "textColorPrimary": "MuiTab-textColorPrimary",
-                                          "textColorSecondary": "MuiTab-textColorSecondary",
-                                          "wrapped": "MuiTab-wrapped",
-                                          "wrapper": "MuiTab-wrapper",
-                                        }
-                                      }
                                       fullWidth={false}
                                       id="simple-tab-datafile"
                                       indicator={false}
+                                      key=".2"
                                       label={
                                         <WithStyles(WithStyles(ForwardRef(Badge)))
                                           badgeContent={0}
@@ -3711,29 +3678,54 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                       textColor="inherit"
                                       value="datafile"
                                     >
-                                      <WithStyles(ForwardRef(ButtonBase))
+                                      <ForwardRef(Tab)
                                         aria-controls="simple-tabpanel-datafile"
-                                        aria-selected={false}
-                                        className="MuiTab-root MuiTab-textColorInherit"
-                                        disabled={false}
-                                        focusRipple={true}
+                                        classes={
+                                          Object {
+                                            "disabled": "Mui-disabled",
+                                            "fullWidth": "MuiTab-fullWidth",
+                                            "labelIcon": "MuiTab-labelIcon",
+                                            "root": "MuiTab-root",
+                                            "selected": "Mui-selected",
+                                            "textColorInherit": "MuiTab-textColorInherit",
+                                            "textColorPrimary": "MuiTab-textColorPrimary",
+                                            "textColorSecondary": "MuiTab-textColorSecondary",
+                                            "wrapped": "MuiTab-wrapped",
+                                            "wrapper": "MuiTab-wrapper",
+                                          }
+                                        }
+                                        fullWidth={false}
                                         id="simple-tab-datafile"
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        role="tab"
-                                        tabIndex={-1}
+                                        indicator={false}
+                                        label={
+                                          <WithStyles(WithStyles(ForwardRef(Badge)))
+                                            badgeContent={0}
+                                            id="datafile-badge"
+                                            max={999}
+                                            showZero={true}
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                  "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                  "paddingRight": "1ch",
+                                                }
+                                              }
+                                            >
+                                              tabs.datafile
+                                            </span>
+                                          </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                        }
+                                        onChange={[Function]}
+                                        selected={false}
+                                        textColor="inherit"
+                                        value="datafile"
                                       >
-                                        <ForwardRef(ButtonBase)
+                                        <WithStyles(ForwardRef(ButtonBase))
                                           aria-controls="simple-tabpanel-datafile"
                                           aria-selected={false}
                                           className="MuiTab-root MuiTab-textColorInherit"
-                                          classes={
-                                            Object {
-                                              "disabled": "Mui-disabled",
-                                              "focusVisible": "Mui-focusVisible",
-                                              "root": "MuiButtonBase-root",
-                                            }
-                                          }
                                           disabled={false}
                                           focusRipple={true}
                                           id="simple-tab-datafile"
@@ -3742,153 +3734,153 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                           role="tab"
                                           tabIndex={-1}
                                         >
-                                          <button
+                                          <ForwardRef(ButtonBase)
                                             aria-controls="simple-tabpanel-datafile"
                                             aria-selected={false}
-                                            className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                            className="MuiTab-root MuiTab-textColorInherit"
+                                            classes={
+                                              Object {
+                                                "disabled": "Mui-disabled",
+                                                "focusVisible": "Mui-focusVisible",
+                                                "root": "MuiButtonBase-root",
+                                              }
+                                            }
                                             disabled={false}
+                                            focusRipple={true}
                                             id="simple-tab-datafile"
-                                            onBlur={[Function]}
                                             onClick={[Function]}
-                                            onDragLeave={[Function]}
                                             onFocus={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            onMouseDown={[Function]}
-                                            onMouseLeave={[Function]}
-                                            onMouseUp={[Function]}
-                                            onTouchEnd={[Function]}
-                                            onTouchMove={[Function]}
-                                            onTouchStart={[Function]}
                                             role="tab"
                                             tabIndex={-1}
-                                            type="button"
                                           >
-                                            <span
-                                              className="MuiTab-wrapper"
+                                            <button
+                                              aria-controls="simple-tabpanel-datafile"
+                                              aria-selected={false}
+                                              className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                              disabled={false}
+                                              id="simple-tab-datafile"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onDragLeave={[Function]}
+                                              onFocus={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              onMouseDown={[Function]}
+                                              onMouseLeave={[Function]}
+                                              onMouseUp={[Function]}
+                                              onTouchEnd={[Function]}
+                                              onTouchMove={[Function]}
+                                              onTouchStart={[Function]}
+                                              role="tab"
+                                              tabIndex={-1}
+                                              type="button"
                                             >
-                                              <WithStyles(WithStyles(ForwardRef(Badge)))
-                                                badgeContent={0}
-                                                id="datafile-badge"
-                                                max={999}
-                                                showZero={true}
+                                              <span
+                                                className="MuiTab-wrapper"
                                               >
-                                                <WithStyles(ForwardRef(Badge))
+                                                <WithStyles(WithStyles(ForwardRef(Badge)))
                                                   badgeContent={0}
-                                                  classes={
-                                                    Object {
-                                                      "badge": "WithStyles(ForwardRef(Badge))-badge-1",
-                                                    }
-                                                  }
                                                   id="datafile-badge"
                                                   max={999}
                                                   showZero={true}
                                                 >
-                                                  <ForwardRef(Badge)
+                                                  <WithStyles(ForwardRef(Badge))
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
-                                                        "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
-                                                        "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
-                                                        "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
-                                                        "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
-                                                        "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
-                                                        "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
-                                                        "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                        "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1",
-                                                        "colorError": "MuiBadge-colorError",
-                                                        "colorPrimary": "MuiBadge-colorPrimary",
-                                                        "colorSecondary": "MuiBadge-colorSecondary",
-                                                        "dot": "MuiBadge-dot",
-                                                        "invisible": "MuiBadge-invisible",
-                                                        "root": "MuiBadge-root",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
                                                       }
                                                     }
                                                     id="datafile-badge"
                                                     max={999}
                                                     showZero={true}
                                                   >
-                                                    <span
-                                                      className="MuiBadge-root"
+                                                    <ForwardRef(Badge)
+                                                      badgeContent={0}
+                                                      classes={
+                                                        Object {
+                                                          "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
+                                                          "anchorOriginBottomLeftRectangle": "MuiBadge-anchorOriginBottomLeftRectangle",
+                                                          "anchorOriginBottomRightCircle": "MuiBadge-anchorOriginBottomRightCircle",
+                                                          "anchorOriginBottomRightRectangle": "MuiBadge-anchorOriginBottomRightRectangle",
+                                                          "anchorOriginTopLeftCircle": "MuiBadge-anchorOriginTopLeftCircle",
+                                                          "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
+                                                          "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
+                                                          "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "colorError": "MuiBadge-colorError",
+                                                          "colorPrimary": "MuiBadge-colorPrimary",
+                                                          "colorSecondary": "MuiBadge-colorSecondary",
+                                                          "dot": "MuiBadge-dot",
+                                                          "invisible": "MuiBadge-invisible",
+                                                          "root": "MuiBadge-root",
+                                                        }
+                                                      }
                                                       id="datafile-badge"
+                                                      max={999}
+                                                      showZero={true}
                                                     >
                                                       <span
-                                                        style={
-                                                          Object {
-                                                            "marginLeft": "calc(-0.5 * 1ch - 6px)",
-                                                            "marginRight": "calc(0.5 * 1ch + 6px)",
-                                                            "paddingRight": "1ch",
+                                                        className="MuiBadge-root"
+                                                        id="datafile-badge"
+                                                      >
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "marginLeft": "calc(-0.5 * 1ch - 6px)",
+                                                              "marginRight": "calc(0.5 * 1ch + 6px)",
+                                                              "paddingRight": "1ch",
+                                                            }
                                                           }
-                                                        }
-                                                      >
-                                                        tabs.datafile
+                                                        >
+                                                          tabs.datafile
+                                                        </span>
+                                                        <span
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                        >
+                                                          0
+                                                        </span>
                                                       </span>
-                                                      <span
-                                                        className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-1 MuiBadge-anchorOriginTopRightRectangle"
-                                                      >
-                                                        0
-                                                      </span>
-                                                    </span>
-                                                  </ForwardRef(Badge)>
-                                                </WithStyles(ForwardRef(Badge))>
-                                              </WithStyles(WithStyles(ForwardRef(Badge)))>
-                                            </span>
-                                            <WithStyles(memo)
-                                              center={false}
-                                            >
-                                              <ForwardRef(TouchRipple)
+                                                    </ForwardRef(Badge)>
+                                                  </WithStyles(ForwardRef(Badge))>
+                                                </WithStyles(WithStyles(ForwardRef(Badge)))>
+                                              </span>
+                                              <WithStyles(memo)
                                                 center={false}
-                                                classes={
-                                                  Object {
-                                                    "child": "MuiTouchRipple-child",
-                                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                                    "ripple": "MuiTouchRipple-ripple",
-                                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                    "root": "MuiTouchRipple-root",
-                                                  }
-                                                }
                                               >
-                                                <span
-                                                  className="MuiTouchRipple-root"
+                                                <ForwardRef(TouchRipple)
+                                                  center={false}
+                                                  classes={
+                                                    Object {
+                                                      "child": "MuiTouchRipple-child",
+                                                      "childLeaving": "MuiTouchRipple-childLeaving",
+                                                      "childPulsate": "MuiTouchRipple-childPulsate",
+                                                      "ripple": "MuiTouchRipple-ripple",
+                                                      "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                      "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                      "root": "MuiTouchRipple-root",
+                                                    }
+                                                  }
                                                 >
-                                                  <TransitionGroup
-                                                    childFactory={[Function]}
-                                                    component={null}
-                                                    exit={true}
-                                                  />
-                                                </span>
-                                              </ForwardRef(TouchRipple)>
-                                            </WithStyles(memo)>
-                                          </button>
-                                        </ForwardRef(ButtonBase)>
-                                      </WithStyles(ForwardRef(ButtonBase))>
-                                    </ForwardRef(Tab)>
-                                  </WithStyles(ForwardRef(Tab))>
-                                </div>
-                                <WithStyles(ForwardRef(TabIndicator))
-                                  className="MuiTabs-indicator"
-                                  color="secondary"
-                                  orientation="horizontal"
-                                  style={
-                                    Object {
-                                      "left": 0,
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <ForwardRef(TabIndicator)
-                                    className="MuiTabs-indicator"
-                                    classes={
-                                      Object {
-                                        "colorPrimary": "PrivateTabIndicator-colorPrimary-3",
-                                        "colorSecondary": "PrivateTabIndicator-colorSecondary-4",
-                                        "root": "PrivateTabIndicator-root-2",
-                                        "vertical": "PrivateTabIndicator-vertical-5",
-                                      }
-                                    }
+                                                  <span
+                                                    className="MuiTouchRipple-root"
+                                                  >
+                                                    <TransitionGroup
+                                                      childFactory={[Function]}
+                                                      component={null}
+                                                      exit={true}
+                                                    />
+                                                  </span>
+                                                </ForwardRef(TouchRipple)>
+                                              </WithStyles(memo)>
+                                            </button>
+                                          </ForwardRef(ButtonBase)>
+                                        </WithStyles(ForwardRef(ButtonBase))>
+                                      </ForwardRef(Tab)>
+                                    </WithStyles(ForwardRef(Tab))>
+                                  </div>
+                                  <WithStyles(ForwardRef(TabIndicator))
+                                    className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
                                     color="secondary"
                                     orientation="horizontal"
                                     style={
@@ -3898,21 +3890,41 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                       }
                                     }
                                   >
-                                    <span
-                                      className="PrivateTabIndicator-root-2 PrivateTabIndicator-colorSecondary-4 MuiTabs-indicator"
+                                    <ForwardRef(TabIndicator)
+                                      className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                      classes={
+                                        Object {
+                                          "colorPrimary": "PrivateTabIndicator-colorPrimary-4",
+                                          "colorSecondary": "PrivateTabIndicator-colorSecondary-5",
+                                          "root": "PrivateTabIndicator-root-3",
+                                          "vertical": "PrivateTabIndicator-vertical-6",
+                                        }
+                                      }
+                                      color="secondary"
+                                      orientation="horizontal"
                                       style={
                                         Object {
                                           "left": 0,
                                           "width": 0,
                                         }
                                       }
-                                    />
-                                  </ForwardRef(TabIndicator)>
-                                </WithStyles(ForwardRef(TabIndicator))>
+                                    >
+                                      <span
+                                        className="PrivateTabIndicator-root-3 PrivateTabIndicator-colorSecondary-5 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                        style={
+                                          Object {
+                                            "left": 0,
+                                            "width": 0,
+                                          }
+                                        }
+                                      />
+                                    </ForwardRef(TabIndicator)>
+                                  </WithStyles(ForwardRef(TabIndicator))>
+                                </div>
                               </div>
-                            </div>
-                          </ForwardRef(Tabs)>
-                        </WithStyles(ForwardRef(Tabs))>
+                            </ForwardRef(Tabs)>
+                          </WithStyles(ForwardRef(Tabs))>
+                        </WithStyles(WithStyles(ForwardRef(Tabs)))>
                       </header>
                     </ForwardRef(Paper)>
                   </WithStyles(ForwardRef(Paper))>
@@ -3932,7 +3944,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                 >
                   <div
                     aria-labelledby="simple-tab-investigation"
-                    className="MuiBox-root MuiBox-root-6"
+                    className="MuiBox-root MuiBox-root-7"
                     hidden={false}
                     id="simple-tabpanel-investigation"
                     role="tabpanel"
@@ -3941,7 +3953,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       p={3}
                     >
                       <div
-                        className="MuiBox-root MuiBox-root-7"
+                        className="MuiBox-root MuiBox-root-8"
                       >
                         <WithStyles(ForwardRef(Paper))
                           elevation={0}

--- a/packages/datagateway-search/src/searchPageCardView.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.tsx
@@ -34,6 +34,19 @@ const badgeStyles = (theme: Theme): StyleRules =>
     },
   });
 
+const tabStyles = (theme: Theme): StyleRules =>
+  createStyles({
+    indicator: {
+      //Use white for all modes except use red for dark high contrast mode as this is much clearer
+      backgroundColor:
+        theme.palette.type === 'dark' &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (theme as any).colours?.type === 'contrast'
+          ? '#FF0000'
+          : '#FFFFFF',
+    },
+  });
+
 interface SearchCardViewProps {
   containerHeight: string;
   hierarchy: string;
@@ -82,6 +95,7 @@ function a11yProps(index: string): React.ReactFragment {
 }
 
 const StyledBadge = withStyles(badgeStyles)(Badge);
+const StyledTabs = withStyles(tabStyles)(Tabs);
 
 const SearchPageCardView = (
   props: SearchCardViewProps &
@@ -173,7 +187,7 @@ const SearchPageCardView = (
   return (
     <div>
       <AppBar position="static">
-        <Tabs
+        <StyledTabs
           className="tour-search-tab-select"
           value={currentTab}
           onChange={handleChange}
@@ -269,7 +283,7 @@ const SearchPageCardView = (
           ) : (
             <Tab value="datafile" style={{ display: 'none' }} />
           )}
-        </Tabs>
+        </StyledTabs>
       </AppBar>
 
       {currentTab === 'investigation' && (

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -285,10 +285,10 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
   }, []);
 
   // Table should take up page but leave room for: SG appbar, SG footer,
-  // grid padding, search box, checkboxes, date selectors, padding.
+  // grid padding, search box, checkboxes, date selectors, example search text, limited results message, padding.
   const spacing = 2;
   // TODO: Container height is too small on smaller screens (e.g. laptops).
-  const containerHeight = `calc(100vh - 64px - 30px - ${spacing}*16px - (69px + 19rem/16) - 42px - (53px + 19rem/16) - 8px)`;
+  const containerHeight = `calc(100vh - 64px - 48px - ${spacing}*16px - (69px + 19rem/16) - 42px - (53px + 19rem/16) - 21px - 24px - 8px)`;
 
   const { data: cartItems } = useCart();
   const { push } = useHistory();

--- a/packages/datagateway-search/src/searchPageTable.tsx
+++ b/packages/datagateway-search/src/searchPageTable.tsx
@@ -34,6 +34,19 @@ const badgeStyles = (theme: Theme): StyleRules =>
     },
   });
 
+const tabStyles = (theme: Theme): StyleRules =>
+  createStyles({
+    indicator: {
+      //Use white for all modes except use red for dark high contrast mode as this is much clearer
+      backgroundColor:
+        theme.palette.type === 'dark' &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (theme as any).colours?.type === 'contrast'
+          ? '#FF0000'
+          : '#FFFFFF',
+    },
+  });
+
 interface SearchTableProps {
   containerHeight: string;
   hierarchy: string;
@@ -82,6 +95,7 @@ function a11yProps(index: string): React.ReactFragment {
 }
 
 const StyledBadge = withStyles(badgeStyles)(Badge);
+const StyledTabs = withStyles(tabStyles)(Tabs);
 
 const SearchPageTable = (
   props: SearchTableProps & SearchTableStoreProps & SearchTableDispatchProps
@@ -171,7 +185,7 @@ const SearchPageTable = (
   return (
     <div>
       <AppBar position="static">
-        <Tabs
+        <StyledTabs
           className="tour-search-tab-select"
           value={currentTab}
           onChange={handleChange}
@@ -267,7 +281,7 @@ const SearchPageTable = (
           ) : (
             <Tab value="datafile" style={{ display: 'none' }} />
           )}
-        </Tabs>
+        </StyledTabs>
       </AppBar>
 
       {currentTab === 'investigation' && (


### PR DESCRIPTION
## Description
Changes the tab indicator colour in search to be more visible. Screenshots:
![image](https://user-images.githubusercontent.com/90245114/146368122-3a23aaf7-4637-4f92-8c8e-7a8bc84a600d.png)
![image](https://user-images.githubusercontent.com/90245114/146368188-8990bbdf-c282-46ed-b50b-e498ba71a647.png)
![image](https://user-images.githubusercontent.com/90245114/146368230-526122e5-fb16-4595-b864-d795605a14d5.png)
Previously the tab indicator was the same colour as the background in all but the normal dark mode.

Other changes in this PR:
- Updates dataview and search's page container components to take account of the new footer size to solve #1020.
- Changes browse and search links in the download no selections message to be bold as requested in #996:
![image](https://user-images.githubusercontent.com/90245114/146529316-687b268b-28ef-4b50-ac7e-e3edb0f2f2c4.png)


## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1005, Closes #1020, Closes #996