### PR TITLE
Improved table padding #1022

### DIFF
--- a/packages/datagateway-common/src/table/cellRenderers/__snapshots__/actionCell.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/cellRenderers/__snapshots__/actionCell.component.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Action cell component renders an action correctly 1`] = `
 <div
   aria-sort={null}
-  className="MuiTableCell-root MuiTableCell-body test-class MuiTableCell-paddingCheckbox"
+  className="MuiTableCell-root MuiTableCell-body test-class"
   role="cell"
 >
   <testAction
@@ -16,7 +16,7 @@ exports[`Action cell component renders an action correctly 1`] = `
 exports[`Action cell component renders no actions correctly 1`] = `
 <div
   aria-sort={null}
-  className="MuiTableCell-root MuiTableCell-body test-class MuiTableCell-paddingCheckbox"
+  className="MuiTableCell-root MuiTableCell-body test-class"
   role="cell"
 />
 `;

--- a/packages/datagateway-common/src/table/cellRenderers/__snapshots__/dataCell.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/cellRenderers/__snapshots__/dataCell.component.test.tsx.snap
@@ -5,12 +5,6 @@ exports[`Data cell component renders correctly 1`] = `
   aria-sort={null}
   className="MuiTableCell-root MuiTableCell-body test-class MuiTableCell-sizeSmall"
   role="cell"
-  style={
-    Object {
-      "paddingLeft": 8,
-      "paddingRight": 8,
-    }
-  }
 >
   <ArrowTooltip
     enterDelay={500}
@@ -56,12 +50,6 @@ exports[`Data cell component renders nested cell data correctly 1`] = `
   aria-sort={null}
   className="MuiTableCell-root MuiTableCell-body test-class MuiTableCell-sizeSmall"
   role="cell"
-  style={
-    Object {
-      "paddingLeft": 8,
-      "paddingRight": 8,
-    }
-  }
 >
   <ArrowTooltip
     enterDelay={500}
@@ -107,12 +95,6 @@ exports[`Data cell component renders provided cell data correctly 1`] = `
   aria-sort={null}
   className="MuiTableCell-root MuiTableCell-body test-class MuiTableCell-sizeSmall"
   role="cell"
-  style={
-    Object {
-      "paddingLeft": 8,
-      "paddingRight": 8,
-    }
-  }
 >
   <ArrowTooltip
     enterDelay={500}

