### PR TITLE
Modify dependabot config to ignore patch updates (#987)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
   open-pull-requests-limit: 10
   versioning-strategy: increase
   ignore:
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
   - dependency-name: "@date-io/date-fns"
     versions:
     - ">= 2.a, < 3"


### PR DESCRIPTION
## Description
Changes dependabot config to ignore patch versions. Corresponding SciGateway PR is here: https://github.com/ral-facilities/scigateway/pull/888. The docs found here https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore state that security updates should be unaffected by this change.

## Testing instructions

- [ ] Review changes

## Agile board tracking
Closes #987 
