### PR TITLE
Change exclude filters to use `nilike` operator to API

### DIFF
--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -266,7 +266,7 @@ describe('generic api functions', () => {
       params.append('order', JSON.stringify('name asc'));
       params.append('order', JSON.stringify('id asc'));
       params.append('where', JSON.stringify({ name: { ilike: 'test' } }));
-      params.append('where', JSON.stringify({ title: { nlike: 'test' } }));
+      params.append('where', JSON.stringify({ title: { nilike: 'test' } }));
       params.append(
         'where',
         JSON.stringify({ startDate: { gte: '2021-08-05 00:00:00' } })

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -226,7 +226,7 @@ export const getApiParams = (props: {
           } else {
             searchParams.append(
               'where',
-              JSON.stringify({ [column]: { nlike: filter.value } })
+              JSON.stringify({ [column]: { nilike: filter.value } })
             );
           }
         }


### PR DESCRIPTION
## Description
This is a very small PR to change the not like (`nlike`) to an insensitive not like (`nilike`). The difference in these operators is only noticeable in production where OracleDB is used, but that's been tested in the past with DataGateway API.

## Testing instructions
When using an exclude filter, check that the request sent to DataGateway API contains the `nilike` operator, and not the `nlike` operator.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #{issue number}