--- a/packages/datagateway-common/src/table/cellRenderers/actionCell.component.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/actionCell.component.tsx
@@ -15,7 +15,6 @@ const ActionCell = React.memo(
     return (
       <TableCell
         size="medium"
-        padding="checkbox"
         component="div"
         className={className}
         variant="body"

--- a/packages/datagateway-common/src/table/cellRenderers/dataCell.component.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/dataCell.component.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { TableCellProps, TableCellRenderer } from 'react-virtualized';
-import {
-  Divider,
-  TableCell,
-  Typography,
-  useMediaQuery,
-} from '@material-ui/core';
+import { Divider, TableCell, Typography } from '@material-ui/core';
 import ArrowTooltip, { getTooltipText } from '../../arrowtooltip.component';
 
 type CellRendererProps = TableCellProps & {
@@ -25,14 +20,12 @@ const DataCell = React.memo(
           return prev ? prev[curr] : null;
         }, rowData);
 
-    const smWindow = !useMediaQuery('(min-width: 960px)');
     return (
       <TableCell
         size="small"
         component="div"
         className={className}
         variant="body"
-        style={smWindow ? { paddingLeft: 8, paddingRight: 8 } : {}}
       >
         <ArrowTooltip
           title={getTooltipText(cellContent)}

--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -5,12 +5,6 @@ exports[`Data column header component renders correctly with filter but no sort 
   aria-sort={null}
   className="MuiTableCell-root MuiTableCell-head test-class MuiTableCell-sizeSmall"
   role="cell"
-  style={
-    Object {
-      "paddingLeft": 8,
-      "paddingRight": 8,
-    }
-  }
 >
   <div
     style={
@@ -103,12 +97,6 @@ exports[`Data column header component renders correctly with sort and filter 1`]
   aria-sort={null}
   className="MuiTableCell-root MuiTableCell-head test-class MuiTableCell-sizeSmall"
   role="cell"
-  style={
-    Object {
-      "paddingLeft": 8,
-      "paddingRight": 8,
-    }
-  }
 >
   <div
     style={
@@ -207,12 +195,6 @@ exports[`Data column header component renders correctly with sort but no filter 
   aria-sort={null}
   className="MuiTableCell-root MuiTableCell-head test-class MuiTableCell-sizeSmall"
   role="cell"
-  style={
-    Object {
-      "paddingLeft": 8,
-      "paddingRight": 8,
-    }
-  }
 >
   <div
     style={
@@ -307,12 +289,6 @@ exports[`Data column header component renders correctly without sort or filter 1
   aria-sort={null}
   className="MuiTableCell-root MuiTableCell-head test-class MuiTableCell-sizeSmall"
   role="cell"
-  style={
-    Object {
-      "paddingLeft": 8,
-      "paddingRight": 8,
-    }
-  }
 >
   <div
     style={

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -6,7 +6,6 @@ import {
   TableSortLabel,
   Box,
   Typography,
-  useMediaQuery,
   Divider,
 } from '@material-ui/core';
 import Draggable from 'react-draggable';
@@ -84,8 +83,6 @@ const DataHeader = React.memo(
       </Typography>
     );
 
-    const smWindow = !useMediaQuery('(min-width: 960px)');
-
     return (
       <TableCell
         size="small"
@@ -93,7 +90,6 @@ const DataHeader = React.memo(
         className={className}
         variant="head"
         sortDirection={currSortDirection}
-        style={smWindow ? { paddingLeft: 8, paddingRight: 8 } : {}}
       >
         <div
           style={{

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -63,12 +63,30 @@ const styles = (theme: Theme): StyleRules =>
       overflow: 'hidden',
       height: rowHeight,
       padding: 0,
+      paddingLeft: 16,
+      '&:last-child': {
+        paddingRight: 0,
+      },
+    },
+    tableCellNoPadding: {
+      flex: 1,
+      overflow: 'hidden',
+      height: rowHeight,
+      padding: 0,
+      paddingLeft: 0,
+      '&:last-child': {
+        paddingRight: 0,
+      },
     },
     headerTableCell: {
       flex: 1,
       height: headerHeight,
       justifyContent: 'space-between',
       padding: 0,
+      paddingLeft: 16,
+      '&:last-child': {
+        paddingRight: 0,
+      },
     },
   });
 
@@ -392,16 +410,19 @@ const VirtualizedTable = React.memo(
                     />
                   )}
                   {columns.map(
-                    ({
-                      cellContentRenderer,
-                      className,
-                      dataKey,
-                      label,
-                      icon,
-                      filterComponent,
-                      disableSort,
-                      defaultSort,
-                    }) => {
+                    (
+                      {
+                        cellContentRenderer,
+                        className,
+                        dataKey,
+                        label,
+                        icon,
+                        filterComponent,
+                        disableSort,
+                        defaultSort,
+                      },
+                      index
+                    ) => {
                       return (
                         <Column
                           key={dataKey}
@@ -431,7 +452,12 @@ const VirtualizedTable = React.memo(
                               {...props}
                               cellContentRenderer={cellContentRenderer}
                               className={clsx(
-                                classes.tableCell,
+                                //Remove padding only when in the first column and there is another element displayed before it e.g. a checkbox
+                                ((selectedRows && onCheck && onUncheck) ||
+                                  detailsPanel) &&
+                                  index === 0
+                                  ? classes.tableCellNoPadding
+                                  : classes.tableCell,
                                 classes.flexContainer
                               )}
                             />

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -68,15 +68,8 @@ const styles = (theme: Theme): StyleRules =>
         paddingRight: 0,
       },
     },
-    tableCellNoPadding: {
-      flex: 1,
-      overflow: 'hidden',
-      height: rowHeight,
-      padding: 0,
+    tableNoPadding: {
       paddingLeft: 0,
-      '&:last-child': {
-        paddingRight: 0,
-      },
     },
     headerTableCell: {
       flex: 1,
@@ -279,6 +272,17 @@ const VirtualizedTable = React.memo(
       [widthProps, setWidthProps]
     );
 
+    const tableCellClass = clsx(classes.tableCell, classes.flexContainer);
+    const tableCellNoPaddingClass = clsx(
+      classes.tableCell,
+      classes.tableNoPadding,
+      classes.flexContainer
+    );
+    const headerTableCellClass = clsx(
+      classes.headerTableCell,
+      classes.headerFlexContainer
+    );
+
     return (
       <AutoSizer>
         {({ height, width }) => {
@@ -337,10 +341,7 @@ const VirtualizedTable = React.memo(
                         !disableSelectAll && (
                           <SelectHeader
                             {...props}
-                            className={clsx(
-                              classes.headerTableCell,
-                              classes.headerFlexContainer
-                            )}
+                            className={headerTableCellClass}
                             selectedRows={selectedRows}
                             totalRowCount={rowCount}
                             allIds={
@@ -363,10 +364,7 @@ const VirtualizedTable = React.memo(
                           {...props}
                           selectedRows={selectedRows}
                           data={data}
-                          className={clsx(
-                            classes.tableCell,
-                            classes.flexContainer
-                          )}
+                          className={tableCellClass}
                           onCheck={onCheck}
                           onUncheck={onUncheck}
                           lastChecked={lastChecked}
@@ -401,10 +399,7 @@ const VirtualizedTable = React.memo(
                           {...props}
                           expandedIndex={expandedIndex}
                           setExpandedIndex={setExpandedIndex}
-                          className={clsx(
-                            classes.tableCell,
-                            classes.flexContainer
-                          )}
+                          className={tableCellClass}
                         />
                       )}
                     />
@@ -433,10 +428,7 @@ const VirtualizedTable = React.memo(
                           headerRenderer={(headerProps) => (
                             <DataHeader
                               {...headerProps}
-                              className={clsx(
-                                classes.headerTableCell,
-                                classes.headerFlexContainer
-                              )}
+                              className={headerTableCellClass}
                               sort={sort}
                               onSort={onSort}
                               icon={icon}
@@ -451,15 +443,14 @@ const VirtualizedTable = React.memo(
                             <DataCell
                               {...props}
                               cellContentRenderer={cellContentRenderer}
-                              className={clsx(
+                              className={
                                 //Remove padding only when in the first column and there is another element displayed before it e.g. a checkbox
                                 ((selectedRows && onCheck && onUncheck) ||
                                   detailsPanel) &&
-                                  index === 0
-                                  ? classes.tableCellNoPadding
-                                  : classes.tableCell,
-                                classes.flexContainer
-                              )}
+                                index === 0
+                                  ? tableCellNoPaddingClass
+                                  : tableCellClass
+                              }
                             />
                           )}
                           minWidth={dataColumnMinWidth}
@@ -480,10 +471,7 @@ const VirtualizedTable = React.memo(
                         <TableCell
                           size="small"
                           component="div"
-                          className={clsx(
-                            classes.headerTableCell,
-                            classes.headerFlexContainer
-                          )}
+                          className={headerTableCellClass}
                           variant="head"
                         >
                           Actions
@@ -493,10 +481,7 @@ const VirtualizedTable = React.memo(
                         <ActionCell
                           {...props}
                           actions={actions}
-                          className={clsx(
-                            classes.tableCell,
-                            classes.flexContainer
-                          )}
+                          className={tableCellClass}
                         />
                       )}
                     />

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datafileTable.component.test.tsx.snap
@@ -11,9 +11,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -96,7 +97,7 @@ Object {
 
 exports[`Datafile table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-276"
+  className="makeStyles-root-287"
   container={true}
   direction="column"
   id="details-panel"
@@ -113,7 +114,7 @@ exports[`Datafile table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-277"
+      className="makeStyles-divider-288"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/datasetTable.component.test.tsx.snap
@@ -161,9 +161,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -247,7 +248,7 @@ Object {
 
 exports[`Dataset table component renders details panel correctly 1`] = `
 <div
-  className="MuiGrid-root makeStyles-root-251 MuiGrid-container MuiGrid-direction-xs-column"
+  className="MuiGrid-root makeStyles-root-261 MuiGrid-container MuiGrid-direction-xs-column"
   id="details-panel"
 >
   <WithStyles(ForwardRef(Grid))
@@ -262,7 +263,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-252"
+      className="makeStyles-divider-262"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/__snapshots__/investigationTable.component.test.tsx.snap
@@ -8,9 +8,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -162,7 +163,7 @@ Object {
 
 exports[`Investigation table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-408"
+  className="makeStyles-root-419"
   container={true}
   direction="column"
   id="details-panel"
@@ -179,7 +180,7 @@ exports[`Investigation table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-409"
+      className="makeStyles-divider-420"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatafilesTable.component.test.tsx.snap
@@ -8,9 +8,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsDatasetsTable.component.test.tsx.snap
@@ -161,9 +161,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsMyDataTable.component.test.tsx.snap
@@ -5,9 +5,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsProposalsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsProposalsTable.component.test.tsx.snap
@@ -5,9 +5,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsVisitsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsVisitsTable.component.test.tsx.snap
@@ -5,9 +5,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatafilesTable.component.test.tsx.snap
@@ -11,9 +11,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisDatasetsTable.component.test.tsx.snap
@@ -11,9 +11,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisFacilityCyclesTable.component.test.tsx.snap
@@ -5,9 +5,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInstrumentsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInstrumentsTable.component.test.tsx.snap
@@ -5,9 +5,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisInvestigationsTable.component.test.tsx.snap
@@ -11,9 +11,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -196,7 +197,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-443"
+      className="makeStyles-root-456"
       container={true}
       direction="column"
     >
@@ -212,7 +213,7 @@ exports[`ISIS Investigations table component renders details panel correctly and
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-444"
+          className="makeStyles-divider-457"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisMyDataTable.component.test.tsx.snap
@@ -8,9 +8,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -215,7 +216,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
     role="tabpanel"
   >
     <WithStyles(ForwardRef(Grid))
-      className="makeStyles-root-482"
+      className="makeStyles-root-495"
       container={true}
       direction="column"
     >
@@ -231,7 +232,7 @@ exports[`ISIS MyData table component renders details panel correctly and it fetc
           </b>
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Divider))
-          className="makeStyles-divider-483"
+          className="makeStyles-divider-496"
         />
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
@@ -5,9 +5,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },

--- a/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datafileSearchTable.component.test.tsx.snap
@@ -8,9 +8,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -119,7 +120,7 @@ Object {
 
 exports[`Datafile search table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-281"
+  className="makeStyles-root-291"
   container={true}
   direction="column"
   id="details-panel"
@@ -136,7 +137,7 @@ exports[`Datafile search table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-282"
+      className="makeStyles-divider-292"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/datasetSearchTable.component.test.tsx.snap
@@ -161,9 +161,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -265,7 +266,7 @@ Object {
 
 exports[`Dataset table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-281"
+  className="makeStyles-root-291"
   container={true}
   direction="column"
   id="details-panel"
@@ -282,7 +283,7 @@ exports[`Dataset table component renders details panel correctly 1`] = `
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-282"
+      className="makeStyles-divider-292"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))

--- a/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/table/__snapshots__/investigationSearchTable.component.test.tsx.snap
@@ -8,9 +8,10 @@ Object {
   "classes": Object {
     "flexContainer": "VirtualizedTable-flexContainer-2",
     "headerFlexContainer": "VirtualizedTable-headerFlexContainer-3",
-    "headerTableCell": "VirtualizedTable-headerTableCell-7",
+    "headerTableCell": "VirtualizedTable-headerTableCell-8",
     "table": "VirtualizedTable-table-1",
     "tableCell": "VirtualizedTable-tableCell-6",
+    "tableNoPadding": "VirtualizedTable-tableNoPadding-7",
     "tableRow": "VirtualizedTable-tableRow-4",
     "tableRowHover": "VirtualizedTable-tableRowHover-5",
   },
@@ -121,7 +122,7 @@ Object {
 
 exports[`Investigation Search Table component renders details panel correctly 1`] = `
 <WithStyles(ForwardRef(Grid))
-  className="makeStyles-root-408"
+  className="makeStyles-root-419"
   container={true}
   direction="column"
   id="details-panel"
@@ -138,7 +139,7 @@ exports[`Investigation Search Table component renders details panel correctly 1`
       </b>
     </WithStyles(ForwardRef(Typography))>
     <WithStyles(ForwardRef(Divider))
-      className="makeStyles-divider-409"
+      className="makeStyles-divider-420"
     />
   </WithStyles(ForwardRef(Grid))>
   <WithStyles(ForwardRef(Grid))


### PR DESCRIPTION
## Description
Improves table padding so that the first column in a table also obtains padding before any text when there is no checkbox/detail panel to display.

![image](https://user-images.githubusercontent.com/90245114/148356153-907284c6-1238-40df-a7ae-f0f6e94865bc.png)
![image](https://user-images.githubusercontent.com/90245114/148356226-71ad708d-6ac2-47f3-87ab-7580c3584294.png)
![image](https://user-images.githubusercontent.com/90245114/148356305-57135791-e25c-4c18-9f8f-97dc467f08a7.png)
![image](https://user-images.githubusercontent.com/90245114/148356324-e76cfa9e-edcf-4a5c-a88b-4042671f0808.png)


## Testing instructions
This change will effect all tables in dataview/search/download.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1022
