### PR TITLE
Fix search table vertical space #1021

### DIFF
--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
@@ -4956,7 +4956,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     role="tabpanel"
                   >
                     <Styled(MuiBox)
-                      p={3}
+                      pt={1}
                     >
                       <div
                         className="MuiBox-root MuiBox-root-8"
@@ -4965,8 +4965,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                           elevation={0}
                           style={
                             Object {
-                              "height": "calc(undefined - 96px)",
-                              "minHeight": 230,
+                              "height": "calc(undefined - 56px)",
+                              "minHeight": "calc(500px - 56px)",
                               "overflowX": "auto",
                             }
                           }
@@ -5007,8 +5007,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                             elevation={0}
                             style={
                               Object {
-                                "height": "calc(undefined - 96px)",
-                                "minHeight": 230,
+                                "height": "calc(undefined - 56px)",
+                                "minHeight": "calc(500px - 56px)",
                                 "overflowX": "auto",
                               }
                             }
@@ -5017,8 +5017,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                               className="MuiPaper-root MuiPaper-elevation0 MuiPaper-rounded"
                               style={
                                 Object {
-                                  "height": "calc(undefined - 96px)",
-                                  "minHeight": 230,
+                                  "height": "calc(undefined - 56px)",
+                                  "minHeight": "calc(500px - 56px)",
                                   "overflowX": "auto",
                                 }
                               }

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -347,8 +347,8 @@ const SearchPageCardView = (
         <TabPanel value={currentTab} index={'datafile'}>
           <Paper
             style={{
-              height: `calc(${containerHeight} - 96px)`,
-              minHeight: 230,
+              height: `calc(${containerHeight} - 56px)`,
+              minHeight: `calc(500px - 56px)`,
               overflowX: 'auto',
             }}
             elevation={0}

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -121,7 +121,6 @@ const ViewButton = (props: {
 // Table should take up page but leave room for: SG appbar, SG footer,
 // grid padding, search box, checkboxes, date selectors, example search text, limited results message, padding.
 const spacing = 1;
-// TODO: Container height is too small on smaller screens (e.g. laptops).
 const containerHeight = `calc(100vh - 64px - 48px - ${spacing}*16px - (69px + 19rem/16) - 42px - (53px + 19rem/16) - 21px - 24px - 8px)`;
 
 const calculateScrollbarHeight = (): number => {

--- a/packages/datagateway-search/src/searchPageTable.component.tsx
+++ b/packages/datagateway-search/src/searchPageTable.component.tsx
@@ -90,7 +90,7 @@ function TabPanel(props: TabPanelProps): React.ReactElement {
       border={0}
       {...other}
     >
-      {value === index && <Box p={3}>{children}</Box>}
+      {value === index && <Box pt={1}>{children}</Box>}
     </Box>
   );
 }
@@ -332,8 +332,8 @@ const SearchPageTable = (
         <TabPanel value={currentTab} index={'investigation'}>
           <Paper
             style={{
-              height: `calc(${containerHeight} - 96px)`,
-              minHeight: 230,
+              height: `calc(${containerHeight} - 56px)`,
+              minHeight: `calc(500px - 56px)`,
               overflowX: 'auto',
             }}
             elevation={0}
@@ -346,8 +346,8 @@ const SearchPageTable = (
         <TabPanel value={currentTab} index={'dataset'}>
           <Paper
             style={{
-              height: `calc(${containerHeight} - 96px)`,
-              minHeight: 230,
+              height: `calc(${containerHeight} - 56px)`,
+              minHeight: `calc(500px - 56px)`,
               overflowX: 'auto',
             }}
             elevation={0}
@@ -360,8 +360,8 @@ const SearchPageTable = (
         <TabPanel value={currentTab} index={'datafile'}>
           <Paper
             style={{
-              height: `calc(${containerHeight} - 96px)`,
-              minHeight: 230,
+              height: `calc(${containerHeight} - 56px)`,
+              minHeight: `calc(500px - 56px)`,
               overflowX: 'auto',
             }}
             elevation={0}


### PR DESCRIPTION
## Description
Added some sensible min heights to ensure the table doesn't shrink too much.

Also removed a few min-widths & vw based values as these often overflowed on small windows.

I had a lot of grief with the scrollbars - hence that scrollbar height calculating function!

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Test out search with different window sizes

## Agile board tracking
Closes #1021