### PR TITLE
Fix bug in ResizeObserver code

### DIFF
--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -324,21 +324,26 @@ const SearchPageContainer: React.FC<SearchPageContainerCombinedProps> = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const searchBoxRef = React.useRef<HTMLDivElement>(null);
   const [searchBoxHeight, setSearchBoxHeight] = React.useState(0);
 
-  React.useEffect(() => {
-    const observer = new ResizeObserver((entries) => {
+  const searchBoxResizeObserver = React.useRef<ResizeObserver>(
+    new ResizeObserver((entries) => {
       if (entries[0].contentRect.height)
         setSearchBoxHeight(entries[0].contentRect.height);
-    });
-    const curr = searchBoxRef.current;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    observer.observe(curr);
-    return () => {
-      curr && observer.unobserve(curr);
-    };
+    })
+  );
+
+  // need to use a useCallback instead of a useRef for this
+  // see https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
+  const searchBoxRef = React.useCallback((container: HTMLDivElement) => {
+    if (container !== null) {
+      searchBoxResizeObserver.current.observe(container);
+    }
+    // When element is unmounted we know container is null so time to clean up
+    else {
+      if (searchBoxResizeObserver.current)
+        searchBoxResizeObserver.current.disconnect();
+    }
   }, []);
 
   // Table should take up page but leave room for: SG appbar, SG footer,


### PR DESCRIPTION
## Description
Joel noticed that search could error when run standalone from scigateway. This was due to the fact that the ResizeObserver code assumed the search box is always mounted (which is the case in scigateway) - but when ran locally we load the blank page which throws an error. I fixed it by using the technique described here: ``ttps://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node` and adapting it to work for a ResizeObserver

## Testing instructions
- [x] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [x] No errors when running search locally, and the table gets resized properly still on different window widths
