### PR TITLE
Change Python to use 3.6 as workaround for import issue

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.6
           architecture: x64
 
       # ICAT Ansible clone and install dependencies
@@ -226,7 +226,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.6
           architecture: x64
 
       # ICAT Ansible clone and install dependencies
@@ -377,7 +377,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.6
           architecture: x64
 
       # ICAT Ansible clone and install dependencies


### PR DESCRIPTION
## Description
A change to use Python 3.6 as this _seemed_ to work on the API's CI. 
## Testing instructions
See if this resolves the import error as reported on Slack.

- [ ] Review code
- [ ] Check Actions build