### PR TITLE
Feature/search box redesign #1066

### DIFF
--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     noSelectionsMessage: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      color: (theme as any).colours?.homePage?.description,
+      color: (theme as any).colours?.contrastGrey,
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(2),
     },

--- a/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
@@ -24,8 +24,11 @@ describe('Datafile search tab', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway Search');
 
+    cy.get('#search-entities-menu').click();
     cy.get('[aria-label="Investigation checkbox"]').click();
     cy.get('[aria-label="Dataset checkbox"]').click();
+    //Close drop down menu
+    cy.get('body').type('{esc}');
 
     cy.get('[aria-label="Submit search"]')
       .click()
@@ -94,7 +97,10 @@ describe('Datafile search tab', () => {
   });
 
   it('should be hidden if datafile checkbox is unchecked', () => {
+    cy.get('#search-entities-menu').click();
     cy.get('[aria-label="Datafile checkbox"]').click();
+    //Close drop down menu
+    cy.get('body').type('{esc}');
 
     cy.get('[aria-label="Submit search"]')
       .click()

--- a/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datasetSearch.spec.ts
@@ -24,8 +24,11 @@ describe('Dataset search tab', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway Search');
 
+    cy.get('#search-entities-menu').click();
     cy.get('[aria-label="Investigation checkbox"]').click();
     cy.get('[aria-label="Datafile checkbox"]').click();
+    //Close drop down menu
+    cy.get('body').type('{esc}');
 
     cy.get('[aria-label="Submit search"]')
       .click()
@@ -95,7 +98,10 @@ describe('Dataset search tab', () => {
   });
 
   it('should be hidden if dataset checkbox is unchecked', () => {
+    cy.get('#search-entities-menu').click();
     cy.get('[aria-label="Dataset checkbox"]').click();
+    //Close drop down menu
+    cy.get('body').type('{esc}');
 
     cy.get('[aria-label="Submit search"]')
       .click()

--- a/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/investigationSearch.spec.ts
@@ -24,8 +24,11 @@ describe('Investigation search tab', () => {
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway Search');
 
+    cy.get('#search-entities-menu').click();
     cy.get('[aria-label="Dataset checkbox"]').click();
     cy.get('[aria-label="Datafile checkbox"]').click();
+    //Close drop down menu
+    cy.get('body').type('{esc}');
 
     cy.get('[aria-label="Submit search"]')
       .click()
@@ -111,7 +114,10 @@ describe('Investigation search tab', () => {
   });
 
   it('should be hidden if investigation checkbox is unchecked', () => {
+    cy.get('#search-entities-menu').click();
     cy.get('[aria-label="Investigation checkbox"]').click();
+    //Close drop down menu
+    cy.get('body').type('{esc}');
 
     cy.get('[aria-label="Submit search"]')
       .click()

--- a/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
@@ -15,40 +15,35 @@ describe('SearchBoxContainer Component', () => {
     cy.get('[aria-label="Start date input"]').should('exist');
     cy.get('[aria-label="End date input"]').should('exist');
 
+    cy.get('#search-entities-menu').should('exist');
+
+    cy.get('[aria-label="Submit search"]').should('exist');
+    cy.get('[aria-label="Search options"]').should('exist');
+
+    cy.get('#search-entities-menu').click();
     cy.get('[aria-label="Investigation checkbox"]').should('exist');
     cy.get('[aria-label="Dataset checkbox"]').should('exist');
     cy.get('[aria-label="Datafile checkbox"]').should('exist');
-
-    cy.get('[aria-label="Submit search"]').should('exist');
-    cy.get('[aria-label="Advanced help"]').should('exist');
   });
 
   it('should display an error when an invalid start date is entered', () => {
     cy.get('[aria-label="Start date input"]').type('2009-13-01');
-    cy.get('.MuiFormHelperText-root').contains(
-      'Please enter the date in the format yyyy-MM-dd.'
-    );
+    cy.get('.MuiFormHelperText-root').contains('Date format: yyyy-MM-dd.');
 
     cy.get('[aria-label="Start date input"]').clear();
     cy.get('.MuiFormHelperText-root').should('not.exist');
     cy.get('[aria-label="Start date input"]').type('2009-02-30');
-    cy.get('.MuiFormHelperText-root').contains(
-      'Please enter the date in the format yyyy-MM-dd.'
-    );
+    cy.get('.MuiFormHelperText-root').contains('Date format: yyyy-MM-dd.');
   });
 
   it('should display an error when an invalid end date is entered', () => {
     cy.get('[aria-label="End date input"]').type('2009-13-01');
-    cy.get('.MuiFormHelperText-root').contains(
-      'Please enter the date in the format yyyy-MM-dd.'
-    );
+    cy.get('.MuiFormHelperText-root').contains('Date format: yyyy-MM-dd.');
 
     cy.get('[aria-label="End date input"]').clear();
     cy.get('.MuiFormHelperText-root').should('not.exist');
     cy.get('[aria-label="End date input"]').type('2009-02-30');
-    cy.get('.MuiFormHelperText-root').contains(
-      'Please enter the date in the format yyyy-MM-dd.'
-    );
+    cy.get('.MuiFormHelperText-root').contains('Date format: yyyy-MM-dd.');
   });
 
   it('should display an error when the entered end date is before the start date', () => {
@@ -66,7 +61,7 @@ describe('SearchBoxContainer Component', () => {
   });
 
   it('should display advanced help dialogue when advanced button is clicked', () => {
-    cy.get('[aria-label="Advanced help"]').click();
+    cy.get('[aria-label="Search options"]').click();
 
     cy.get('[aria-labelledby="advanced-search-dialog-title"')
       .contains('Advanced Search Tips')
@@ -79,7 +74,7 @@ describe('SearchBoxContainer Component', () => {
       .should('not.exist');
 
     //Should be able to click on one of the links
-    cy.get('[aria-label="Advanced help"]').click();
+    cy.get('[aria-label="Search options"]').click();
 
     cy.get('[aria-labelledby="advanced-search-dialog-title"').contains(
       'Advanced Search Tips'

--- a/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchBoxContainer.spec.ts
@@ -26,6 +26,21 @@ describe('SearchBoxContainer Component', () => {
     cy.get('[aria-label="Datafile checkbox"]').should('exist');
   });
 
+  it('should display an error when all checkboxes are deselected', () => {
+    cy.get('#search-entities-menu').should('exist');
+    cy.get('.MuiFormHelperText-root').should('not.exist');
+
+    cy.get('#search-entities-menu').click();
+    cy.get('[aria-label="Investigation checkbox"]').click();
+    cy.get('[aria-label="Dataset checkbox"]').click();
+    cy.get('[aria-label="Datafile checkbox"]').click();
+    //Close drop down menu
+    cy.get('body').type('{esc}');
+
+    cy.get('.MuiFormHelperText-root').should('exist');
+    cy.get('.MuiFormHelperText-root').contains('At least one required');
+  });
+
   it('should display an error when an invalid start date is entered', () => {
     cy.get('[aria-label="Start date input"]').type('2009-13-01');
     cy.get('.MuiFormHelperText-root').contains('Date format: yyyy-MM-dd.');

--- a/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
@@ -261,13 +261,15 @@ describe('SearchPageContainer Component', () => {
       cy.get('[aria-label="selection-alert"]').should('not.exist');
     });
 
-    it.only('should be able to deselect checkboxes', () => {
+    it('should be able to deselect checkboxes', () => {
       cy.get('#search-entities-menu').click();
       cy.get('[aria-label="Investigation checkbox"]').click();
       cy.get('[aria-label="Datafile checkbox"]').click();
+      //Close drop down menu
+      cy.get('body').type('{esc}');
 
       cy.get('[aria-label="Submit search"]')
-        .click({ force: true })
+        .click()
         .wait(['@investigations', '@investigations', '@investigationsCount'], {
           timeout: 10000,
         });

--- a/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
@@ -261,12 +261,13 @@ describe('SearchPageContainer Component', () => {
       cy.get('[aria-label="selection-alert"]').should('not.exist');
     });
 
-    it('should be able to deselect checkboxes', () => {
+    it.only('should be able to deselect checkboxes', () => {
+      cy.get('#search-entities-menu').click();
       cy.get('[aria-label="Investigation checkbox"]').click();
       cy.get('[aria-label="Datafile checkbox"]').click();
 
       cy.get('[aria-label="Submit search"]')
-        .click()
+        .click({ force: true })
         .wait(['@investigations', '@investigations', '@investigationsCount'], {
           timeout: 10000,
         });

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -1,6 +1,6 @@
 {
   "searchBox": {
-    "search_text": "Search for investigations, datasets or datafiles",
+    "search_text": "Search for investigations, datasets and datafiles",
     "examples_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>.",
     "examples_label_link1": "?searchText=\"instrument+calibration\"",
     "examples_label_link2": "?searchText=neutron+AND+scattering",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -1,7 +1,7 @@
 {
   "searchBox": {
     "search_text": "Search for title, name, instrument",
-    "search_textbox_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>. See all search options.",
+    "search_textbox_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>.",
     "search_textbox_label_link1": "?searchText=\"instrument+calibration\"",
     "search_textbox_label_link2": "?searchText=neutron+AND+scattering",
     "start_date": "Start date",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -137,8 +137,7 @@
     "show_less": "Show less"
   },
   "advanced_search_help": {
-    "advanced_button": "Advanced",
-    "advanced_button_arialabel": "Advanced help",
+    "search_options_arialabel": "Search options",
     "close_button_arialabel": "Close",
     "title": "Advanced Search Tips",
     "description": "When you search for a word e.g. 'calibration', we will search for any records containing this word. But, sometimes you may wish to be more specific. Here we show you how.",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -13,7 +13,8 @@
       "investigation_arialabel": "Investigation checkbox",
       "dataset_arialabel": "Dataset checkbox",
       "datafile_arialabel": "Datafile checkbox",
-      "types": "Types"
+      "types": "Types",
+      "types_error": "At least one required"
     },
     "search_button": "Search",
     "search_text_arialabel": "Search text input",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -1,11 +1,11 @@
 {
   "searchBox": {
     "search_text": "Search for title, name, instrument",
-    "search_textbox_label": "e.g. <1>\"instrument calibration\"</1>, or <4>neutron AND scattering</4>.",
+    "search_textbox_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>. See all search options.",
     "search_textbox_label_link1": "?searchText=\"instrument+calibration\"",
     "search_textbox_label_link2": "?searchText=neutron+AND+scattering",
-    "start_date": "Start Date",
-    "end_date": "End Date",
+    "start_date": "Start date",
+    "end_date": "End date",
     "checkboxes": {
       "text": "Please select at least one",
       "investigation": "Investigation",
@@ -29,7 +29,7 @@
       "cancel": "Cancel",
       "clear": "Clear"
     },
-    "limited_results_message": "Please note: Only the top {{maxNumResults}} results will be displayed for each entity type i.e. Investigation, Dataset or Datafile. Click 'Advanced' to learn more."
+    "limited_results_message": "Only the top {{maxNumResults}} results will be displayed for each type"
   },
   "searchPageTable": {
     "tabs_arialabel": "Search table",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -1,9 +1,9 @@
 {
   "searchBox": {
     "search_text": "Search for title, name, instrument",
-    "search_textbox_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>.",
-    "search_textbox_label_link1": "?searchText=\"instrument+calibration\"",
-    "search_textbox_label_link2": "?searchText=neutron+AND+scattering",
+    "examples_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>.",
+    "examples_label_link1": "?searchText=\"instrument+calibration\"",
+    "examples_label_link2": "?searchText=neutron+AND+scattering",
     "start_date": "Start date",
     "end_date": "End date",
     "checkboxes": {
@@ -22,7 +22,7 @@
     "end_date_arialabel": "End date input",
     "end_date_button_arialabel": "End date picker",
     "search_button_arialabel": "Submit search",
-    "invalid_date_message": "Please enter the date in the format yyyy-MM-dd.",
+    "invalid_date_message": "Date format: yyyy-MM-dd.",
     "invalid_date_range_message": "Invalid date range",
     "date_picker": {
       "ok": "OK",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -7,13 +7,13 @@
     "start_date": "Start date",
     "end_date": "End date",
     "checkboxes": {
-      "text": "Please select at least one",
       "investigation": "Investigation",
       "dataset": "Dataset",
       "datafile": "Datafile",
       "investigation_arialabel": "Investigation checkbox",
       "dataset_arialabel": "Dataset checkbox",
-      "datafile_arialabel": "Datafile checkbox"
+      "datafile_arialabel": "Datafile checkbox",
+      "types": "Types"
     },
     "search_button": "Search",
     "search_text_arialabel": "Search text input",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -1,6 +1,6 @@
 {
   "searchBox": {
-    "search_text": "Search for title, name, instrument",
+    "search_text": "Search for investigations, datasets or datafiles",
     "examples_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>.",
     "examples_label_link1": "?searchText=\"instrument+calibration\"",
     "examples_label_link2": "?searchText=neutron+AND+scattering",

--- a/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
@@ -2,141 +2,137 @@
 
 exports[`SearchBoxContainer - Tests renders searchBoxContainer correctly 1`] = `
 <div
-  className="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-center"
-  id="container-searchbox"
+  className="MuiBox-root MuiBox-root-6 makeStyles-containerBox-2"
 >
   <WithStyles(ForwardRef(Grid))
-    item={true}
-    xs={8}
+    container={true}
+    direction="row"
+    id="container-searchbox"
+    justify="center"
   >
-    <Styled(MuiBox)
-      pb={1}
-      pl={2}
+    <WithStyles(ForwardRef(Grid))
+      item={true}
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+      xs="auto"
     >
       <SearchTextBox
         initiateSearch={[MockFunction]}
       />
-    </Styled(MuiBox)>
-  </WithStyles(ForwardRef(Grid))>
-  <WithStyles(ForwardRef(Grid))
-    item={true}
-    style={
-      Object {
-        "display": "flex",
-      }
-    }
-  >
-    <Styled(MuiBox)
-      m="auto"
-      px={2}
-    >
-      <TranslatedSearchButton
-        initiateSearch={[MockFunction]}
-      />
-    </Styled(MuiBox)>
-  </WithStyles(ForwardRef(Grid))>
-  <WithStyles(ForwardRef(Grid))
-    item={true}
-    style={
-      Object {
-        "display": "flex",
-      }
-    }
-  >
-    <Styled(MuiBox)
-      m="auto"
-      px={2}
-    >
-      <AdvancedHelpDialogue />
-    </Styled(MuiBox)>
-  </WithStyles(ForwardRef(Grid))>
-  <WithStyles(ForwardRef(Grid))
-    container={true}
-    item={true}
-    justify="center"
-    style={
-      Object {
-        "margin": 0,
-        "padding": 0,
-      }
-    }
-  >
-    <WithStyles(ForwardRef(Typography))
+    </WithStyles(ForwardRef(Grid))>
+    <WithStyles(ForwardRef(Grid))
+      item={true}
       style={
         Object {
-          "fontSize": "14px",
-          "margin": 0,
-          "padding": 0,
+          "marginTop": "8px",
         }
       }
     >
-      <Trans
-        i18nKey="searchBox.search_textbox_label"
-        t={[Function]}
-      >
-        e.g. title has
-        <WithStyles(ForwardRef(Link))
-          href="searchBox.search_textbox_label_link1"
-        >
-          "instrument calibration"
-        </WithStyles(ForwardRef(Link))>
-        , or
-         
-        <WithStyles(ForwardRef(Link))
-          href="searchBox.search_textbox_label_link2"
-        >
-          neutron AND scattering
-        </WithStyles(ForwardRef(Link))>
-        .
-      </Trans>
-    </WithStyles(ForwardRef(Typography))>
-  </WithStyles(ForwardRef(Grid))>
-  <WithStyles(ForwardRef(Grid))
-    container={true}
-    item={true}
-    justify="center"
-    style={
-      Object {
-        "paddingBottom": 8,
-        "paddingTop": 8,
+      <Connect(CheckboxesGroup) />
+    </WithStyles(ForwardRef(Grid))>
+    <WithStyles(ForwardRef(Grid))
+      item={true}
+      style={
+        Object {
+          "marginTop": "8px",
+        }
       }
-    }
-  >
+    >
+      <Connect(SelectDates)
+        initiateSearch={[MockFunction]}
+      />
+    </WithStyles(ForwardRef(Grid))>
     <WithStyles(ForwardRef(Grid))
       item={true}
       style={
         Object {
           "display": "flex",
+          "marginLeft": 6,
+          "marginTop": "24px",
         }
       }
     >
-      <Styled(MuiBox)
-        m="auto"
-      >
-        <Connect(CheckboxesGroup) />
-      </Styled(MuiBox)>
-    </WithStyles(ForwardRef(Grid))>
-    <WithStyles(ForwardRef(Grid))
-      item={true}
-    >
-      <Styled(MuiBox)
-        px={0.75}
-      >
-        <Connect(SelectDates)
-          initiateSearch={[MockFunction]}
-        />
-      </Styled(MuiBox)>
+      <TranslatedSearchButton
+        initiateSearch={[MockFunction]}
+      />
     </WithStyles(ForwardRef(Grid))>
   </WithStyles(ForwardRef(Grid))>
-  <WithStyles(ForwardRef(Typography))
+  <div
     style={
       Object {
-        "margin": "10px",
+        "display": "flex",
       }
     }
   >
-    searchBox.limited_results_message {maxNumResults:{tabs:{datasetTab:false,datafileTab:false,investigationTab:false,currentTab:investigation},selectAllSetting:true,settingsLoaded:false,sideLayout:false,searchableEntities:[investigation,dataset,datafile],maxNumResults:300}}
-  </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      className="makeStyles-leftText-3"
+    >
+      <Trans
+        i18nKey="searchBox.examples_label"
+        t={[Function]}
+      >
+        For example
+        <WithStyles(ForwardRef(Link))
+          href="searchBox.examples_label_link1"
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          "instrument calibration"
+        </WithStyles(ForwardRef(Link))>
+        or
+         
+        <WithStyles(ForwardRef(Link))
+          href="searchBox.examples_label_link2"
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          neutron AND scattering
+        </WithStyles(ForwardRef(Link))>
+        .
+      </Trans>
+       
+      <AdvancedHelpDialogue />
+    </WithStyles(ForwardRef(Typography))>
+    <div
+      className="makeStyles-rightText-4"
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexWrap": "nowrap",
+          }
+        }
+      >
+        <Memo(ForwardRef(InfoOutlinedIcon))
+          className="makeStyles-infoIcon-1"
+          fontSize="small"
+        />
+         
+        <WithStyles(ForwardRef(Typography))
+          display="inline"
+          style={
+            Object {
+              "fontSize": "14px",
+              "paddingLeft": "6px",
+            }
+          }
+        >
+          searchBox.limited_results_message {maxNumResults:{tabs:{datasetTab:false,datafileTab:false,investigationTab:false,currentTab:investigation},selectAllSetting:true,settingsLoaded:false,sideLayout:false,searchableEntities:[investigation,dataset,datafile],maxNumResults:300}}
+        </WithStyles(ForwardRef(Typography))>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
@@ -3469,7 +3469,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                             className="tour-search-tab-select"
                             classes={
                               Object {
-                                "indicator": "WithStyles(ForwardRef(Tabs))-indicator-1",
+                                "indicator": "WithStyles(ForwardRef(Tabs))-indicator-2",
+                                "root": "WithStyles(ForwardRef(Tabs))-root-1",
                               }
                             }
                             onChange={[Function]}
@@ -3484,8 +3485,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                   "fixed": "MuiTabs-fixed",
                                   "flexContainer": "MuiTabs-flexContainer",
                                   "flexContainerVertical": "MuiTabs-flexContainerVertical",
-                                  "indicator": "MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1",
-                                  "root": "MuiTabs-root",
+                                  "indicator": "MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2",
+                                  "root": "MuiTabs-root WithStyles(ForwardRef(Tabs))-root-1",
                                   "scrollButtons": "MuiTabs-scrollButtons",
                                   "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
                                   "scrollable": "MuiTabs-scrollable",
@@ -3497,7 +3498,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                               value="investigation"
                             >
                               <div
-                                className="MuiTabs-root tour-search-tab-select"
+                                className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-1 tour-search-tab-select"
                               >
                                 <div
                                   className="MuiTabs-scroller MuiTabs-fixed"
@@ -3661,7 +3662,6 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                     classes={
                                                       Object {
                                                         "badge": "WithStyles(ForwardRef(Badge))-badge-3",
-                                                        "root": "WithStyles(ForwardRef(Badge))-root-2",
                                                       }
                                                     }
                                                     id="investigation-badge"
@@ -3686,7 +3686,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           "colorSecondary": "MuiBadge-colorSecondary",
                                                           "dot": "MuiBadge-dot",
                                                           "invisible": "MuiBadge-invisible",
-                                                          "root": "MuiBadge-root WithStyles(ForwardRef(Badge))-root-2",
+                                                          "root": "MuiBadge-root",
                                                         }
                                                       }
                                                       id="investigation-badge"
@@ -3694,7 +3694,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                       showZero={true}
                                                     >
                                                       <span
-                                                        className="MuiBadge-root WithStyles(ForwardRef(Badge))-root-2"
+                                                        className="MuiBadge-root"
                                                         id="investigation-badge"
                                                       >
                                                         <span
@@ -3899,7 +3899,6 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                     classes={
                                                       Object {
                                                         "badge": "WithStyles(ForwardRef(Badge))-badge-3",
-                                                        "root": "WithStyles(ForwardRef(Badge))-root-2",
                                                       }
                                                     }
                                                     id="dataset-badge"
@@ -3924,7 +3923,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           "colorSecondary": "MuiBadge-colorSecondary",
                                                           "dot": "MuiBadge-dot",
                                                           "invisible": "MuiBadge-invisible",
-                                                          "root": "MuiBadge-root WithStyles(ForwardRef(Badge))-root-2",
+                                                          "root": "MuiBadge-root",
                                                         }
                                                       }
                                                       id="dataset-badge"
@@ -3932,7 +3931,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                       showZero={true}
                                                     >
                                                       <span
-                                                        className="MuiBadge-root WithStyles(ForwardRef(Badge))-root-2"
+                                                        className="MuiBadge-root"
                                                         id="dataset-badge"
                                                       >
                                                         <span
@@ -4137,7 +4136,6 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                     classes={
                                                       Object {
                                                         "badge": "WithStyles(ForwardRef(Badge))-badge-3",
-                                                        "root": "WithStyles(ForwardRef(Badge))-root-2",
                                                       }
                                                     }
                                                     id="datafile-badge"
@@ -4162,7 +4160,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           "colorSecondary": "MuiBadge-colorSecondary",
                                                           "dot": "MuiBadge-dot",
                                                           "invisible": "MuiBadge-invisible",
-                                                          "root": "MuiBadge-root WithStyles(ForwardRef(Badge))-root-2",
+                                                          "root": "MuiBadge-root",
                                                         }
                                                       }
                                                       id="datafile-badge"
@@ -4170,7 +4168,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                       showZero={true}
                                                     >
                                                       <span
-                                                        className="MuiBadge-root WithStyles(ForwardRef(Badge))-root-2"
+                                                        className="MuiBadge-root"
                                                         id="datafile-badge"
                                                       >
                                                         <span
@@ -4231,7 +4229,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                     </WithStyles(ForwardRef(Tab))>
                                   </div>
                                   <WithStyles(ForwardRef(TabIndicator))
-                                    className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                    className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2"
                                     color="secondary"
                                     orientation="horizontal"
                                     style={
@@ -4242,7 +4240,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                     }
                                   >
                                     <ForwardRef(TabIndicator)
-                                      className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                      className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2"
                                       classes={
                                         Object {
                                           "colorPrimary": "PrivateTabIndicator-colorPrimary-5",
@@ -4261,7 +4259,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                       }
                                     >
                                       <span
-                                        className="PrivateTabIndicator-root-4 PrivateTabIndicator-colorSecondary-6 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                        className="PrivateTabIndicator-root-4 PrivateTabIndicator-colorSecondary-6 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2"
                                         style={
                                           Object {
                                             "left": 0,

--- a/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
@@ -3389,6 +3389,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
           >
             <div>
               <WithStyles(ForwardRef(AppBar))
+                elevation={0}
                 position="static"
               >
                 <ForwardRef(AppBar)
@@ -3407,12 +3408,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                       "root": "MuiAppBar-root",
                     }
                   }
+                  elevation={0}
                   position="static"
                 >
                   <WithStyles(ForwardRef(Paper))
                     className="MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary"
                     component="header"
-                    elevation={4}
+                    elevation={0}
                     square={true}
                   >
                     <ForwardRef(Paper)
@@ -3450,11 +3452,11 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         }
                       }
                       component="header"
-                      elevation={4}
+                      elevation={0}
                       square={true}
                     >
                       <header
-                        className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation4"
+                        className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation0"
                       >
                         <WithStyles(WithStyles(ForwardRef(Tabs)))
                           aria-label="searchPageCardView.tabs_arialabel"
@@ -3529,6 +3531,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                           <span
                                             style={
                                               Object {
+                                                "fontSize": "16px",
+                                                "fontWeight": "bold",
                                                 "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                 "marginRight": "calc(0.5 * 1ch + 6px)",
                                                 "paddingRight": "1ch",
@@ -3573,6 +3577,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                             <span
                                               style={
                                                 Object {
+                                                  "fontSize": "16px",
+                                                  "fontWeight": "bold",
                                                   "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                   "marginRight": "calc(0.5 * 1ch + 6px)",
                                                   "paddingRight": "1ch",
@@ -3693,6 +3699,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                         <span
                                                           style={
                                                             Object {
+                                                              "fontSize": "16px",
+                                                              "fontWeight": "bold",
                                                               "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                               "marginRight": "calc(0.5 * 1ch + 6px)",
                                                               "paddingRight": "1ch",
@@ -3760,6 +3768,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                           <span
                                             style={
                                               Object {
+                                                "fontSize": "16px",
+                                                "fontWeight": "bold",
                                                 "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                 "marginRight": "calc(0.5 * 1ch + 6px)",
                                                 "paddingRight": "1ch",
@@ -3804,6 +3814,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                             <span
                                               style={
                                                 Object {
+                                                  "fontSize": "16px",
+                                                  "fontWeight": "bold",
                                                   "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                   "marginRight": "calc(0.5 * 1ch + 6px)",
                                                   "paddingRight": "1ch",
@@ -3924,6 +3936,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                         <span
                                                           style={
                                                             Object {
+                                                              "fontSize": "16px",
+                                                              "fontWeight": "bold",
                                                               "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                               "marginRight": "calc(0.5 * 1ch + 6px)",
                                                               "paddingRight": "1ch",
@@ -3991,6 +4005,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                           <span
                                             style={
                                               Object {
+                                                "fontSize": "16px",
+                                                "fontWeight": "bold",
                                                 "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                 "marginRight": "calc(0.5 * 1ch + 6px)",
                                                 "paddingRight": "1ch",
@@ -4035,6 +4051,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                             <span
                                               style={
                                                 Object {
+                                                  "fontSize": "16px",
+                                                  "fontWeight": "bold",
                                                   "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                   "marginRight": "calc(0.5 * 1ch + 6px)",
                                                   "paddingRight": "1ch",
@@ -4155,6 +4173,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                         <span
                                                           style={
                                                             Object {
+                                                              "fontSize": "16px",
+                                                              "fontWeight": "bold",
                                                               "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                               "marginRight": "calc(0.5 * 1ch + 6px)",
                                                               "paddingRight": "1ch",

--- a/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
@@ -3660,7 +3660,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-3",
+                                                        "root": "WithStyles(ForwardRef(Badge))-root-2",
                                                       }
                                                     }
                                                     id="investigation-badge"
@@ -3679,13 +3680,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
                                                           "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
                                                           "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3",
                                                           "colorError": "MuiBadge-colorError",
                                                           "colorPrimary": "MuiBadge-colorPrimary",
                                                           "colorSecondary": "MuiBadge-colorSecondary",
                                                           "dot": "MuiBadge-dot",
                                                           "invisible": "MuiBadge-invisible",
-                                                          "root": "MuiBadge-root",
+                                                          "root": "MuiBadge-root WithStyles(ForwardRef(Badge))-root-2",
                                                         }
                                                       }
                                                       id="investigation-badge"
@@ -3693,7 +3694,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                       showZero={true}
                                                     >
                                                       <span
-                                                        className="MuiBadge-root"
+                                                        className="MuiBadge-root WithStyles(ForwardRef(Badge))-root-2"
                                                         id="investigation-badge"
                                                       >
                                                         <span
@@ -3710,7 +3711,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           tabs.investigation
                                                         </span>
                                                         <span
-                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3 MuiBadge-anchorOriginTopRightRectangle"
                                                         >
                                                           0
                                                         </span>
@@ -3897,7 +3898,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-3",
+                                                        "root": "WithStyles(ForwardRef(Badge))-root-2",
                                                       }
                                                     }
                                                     id="dataset-badge"
@@ -3916,13 +3918,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
                                                           "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
                                                           "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3",
                                                           "colorError": "MuiBadge-colorError",
                                                           "colorPrimary": "MuiBadge-colorPrimary",
                                                           "colorSecondary": "MuiBadge-colorSecondary",
                                                           "dot": "MuiBadge-dot",
                                                           "invisible": "MuiBadge-invisible",
-                                                          "root": "MuiBadge-root",
+                                                          "root": "MuiBadge-root WithStyles(ForwardRef(Badge))-root-2",
                                                         }
                                                       }
                                                       id="dataset-badge"
@@ -3930,7 +3932,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                       showZero={true}
                                                     >
                                                       <span
-                                                        className="MuiBadge-root"
+                                                        className="MuiBadge-root WithStyles(ForwardRef(Badge))-root-2"
                                                         id="dataset-badge"
                                                       >
                                                         <span
@@ -3947,7 +3949,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           tabs.dataset
                                                         </span>
                                                         <span
-                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3 MuiBadge-anchorOriginTopRightRectangle"
                                                         >
                                                           0
                                                         </span>
@@ -4134,7 +4136,8 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-3",
+                                                        "root": "WithStyles(ForwardRef(Badge))-root-2",
                                                       }
                                                     }
                                                     id="datafile-badge"
@@ -4153,13 +4156,13 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
                                                           "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
                                                           "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3",
                                                           "colorError": "MuiBadge-colorError",
                                                           "colorPrimary": "MuiBadge-colorPrimary",
                                                           "colorSecondary": "MuiBadge-colorSecondary",
                                                           "dot": "MuiBadge-dot",
                                                           "invisible": "MuiBadge-invisible",
-                                                          "root": "MuiBadge-root",
+                                                          "root": "MuiBadge-root WithStyles(ForwardRef(Badge))-root-2",
                                                         }
                                                       }
                                                       id="datafile-badge"
@@ -4167,7 +4170,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                       showZero={true}
                                                     >
                                                       <span
-                                                        className="MuiBadge-root"
+                                                        className="MuiBadge-root WithStyles(ForwardRef(Badge))-root-2"
                                                         id="datafile-badge"
                                                       >
                                                         <span
@@ -4184,7 +4187,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                                           tabs.datafile
                                                         </span>
                                                         <span
-                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3 MuiBadge-anchorOriginTopRightRectangle"
                                                         >
                                                           0
                                                         </span>
@@ -4242,10 +4245,10 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                       className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
                                       classes={
                                         Object {
-                                          "colorPrimary": "PrivateTabIndicator-colorPrimary-4",
-                                          "colorSecondary": "PrivateTabIndicator-colorSecondary-5",
-                                          "root": "PrivateTabIndicator-root-3",
-                                          "vertical": "PrivateTabIndicator-vertical-6",
+                                          "colorPrimary": "PrivateTabIndicator-colorPrimary-5",
+                                          "colorSecondary": "PrivateTabIndicator-colorSecondary-6",
+                                          "root": "PrivateTabIndicator-root-4",
+                                          "vertical": "PrivateTabIndicator-vertical-7",
                                         }
                                       }
                                       color="secondary"
@@ -4258,7 +4261,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                                       }
                                     >
                                       <span
-                                        className="PrivateTabIndicator-root-3 PrivateTabIndicator-colorSecondary-5 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                        className="PrivateTabIndicator-root-4 PrivateTabIndicator-colorSecondary-6 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
                                         style={
                                           Object {
                                             "left": 0,
@@ -4292,7 +4295,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                 >
                   <div
                     aria-labelledby="simple-tab-investigation"
-                    className="MuiBox-root MuiBox-root-7"
+                    className="MuiBox-root MuiBox-root-8"
                     hidden={false}
                     id="simple-tabpanel-investigation"
                     role="tabpanel"
@@ -4301,7 +4304,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                       p={3}
                     >
                       <div
-                        className="MuiBox-root MuiBox-root-8"
+                        className="MuiBox-root MuiBox-root-9"
                       >
                         <InvestigationCardView>
                           <mockConstructor

--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
@@ -4067,6 +4067,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
           >
             <div>
               <WithStyles(ForwardRef(AppBar))
+                elevation={0}
                 position="static"
               >
                 <ForwardRef(AppBar)
@@ -4085,12 +4086,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       "root": "MuiAppBar-root",
                     }
                   }
+                  elevation={0}
                   position="static"
                 >
                   <WithStyles(ForwardRef(Paper))
                     className="MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary"
                     component="header"
-                    elevation={4}
+                    elevation={0}
                     square={true}
                   >
                     <ForwardRef(Paper)
@@ -4128,11 +4130,11 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         }
                       }
                       component="header"
-                      elevation={4}
+                      elevation={0}
                       square={true}
                     >
                       <header
-                        className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation4"
+                        className="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation0"
                       >
                         <WithStyles(WithStyles(ForwardRef(Tabs)))
                           aria-label="searchPageTable.tabs_arialabel"
@@ -4199,7 +4201,19 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                       key=".0"
                                       label={
                                         <WithStyles(WithStyles(ForwardRef(Badge)))
-                                          badgeContent={0}
+                                          badgeContent={
+                                            <span
+                                              style={
+                                                Object {
+                                                  "fontSize": "14px",
+                                                  "fontWeight": "bold",
+                                                  "marginTop": "1px",
+                                                }
+                                              }
+                                            >
+                                              0
+                                            </span>
+                                          }
                                           id="investigation-badge"
                                           max={999}
                                           showZero={true}
@@ -4207,6 +4221,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                           <span
                                             style={
                                               Object {
+                                                "fontSize": "16px",
+                                                "fontWeight": "bold",
                                                 "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                 "marginRight": "calc(0.5 * 1ch + 6px)",
                                                 "paddingRight": "1ch",
@@ -4243,7 +4259,19 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                         indicator={false}
                                         label={
                                           <WithStyles(WithStyles(ForwardRef(Badge)))
-                                            badgeContent={0}
+                                            badgeContent={
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "fontSize": "14px",
+                                                    "fontWeight": "bold",
+                                                    "marginTop": "1px",
+                                                  }
+                                                }
+                                              >
+                                                0
+                                              </span>
+                                            }
                                             id="investigation-badge"
                                             max={999}
                                             showZero={true}
@@ -4251,6 +4279,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                             <span
                                               style={
                                                 Object {
+                                                  "fontSize": "16px",
+                                                  "fontWeight": "bold",
                                                   "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                   "marginRight": "calc(0.5 * 1ch + 6px)",
                                                   "paddingRight": "1ch",
@@ -4323,13 +4353,37 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                 className="MuiTab-wrapper"
                                               >
                                                 <WithStyles(WithStyles(ForwardRef(Badge)))
-                                                  badgeContent={0}
+                                                  badgeContent={
+                                                    <span
+                                                      style={
+                                                        Object {
+                                                          "fontSize": "14px",
+                                                          "fontWeight": "bold",
+                                                          "marginTop": "1px",
+                                                        }
+                                                      }
+                                                    >
+                                                      0
+                                                    </span>
+                                                  }
                                                   id="investigation-badge"
                                                   max={999}
                                                   showZero={true}
                                                 >
                                                   <WithStyles(ForwardRef(Badge))
-                                                    badgeContent={0}
+                                                    badgeContent={
+                                                      <span
+                                                        style={
+                                                          Object {
+                                                            "fontSize": "14px",
+                                                            "fontWeight": "bold",
+                                                            "marginTop": "1px",
+                                                          }
+                                                        }
+                                                      >
+                                                        0
+                                                      </span>
+                                                    }
                                                     classes={
                                                       Object {
                                                         "badge": "WithStyles(ForwardRef(Badge))-badge-2",
@@ -4340,7 +4394,19 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                     showZero={true}
                                                   >
                                                     <ForwardRef(Badge)
-                                                      badgeContent={0}
+                                                      badgeContent={
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "fontSize": "14px",
+                                                              "fontWeight": "bold",
+                                                              "marginTop": "1px",
+                                                            }
+                                                          }
+                                                        >
+                                                          0
+                                                        </span>
+                                                      }
                                                       classes={
                                                         Object {
                                                           "anchorOriginBottomLeftCircle": "MuiBadge-anchorOriginBottomLeftCircle",
@@ -4371,6 +4437,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                         <span
                                                           style={
                                                             Object {
+                                                              "fontSize": "16px",
+                                                              "fontWeight": "bold",
                                                               "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                               "marginRight": "calc(0.5 * 1ch + 6px)",
                                                               "paddingRight": "1ch",
@@ -4382,7 +4450,17 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                         <span
                                                           className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
                                                         >
-                                                          0
+                                                          <span
+                                                            style={
+                                                              Object {
+                                                                "fontSize": "14px",
+                                                                "fontWeight": "bold",
+                                                                "marginTop": "1px",
+                                                              }
+                                                            }
+                                                          >
+                                                            0
+                                                          </span>
                                                         </span>
                                                       </span>
                                                     </ForwardRef(Badge)>
@@ -4438,6 +4516,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                           <span
                                             style={
                                               Object {
+                                                "fontSize": "16px",
+                                                "fontWeight": "bold",
                                                 "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                 "marginRight": "calc(0.5 * 1ch + 6px)",
                                                 "paddingRight": "1ch",
@@ -4482,6 +4562,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                             <span
                                               style={
                                                 Object {
+                                                  "fontSize": "16px",
+                                                  "fontWeight": "bold",
                                                   "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                   "marginRight": "calc(0.5 * 1ch + 6px)",
                                                   "paddingRight": "1ch",
@@ -4602,6 +4684,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                         <span
                                                           style={
                                                             Object {
+                                                              "fontSize": "16px",
+                                                              "fontWeight": "bold",
                                                               "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                               "marginRight": "calc(0.5 * 1ch + 6px)",
                                                               "paddingRight": "1ch",
@@ -4669,6 +4753,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                           <span
                                             style={
                                               Object {
+                                                "fontSize": "16px",
+                                                "fontWeight": "bold",
                                                 "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                 "marginRight": "calc(0.5 * 1ch + 6px)",
                                                 "paddingRight": "1ch",
@@ -4713,6 +4799,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                             <span
                                               style={
                                                 Object {
+                                                  "fontSize": "16px",
+                                                  "fontWeight": "bold",
                                                   "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                   "marginRight": "calc(0.5 * 1ch + 6px)",
                                                   "paddingRight": "1ch",
@@ -4833,6 +4921,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                         <span
                                                           style={
                                                             Object {
+                                                              "fontSize": "16px",
+                                                              "fontWeight": "bold",
                                                               "marginLeft": "calc(-0.5 * 1ch - 6px)",
                                                               "marginRight": "calc(0.5 * 1ch + 6px)",
                                                               "paddingRight": "1ch",

--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
@@ -4147,7 +4147,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                             className="tour-search-tab-select"
                             classes={
                               Object {
-                                "indicator": "WithStyles(ForwardRef(Tabs))-indicator-1",
+                                "indicator": "WithStyles(ForwardRef(Tabs))-indicator-2",
+                                "root": "WithStyles(ForwardRef(Tabs))-root-1",
                               }
                             }
                             onChange={[Function]}
@@ -4162,8 +4163,8 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                   "fixed": "MuiTabs-fixed",
                                   "flexContainer": "MuiTabs-flexContainer",
                                   "flexContainerVertical": "MuiTabs-flexContainerVertical",
-                                  "indicator": "MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1",
-                                  "root": "MuiTabs-root",
+                                  "indicator": "MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2",
+                                  "root": "MuiTabs-root WithStyles(ForwardRef(Tabs))-root-1",
                                   "scrollButtons": "MuiTabs-scrollButtons",
                                   "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
                                   "scrollable": "MuiTabs-scrollable",
@@ -4175,7 +4176,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                               value="investigation"
                             >
                               <div
-                                className="MuiTabs-root tour-search-tab-select"
+                                className="MuiTabs-root WithStyles(ForwardRef(Tabs))-root-1 tour-search-tab-select"
                               >
                                 <div
                                   className="MuiTabs-scroller MuiTabs-fixed"
@@ -4386,7 +4387,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                     }
                                                     classes={
                                                       Object {
-                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-3",
                                                       }
                                                     }
                                                     id="investigation-badge"
@@ -4417,7 +4418,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                           "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
                                                           "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
                                                           "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3",
                                                           "colorError": "MuiBadge-colorError",
                                                           "colorPrimary": "MuiBadge-colorPrimary",
                                                           "colorSecondary": "MuiBadge-colorSecondary",
@@ -4448,7 +4449,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                           tabs.investigation
                                                         </span>
                                                         <span
-                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3 MuiBadge-anchorOriginTopRightRectangle"
                                                         >
                                                           <span
                                                             style={
@@ -4645,7 +4646,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-3",
                                                       }
                                                     }
                                                     id="dataset-badge"
@@ -4664,7 +4665,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                           "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
                                                           "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
                                                           "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3",
                                                           "colorError": "MuiBadge-colorError",
                                                           "colorPrimary": "MuiBadge-colorPrimary",
                                                           "colorSecondary": "MuiBadge-colorSecondary",
@@ -4695,7 +4696,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                           tabs.dataset
                                                         </span>
                                                         <span
-                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3 MuiBadge-anchorOriginTopRightRectangle"
                                                         >
                                                           0
                                                         </span>
@@ -4882,7 +4883,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                     badgeContent={0}
                                                     classes={
                                                       Object {
-                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-2",
+                                                        "badge": "WithStyles(ForwardRef(Badge))-badge-3",
                                                       }
                                                     }
                                                     id="datafile-badge"
@@ -4901,7 +4902,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                           "anchorOriginTopLeftRectangle": "MuiBadge-anchorOriginTopLeftRectangle",
                                                           "anchorOriginTopRightCircle": "MuiBadge-anchorOriginTopRightCircle",
                                                           "anchorOriginTopRightRectangle": "MuiBadge-anchorOriginTopRightRectangle",
-                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2",
+                                                          "badge": "MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3",
                                                           "colorError": "MuiBadge-colorError",
                                                           "colorPrimary": "MuiBadge-colorPrimary",
                                                           "colorSecondary": "MuiBadge-colorSecondary",
@@ -4932,7 +4933,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                                           tabs.datafile
                                                         </span>
                                                         <span
-                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-2 MuiBadge-anchorOriginTopRightRectangle"
+                                                          className="MuiBadge-badge WithStyles(ForwardRef(Badge))-badge-3 MuiBadge-anchorOriginTopRightRectangle"
                                                         >
                                                           0
                                                         </span>
@@ -4976,7 +4977,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                     </WithStyles(ForwardRef(Tab))>
                                   </div>
                                   <WithStyles(ForwardRef(TabIndicator))
-                                    className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                    className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2"
                                     color="secondary"
                                     orientation="horizontal"
                                     style={
@@ -4987,13 +4988,13 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                     }
                                   >
                                     <ForwardRef(TabIndicator)
-                                      className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                      className="MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2"
                                       classes={
                                         Object {
-                                          "colorPrimary": "PrivateTabIndicator-colorPrimary-4",
-                                          "colorSecondary": "PrivateTabIndicator-colorSecondary-5",
-                                          "root": "PrivateTabIndicator-root-3",
-                                          "vertical": "PrivateTabIndicator-vertical-6",
+                                          "colorPrimary": "PrivateTabIndicator-colorPrimary-5",
+                                          "colorSecondary": "PrivateTabIndicator-colorSecondary-6",
+                                          "root": "PrivateTabIndicator-root-4",
+                                          "vertical": "PrivateTabIndicator-vertical-7",
                                         }
                                       }
                                       color="secondary"
@@ -5006,7 +5007,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                                       }
                                     >
                                       <span
-                                        className="PrivateTabIndicator-root-3 PrivateTabIndicator-colorSecondary-5 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-1"
+                                        className="PrivateTabIndicator-root-4 PrivateTabIndicator-colorSecondary-6 MuiTabs-indicator WithStyles(ForwardRef(Tabs))-indicator-2"
                                         style={
                                           Object {
                                             "left": 0,
@@ -5040,7 +5041,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                 >
                   <div
                     aria-labelledby="simple-tab-investigation"
-                    className="MuiBox-root MuiBox-root-7"
+                    className="MuiBox-root MuiBox-root-8"
                     hidden={false}
                     id="simple-tabpanel-investigation"
                     role="tabpanel"
@@ -5049,7 +5050,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                       pt={1}
                     >
                       <div
-                        className="MuiBox-root MuiBox-root-8"
+                        className="MuiBox-root MuiBox-root-9"
                       >
                         <WithStyles(ForwardRef(Paper))
                           elevation={0}

--- a/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
   See all
    
   <WithStyles(ForwardRef(Link))
-    aria-label="advanced_search_help.advanced_button_arialabel"
+    aria-label="advanced_search_help.search_options_arialabel"
     className="makeStyles-advancedButton-2"
     component="button"
     onClick={[Function]}

--- a/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
@@ -1,15 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Advanced help dialogue component tests renders correctly 1`] = `
-<div>
-  <WithStyles(ForwardRef(Button))
+<Fragment>
+  See all
+   
+  <WithStyles(ForwardRef(Link))
     aria-label="advanced_search_help.advanced_button_arialabel"
     className="makeStyles-advancedButton-2"
+    component="button"
     onClick={[Function]}
-    variant="text"
   >
-    advanced_search_help.advanced_button
-  </WithStyles(ForwardRef(Button))>
+    search options
+  </WithStyles(ForwardRef(Link))>
+  .
   <WithStyles(ForwardRef(Dialog))
     PaperProps={
       Object {
@@ -166,5 +169,5 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
       </Trans>
     </WithStyles(ForwardRef(Typography))>
   </WithStyles(ForwardRef(Dialog))>
-</div>
+</Fragment>
 `;

--- a/packages/datagateway-search/src/search/__snapshots__/searchTextBox.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/searchTextBox.component.test.tsx.snap
@@ -1,29 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Search text box component tests renders correctly 1`] = `
-<div>
-  <WithStyles(ForwardRef(TextField))
-    InputProps={
-      Object {
-        "aria-label": "searchBox.search_text_arialabel",
-        "endAdornment": <WithStyles(ForwardRef(InputAdornment))
-          position="start"
-        >
-          <Memo />
-        </WithStyles(ForwardRef(InputAdornment))>,
-      }
-    }
-    className="tour-search-textfield"
-    color="secondary"
+<div
+  className="MuiFormControl-root MuiTextField-root tour-search-textfield MuiFormControl-marginNormal MuiFormControl-fullWidth"
+  onKeyDown={[Function]}
+>
+  <WithStyles(ForwardRef(InputLabel))
+    htmlFor="filled-search"
+    id="filled-search-label"
+  >
+    searchBox.search_text
+  </WithStyles(ForwardRef(InputLabel))>
+  <WithStyles(ForwardRef(OutlinedInput))
+    aria-label="searchBox.search_text_arialabel"
+    autoFocus={false}
     fullWidth={true}
     id="filled-search"
-    label="searchBox.search_text"
-    margin="normal"
+    label={
+      <React.Fragment>
+        searchBox.search_text
+      </React.Fragment>
+    }
+    multiline={false}
     onChange={[Function]}
-    onKeyDown={[Function]}
     type="search"
     value="test"
-    variant="outlined"
   />
 </div>
 `;

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
@@ -52,7 +52,7 @@ describe('Advanced help dialogue component tests', () => {
   it('can open and close help dialogue', () => {
     const wrapper = createWrapper();
     wrapper
-      .find('[aria-label="advanced_search_help.advanced_button_arialabel"]')
+      .find('[aria-label="advanced_search_help.search_options_arialabel"]')
       .first()
       .simulate('click');
     expect(

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
@@ -5,7 +5,6 @@ import {
   Theme,
   withStyles,
 } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import MuiDialogTitle from '@material-ui/core/DialogTitle';
 import MuiDialogContent from '@material-ui/core/DialogContent';
@@ -24,8 +23,9 @@ const useStyles = makeStyles((theme: Theme) => {
       padding: theme.spacing(2),
     },
     advancedButton: {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      color: (theme as any).colours?.blue,
+      top: '-1px',
+      fontSize: '14px',
+      fontWeight: 'bold',
     },
     closeButton: {
       position: 'absolute',
@@ -76,15 +76,19 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
   };
 
   return (
-    <div>
-      <Button
-        variant="text"
-        className={classes.advancedButton}
-        aria-label={t('advanced_search_help.advanced_button_arialabel')}
-        onClick={handleClickOpen}
-      >
-        {t('advanced_search_help.advanced_button')}
-      </Button>
+    <React.Fragment>
+      <Typography display="inline" style={{ fontSize: '14px' }}>
+        See all{' '}
+        <Link
+          component="button"
+          className={classes.advancedButton}
+          aria-label={t('advanced_search_help.advanced_button_arialabel')}
+          onClick={handleClickOpen}
+        >
+          search options
+        </Link>
+        .
+      </Typography>
       <Dialog
         onClose={handleClose}
         aria-labelledby="advanced-search-dialog-title"
@@ -201,7 +205,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
           </Trans>
         </Typography>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 };
 

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
@@ -76,18 +76,16 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
 
   return (
     <React.Fragment>
-      <Typography display="inline" style={{ fontSize: '14px' }}>
-        See all{' '}
-        <Link
-          component="button"
-          className={classes.advancedButton}
-          aria-label={t('advanced_search_help.advanced_button_arialabel')}
-          onClick={handleClickOpen}
-        >
-          search options
-        </Link>
-        .
-      </Typography>
+      See all{' '}
+      <Link
+        component="button"
+        className={classes.advancedButton}
+        aria-label={t('advanced_search_help.advanced_button_arialabel')}
+        onClick={handleClickOpen}
+      >
+        search options
+      </Link>
+      .
       <Dialog
         onClose={handleClose}
         aria-labelledby="advanced-search-dialog-title"

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
@@ -80,7 +80,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
       <Link
         component="button"
         className={classes.advancedButton}
-        aria-label={t('advanced_search_help.advanced_button_arialabel')}
+        aria-label={t('advanced_search_help.search_options_arialabel')}
         onClick={handleClickOpen}
       >
         search options

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
@@ -23,7 +23,6 @@ const useStyles = makeStyles((theme: Theme) => {
       padding: theme.spacing(2),
     },
     advancedButton: {
-      top: '-1px',
       fontSize: '14px',
       fontWeight: 'bold',
     },

--- a/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
@@ -61,7 +61,7 @@ describe('Checkbox component tests', () => {
     const wrapper = createWrapper();
 
     expect(wrapper.find('#search-entities-menu').last().text()).toEqual(
-      'Types (2)'
+      'searchBox.checkboxes.types (2)'
     );
 
     wrapper
@@ -100,7 +100,7 @@ describe('Checkbox component tests', () => {
     const wrapper = createWrapper();
 
     expect(wrapper.find('#search-entities-menu').last().text()).toEqual(
-      'Types (1)'
+      'searchBox.checkboxes.types (1)'
     );
 
     wrapper

--- a/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
@@ -59,22 +59,36 @@ describe('Checkbox component tests', () => {
   it('renders correctly', () => {
     history.replace('/?searchText=&investigation=false');
     const wrapper = createWrapper();
+
+    expect(wrapper.find('#search-entities-menu').last().text()).toEqual(
+      'Types (2)'
+    );
+
+    wrapper
+      .find('#search-entities-menu')
+      .find('[role="button"]')
+      .simulate('mousedown', { button: 0 });
+
     const investigationCheckbox = wrapper.find(
-      '[aria-label="Investigation checkbox"]'
+      '[aria-label="searchBox.checkboxes.investigation_arialabel"]'
     );
     expect(investigationCheckbox.exists());
     investigationCheckbox.find('input').forEach((node) => {
       expect(node.props().checked).toEqual(false);
     });
 
-    const datasetCheckbox = wrapper.find('[aria-label="Dataset checkbox"]');
+    const datasetCheckbox = wrapper.find(
+      '[aria-label="searchBox.checkboxes.dataset_arialabel"]'
+    );
     expect(datasetCheckbox.exists());
     datasetCheckbox.find('input').forEach((node) => {
       expect(node.props().checked).toEqual(true);
     });
 
-    const datafileCheckbox = wrapper.find('[aria-label="Datafile checkbox"]');
-    expect(datafileCheckbox.exists());
+    const datafileCheckbox = wrapper.find(
+      '[aria-label="searchBox.checkboxes.datafile_arialabel"]'
+    );
+    expect(datafileCheckbox.exists()).toEqual(true);
     datafileCheckbox.find('input').forEach((node) => {
       expect(node.props().checked).toEqual(true);
     });
@@ -84,23 +98,37 @@ describe('Checkbox component tests', () => {
     state.dgsearch.searchableEntities = ['investigation', 'dataset'];
     history.replace('/?searchText=&investigation=false');
     const wrapper = createWrapper();
+
+    expect(wrapper.find('#search-entities-menu').last().text()).toEqual(
+      'Types (1)'
+    );
+
+    wrapper
+      .find('#search-entities-menu')
+      .find('[role="button"]')
+      .simulate('mousedown', { button: 0 });
+
     const investigationCheckbox = wrapper.find(
-      '[aria-label="Investigation checkbox"]'
+      '[aria-label="searchBox.checkboxes.investigation_arialabel"]'
     );
     expect(investigationCheckbox.exists());
     investigationCheckbox.find('input').forEach((node) => {
       expect(node.props().checked).toEqual(false);
     });
 
-    const datasetCheckbox = wrapper.find('[aria-label="Dataset checkbox"]');
+    const datasetCheckbox = wrapper.find(
+      '[aria-label="searchBox.checkboxes.dataset_arialabel"]'
+    );
     expect(datasetCheckbox.exists());
     datasetCheckbox.find('input').forEach((node) => {
       expect(node.props().checked).toEqual(true);
     });
 
-    expect(wrapper.find('[aria-label="Datafile checkbox"]').exists()).toEqual(
-      false
-    );
+    expect(
+      wrapper
+        .find('[aria-label="searchBox.checkboxes.datafile_arialabel"]')
+        .exists()
+    ).toEqual(false);
   });
 
   it('pushes URL with new dataset value when user clicks checkbox', () => {
@@ -108,8 +136,13 @@ describe('Checkbox component tests', () => {
     const wrapper = createWrapper();
 
     wrapper
+      .find('#search-entities-menu')
+      .find('[role="button"]')
+      .simulate('mousedown', { button: 0 });
+
+    wrapper
       .find('[aria-label="searchBox.checkboxes.dataset_arialabel"]')
-      .simulate('change');
+      .simulate('click');
 
     expect(pushSpy).toHaveBeenCalledWith('?dataset=false&investigation=false');
   });
@@ -119,8 +152,13 @@ describe('Checkbox component tests', () => {
     const wrapper = createWrapper();
 
     wrapper
+      .find('#search-entities-menu')
+      .find('[role="button"]')
+      .simulate('mousedown', { button: 0 });
+
+    wrapper
       .find('[aria-label="searchBox.checkboxes.datafile_arialabel"]')
-      .simulate('change');
+      .simulate('click');
 
     expect(pushSpy).toHaveBeenCalledWith('?datafile=false&investigation=false');
   });
@@ -130,8 +168,13 @@ describe('Checkbox component tests', () => {
     const wrapper = createWrapper();
 
     wrapper
+      .find('#search-entities-menu')
+      .find('[role="button"]')
+      .simulate('mousedown', { button: 0 });
+
+    wrapper
       .find('[aria-label="searchBox.checkboxes.investigation_arialabel"]')
-      .simulate('change');
+      .simulate('click');
 
     expect(pushSpy).toHaveBeenCalledWith('?');
   });

--- a/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.test.tsx
@@ -131,6 +131,21 @@ describe('Checkbox component tests', () => {
     ).toEqual(false);
   });
 
+  it('renders an error message when nothing is selected', () => {
+    history.replace(
+      '/?searchText=&investigation=false&dataset=false&datafile=false'
+    );
+    const wrapper = createWrapper();
+
+    expect(
+      wrapper.find('#search-entities-checkbox-label').first().text()
+    ).toContain('searchBox.checkboxes.types');
+
+    expect(wrapper.find('.MuiFormHelperText-root').last().text()).toEqual(
+      'searchBox.checkboxes.types_error'
+    );
+  });
+
   it('pushes URL with new dataset value when user clicks checkbox', () => {
     history.replace('/?searchText=&investigation=false');
     const wrapper = createWrapper();

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -108,12 +108,17 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
         error={error}
         className={`${classes.formControl} tour-search-checkbox`}
       >
-        <InputLabel id="search-entities-checkbox-label" variant="outlined">
-          Types
-        </InputLabel>
+        {error && (
+          <InputLabel
+            id="search-entities-checkbox-label"
+            variant="outlined"
+            shrink={false}
+          >
+            Types
+          </InputLabel>
+        )}
         <Select
           labelId="search-entities-checkbox-label"
-          label="Types *"
           id="search-entities-checkbox"
           multiple
           value={searchToggles
@@ -122,7 +127,7 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
           onChange={handleChange}
           variant="outlined"
           renderValue={(selected) => {
-            return (selected as string[]).join(', ');
+            return `Types (${(selected as string[]).length})`;
           }}
           MenuProps={MenuProps}
         >

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -23,6 +23,10 @@ const useStyles = makeStyles((theme: Theme) =>
       margin: 'auto',
       marginRight: theme.spacing(2),
     },
+    select: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      color: (theme as any).colours?.contrastGrey,
+    },
   })
 );
 
@@ -120,6 +124,7 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
         <Select
           labelId="search-entities-checkbox-label"
           id="search-entities-checkbox"
+          className={classes.select}
           multiple
           value={searchToggles
             .filter((toggle) => toggle.value)

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -123,7 +123,7 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
         )}
         <Select
           labelId="search-entities-checkbox-label"
-          id="search-entities-checkbox"
+          id="search-entities-menu"
           className={classes.select}
           multiple
           value={searchToggles

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -118,11 +118,11 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
             variant="outlined"
             shrink={false}
           >
-            Types
+            {t('searchBox.checkboxes.types')}
           </InputLabel>
         )}
         <Select
-          labelId="search-entities-checkbox-label"
+          {...(error ? { labelId: 'search-entities-checkbox-label' } : {})}
           id="search-entities-menu"
           className={classes.select}
           multiple
@@ -132,7 +132,9 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
           onChange={handleChange}
           variant="outlined"
           renderValue={(selected) => {
-            return `Types (${(selected as string[]).length})`;
+            return `${t('searchBox.checkboxes.types')} (${
+              (selected as string[]).length
+            })`;
           }}
           MenuProps={MenuProps}
         >

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import FormControl from '@material-ui/core/FormControl';
-import FormLabel from '@material-ui/core/FormLabel';
-import FormGroup from '@material-ui/core/FormGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import { connect } from 'react-redux';
 import { StateType } from '../state/app.types';
 import { useTranslation } from 'react-i18next';
 import { parseSearchToQuery, usePushSearchToggles } from 'datagateway-common';
 import { useLocation } from 'react-router-dom';
+import { InputLabel, ListItemText, MenuItem, Select } from '@material-ui/core';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -17,10 +15,9 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
     },
     formControl: {
-      marginLeft: theme.spacing(2),
-    },
-    formControlSide: {
-      margin: theme.spacing(2),
+      margin: theme.spacing(1),
+      minWidth: 120,
+      maxWidth: 300,
     },
     formLabel: {
       margin: 'auto',
@@ -29,14 +26,33 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
+
 interface CheckBoxStoreProps {
   sideLayout: boolean;
   searchableEntities: string[];
 }
 
+interface SearchToggle {
+  name: string;
+  value: boolean;
+  label: string;
+  ariaLabel: string;
+}
+
 const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
   const classes = useStyles();
-  const { sideLayout, searchableEntities } = props;
+  const [t] = useTranslation();
+  const { searchableEntities } = props;
 
   const investigationSearchable = searchableEntities.includes('investigation');
   const datasetSearchable = searchableEntities.includes('dataset');
@@ -49,94 +65,74 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
   );
   const pushSearchToggles = usePushSearchToggles();
 
-  const searchableEntitiesToggles: boolean[] = [];
-  if (investigationSearchable) searchableEntitiesToggles.push(investigation);
-  if (datasetSearchable) searchableEntitiesToggles.push(dataset);
-  if (datafileSearchable) searchableEntitiesToggles.push(datafile);
+  const searchToggles: SearchToggle[] = [];
 
-  const handleChange = (name: string, checked: boolean) => (
-    event: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    const toggleOption = !checked;
-    if (name === 'Investigation') {
-      pushSearchToggles(dataset, datafile, toggleOption);
-    } else if (name === 'Datafile') {
-      pushSearchToggles(dataset, toggleOption, investigation);
-    } else if (name === 'Dataset') {
-      pushSearchToggles(toggleOption, datafile, investigation);
-    }
+  if (investigationSearchable)
+    searchToggles.push({
+      name: 'Investigation',
+      value: investigation,
+      label: t('searchBox.checkboxes.investigation'),
+      ariaLabel: t('searchBox.checkboxes.investigation_arialabel'),
+    });
+  if (datasetSearchable)
+    searchToggles.push({
+      name: 'Dataset',
+      value: dataset,
+      label: t('searchBox.checkboxes.dataset'),
+      ariaLabel: t('searchBox.checkboxes.dataset_arialabel'),
+    });
+  if (datafileSearchable)
+    searchToggles.push({
+      name: 'Datafile',
+      value: datafile,
+      label: t('searchBox.checkboxes.datafile'),
+      ariaLabel: t('searchBox.checkboxes.datafile_arialabel'),
+    });
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
+    const newValues = event.target.value as string[];
+
+    pushSearchToggles(
+      newValues.indexOf('Dataset') > -1,
+      newValues.indexOf('Datafile') > -1,
+      newValues.indexOf('Investigation') > -1
+    );
   };
 
-  const error = !searchableEntitiesToggles.includes(true);
-
-  const [t] = useTranslation();
+  const error = searchToggles.filter((toggle) => toggle.value).length === 0;
 
   return (
     <div className={classes.root}>
       <FormControl
         required
         error={error}
-        component="fieldset"
-        className={`${
-          sideLayout ? classes.formControlSide : classes.formControl
-        } tour-search-checkbox`}
+        className={`${classes.formControl} tour-search-checkbox`}
       >
-        <FormGroup row={!sideLayout}>
-          <FormLabel
-            component="legend"
-            focused={false}
-            className={classes.formLabel}
-          >
-            {t('searchBox.checkboxes.text')}
-          </FormLabel>
-          {investigationSearchable && (
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={investigation}
-                  onChange={handleChange('Investigation', investigation)}
-                  value="Investigation"
-                  inputProps={{
-                    'aria-label': t(
-                      'searchBox.checkboxes.investigation_arialabel'
-                    ),
-                  }}
-                />
-              }
-              label={t('searchBox.checkboxes.investigation')}
-            />
-          )}
-          {datasetSearchable && (
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={dataset}
-                  onChange={handleChange('Dataset', dataset)}
-                  value="Dataset"
-                  inputProps={{
-                    'aria-label': t('searchBox.checkboxes.dataset_arialabel'),
-                  }}
-                />
-              }
-              label={t('searchBox.checkboxes.dataset')}
-            />
-          )}
-          {datafileSearchable && (
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={datafile}
-                  onChange={handleChange('Datafile', datafile)}
-                  value="Datafile"
-                  inputProps={{
-                    'aria-label': t('searchBox.checkboxes.datafile_arialabel'),
-                  }}
-                />
-              }
-              label={t('searchBox.checkboxes.datafile')}
-            />
-          )}
-        </FormGroup>
+        <InputLabel id="search-entities-checkbox-label">Types</InputLabel>
+        <Select
+          labelId="search-entities-checkbox-label"
+          id="search-entities-checkbox"
+          multiple
+          value={searchToggles
+            .filter((toggle) => toggle.value)
+            .map((toggle) => toggle.name)}
+          onChange={handleChange}
+          variant="outlined"
+          renderValue={(selected) => {
+            return (selected as string[]).join(', ');
+          }}
+          MenuProps={MenuProps}
+        >
+          {searchToggles.map((toggle) => (
+            <MenuItem key={toggle.name} value={toggle.name}>
+              <Checkbox
+                checked={toggle.value}
+                inputProps={{ 'aria-label': toggle.ariaLabel }}
+              />
+              <ListItemText primary={toggle.name} />
+            </MenuItem>
+          ))}
+        </Select>
       </FormControl>
     </div>
   );

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -108,9 +108,12 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
         error={error}
         className={`${classes.formControl} tour-search-checkbox`}
       >
-        <InputLabel id="search-entities-checkbox-label">Types</InputLabel>
+        <InputLabel id="search-entities-checkbox-label" variant="outlined">
+          Types
+        </InputLabel>
         <Select
           labelId="search-entities-checkbox-label"
+          label="Types *"
           id="search-entities-checkbox"
           multiple
           value={searchToggles

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -7,7 +7,13 @@ import { StateType } from '../state/app.types';
 import { useTranslation } from 'react-i18next';
 import { parseSearchToQuery, usePushSearchToggles } from 'datagateway-common';
 import { useLocation } from 'react-router-dom';
-import { InputLabel, ListItemText, MenuItem, Select } from '@material-ui/core';
+import {
+  FormHelperText,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Select,
+} from '@material-ui/core';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -148,6 +154,11 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
             </MenuItem>
           ))}
         </Select>
+        {error && (
+          <FormHelperText style={{ marginLeft: '14px', marginRight: '14px' }}>
+            {t('searchBox.checkboxes.types_error')}
+          </FormHelperText>
+        )}
       </FormControl>
     </div>
   );

--- a/packages/datagateway-search/src/search/datePicker.component.tsx
+++ b/packages/datagateway-search/src/search/datePicker.component.tsx
@@ -136,7 +136,7 @@ export function SelectDates(props: DatePickerCombinedProps): JSX.Element {
               'aria-label': t('searchBox.start_date_button_arialabel'),
             }}
             color="secondary"
-            style={sideLayout ? {} : { paddingRight: 6 }}
+            style={sideLayout ? {} : { paddingRight: 6, width: '175px' }}
             okLabel={
               <span style={{ color: buttonColour }}>
                 {t('searchBox.date_picker.ok')}
@@ -176,6 +176,7 @@ export function SelectDates(props: DatePickerCombinedProps): JSX.Element {
               'aria-label': t('searchBox.end_date_button_arialabel'),
             }}
             color="secondary"
+            style={sideLayout ? {} : { width: '175px' }}
             okLabel={
               <span style={{ color: buttonColour }}>
                 {t('searchBox.date_picker.ok')}

--- a/packages/datagateway-search/src/search/datePicker.component.tsx
+++ b/packages/datagateway-search/src/search/datePicker.component.tsx
@@ -136,7 +136,7 @@ export function SelectDates(props: DatePickerCombinedProps): JSX.Element {
               'aria-label': t('searchBox.start_date_button_arialabel'),
             }}
             color="secondary"
-            style={sideLayout ? {} : { paddingRight: 6, width: '175px' }}
+            style={sideLayout ? {} : { paddingRight: 6, width: '178px' }}
             okLabel={
               <span style={{ color: buttonColour }}>
                 {t('searchBox.date_picker.ok')}
@@ -176,7 +176,7 @@ export function SelectDates(props: DatePickerCombinedProps): JSX.Element {
               'aria-label': t('searchBox.end_date_button_arialabel'),
             }}
             color="secondary"
-            style={sideLayout ? {} : { width: '175px' }}
+            style={sideLayout ? {} : { width: '178px' }}
             okLabel={
               <span style={{ color: buttonColour }}>
                 {t('searchBox.date_picker.ok')}

--- a/packages/datagateway-search/src/search/searchTextBox.component.tsx
+++ b/packages/datagateway-search/src/search/searchTextBox.component.tsx
@@ -22,24 +22,22 @@ const SearchTextBox = (props: SearchTextProps): React.ReactElement => {
   };
 
   return (
-    <div>
-      <TextField
-        className="tour-search-textfield"
-        id="filled-search"
-        label={t('searchBox.search_text')}
-        type="search"
-        margin="normal"
-        value={searchText}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        fullWidth
-        variant="outlined"
-        color="secondary"
-        InputProps={{
-          'aria-label': t('searchBox.search_text_arialabel'),
-        }}
-      />
-    </div>
+    <TextField
+      className="tour-search-textfield"
+      id="filled-search"
+      label={t('searchBox.search_text')}
+      type="search"
+      margin="normal"
+      value={searchText}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      fullWidth
+      variant="outlined"
+      color="secondary"
+      InputProps={{
+        'aria-label': t('searchBox.search_text_arialabel'),
+      }}
+    />
   );
 };
 

--- a/packages/datagateway-search/src/search/searchTextBox.component.tsx
+++ b/packages/datagateway-search/src/search/searchTextBox.component.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import TextField from '@material-ui/core/TextField';
-import InputAdornment from '@material-ui/core/InputAdornment';
-import SearchIcon from '@material-ui/icons/Search';
 import { useTranslation } from 'react-i18next';
 
 interface SearchTextProps {
@@ -39,11 +37,6 @@ const SearchTextBox = (props: SearchTextProps): React.ReactElement => {
         color="secondary"
         InputProps={{
           'aria-label': t('searchBox.search_text_arialabel'),
-          endAdornment: (
-            <InputAdornment position="start">
-              <SearchIcon />
-            </InputAdornment>
-          ),
         }}
       />
     </div>

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {
   Grid,
-  Box,
   Typography,
   Link,
   makeStyles,
@@ -18,6 +17,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import AdvancedHelpDialogue from './search/advancedHelpDialogue.component';
 import { useSelector } from 'react-redux';
 import { StateType } from './state/app.types';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -25,7 +25,6 @@ const useStyles = makeStyles((theme: Theme) =>
       textAlign: 'left',
       fontSize: '14px',
       textIndent: '16px',
-      display: 'inline-block',
     },
     rightText: {
       textAlign: 'right',
@@ -58,9 +57,9 @@ const SearchBoxContainer = (
   );
 
   return (
-    <div style={{ display: 'block', boxSizing: 'border-box' }}>
+    <div>
       <Grid container direction="row" justify="center" id="container-searchbox">
-        <Grid item xs={4}>
+        <Grid item xs={6}>
           <SearchTextBox
             searchText={searchText}
             initiateSearch={initiateSearch}
@@ -76,37 +75,54 @@ const SearchBoxContainer = (
           <SelectDates initiateSearch={initiateSearch} />
         </Grid>
 
-        <Grid item style={{ display: 'flex', marginTop: '8px' }}>
-          <Box px={2} m="auto">
-            <SearchButton initiateSearch={initiateSearch} />
-          </Box>
-        </Grid>
-
-        <Grid item style={{ display: 'flex' }}>
-          <Box px={2} m="auto">
-            <AdvancedHelpDialogue />
-          </Box>
+        <Grid
+          item
+          style={{ display: 'flex', marginTop: '24px', marginLeft: 6 }}
+        >
+          <SearchButton initiateSearch={initiateSearch} />
         </Grid>
       </Grid>
       <div style={{ display: 'flex' }}>
         <Typography className={classes.leftText}>
           <Trans t={t} i18nKey="searchBox.search_textbox_label">
             For example
-            <Link href={t('searchBox.search_textbox_label_link1')}>
+            <Link
+              style={{ fontWeight: 'bold' }}
+              href={t('searchBox.search_textbox_label_link1')}
+            >
               &quot;instrument calibration&quot;
             </Link>
             or{' '}
-            <Link href={t('searchBox.search_textbox_label_link2')}>
+            <Link
+              style={{ fontWeight: 'bold' }}
+              href={t('searchBox.search_textbox_label_link2')}
+            >
               neutron AND scattering
             </Link>
-            . See all search options.
+            .
           </Trans>
+          <AdvancedHelpDialogue />
         </Typography>
-        <Typography display="inline" className={classes.rightText}>
-          {t('searchBox.limited_results_message', {
-            maxNumResults,
-          })}
-        </Typography>
+
+        <div className={classes.rightText}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <InfoOutlinedIcon fontSize="small" />{' '}
+            <Typography
+              display="inline"
+              style={{ paddingLeft: '6px', fontSize: '14px' }}
+            >
+              {t('searchBox.limited_results_message', {
+                maxNumResults,
+              })}
+            </Typography>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme: Theme) =>
       color: (theme as any).colours?.contrastGrey,
     },
     containerBox: {
-      maxWidth: '1600px',
+      maxWidth: '1920px',
       paddingLeft: theme.spacing(2),
       paddingRight: theme.spacing(2),
       paddingBottom: theme.spacing(2),

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-import { Grid, Box, Typography, Link } from '@material-ui/core';
+import {
+  Grid,
+  Box,
+  Typography,
+  Link,
+  makeStyles,
+  createStyles,
+  Theme,
+} from '@material-ui/core';
 
 import SelectDates from './search/datePicker.component';
 import CheckboxesGroup from './search/checkBoxes.component';
@@ -10,6 +18,27 @@ import { Trans, useTranslation } from 'react-i18next';
 import AdvancedHelpDialogue from './search/advancedHelpDialogue.component';
 import { useSelector } from 'react-redux';
 import { StateType } from './state/app.types';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    leftText: {
+      textAlign: 'left',
+      fontSize: '14px',
+      textIndent: '16px',
+      display: 'inline-block',
+    },
+    rightText: {
+      textAlign: 'right',
+      fontSize: '14px',
+      right: 0,
+      paddingRight: '16px',
+      marginLeft: 'auto',
+    },
+    bold: {
+      fontWeight: 'bold',
+    },
+  })
+);
 
 interface SearchBoxContainerProps {
   searchText: string;
@@ -21,6 +50,7 @@ const SearchBoxContainer = (
   props: SearchBoxContainerProps
 ): React.ReactElement => {
   const { searchText, initiateSearch, onSearchTextChange } = props;
+  const classes = useStyles();
   const [t] = useTranslation();
 
   const maxNumResults = useSelector(
@@ -28,76 +58,57 @@ const SearchBoxContainer = (
   );
 
   return (
-    <Grid
-      container
-      direction="row"
-      justify="center"
-      alignItems="stretch"
-      id="container-searchbox"
-    >
-      <Grid item xs={8}>
-        <Box pl={2} pb={1}>
+    <div style={{ display: 'block', boxSizing: 'border-box' }}>
+      <Grid container direction="row" justify="center" id="container-searchbox">
+        <Grid item xs={4}>
           <SearchTextBox
             searchText={searchText}
             initiateSearch={initiateSearch}
             onChange={onSearchTextChange}
           />
-        </Box>
-      </Grid>
+        </Grid>
 
-      <Grid item style={{ display: 'flex' }}>
-        <Box px={2} m="auto">
-          <SearchButton initiateSearch={initiateSearch} />
-        </Box>
-      </Grid>
+        <Grid item style={{ marginTop: '8px' }}>
+          <CheckboxesGroup />
+        </Grid>
 
-      <Grid item style={{ display: 'flex' }}>
-        <Box px={2} m="auto">
-          <AdvancedHelpDialogue />
-        </Box>
-      </Grid>
+        <Grid item style={{ marginTop: '8px' }}>
+          <SelectDates initiateSearch={initiateSearch} />
+        </Grid>
 
-      <Grid container item justify="center" style={{ padding: 0, margin: 0 }}>
-        <Typography style={{ fontSize: '14px', padding: 0, margin: 0 }}>
+        <Grid item style={{ display: 'flex', marginTop: '8px' }}>
+          <Box px={2} m="auto">
+            <SearchButton initiateSearch={initiateSearch} />
+          </Box>
+        </Grid>
+
+        <Grid item style={{ display: 'flex' }}>
+          <Box px={2} m="auto">
+            <AdvancedHelpDialogue />
+          </Box>
+        </Grid>
+      </Grid>
+      <div style={{ display: 'flex' }}>
+        <Typography className={classes.leftText}>
           <Trans t={t} i18nKey="searchBox.search_textbox_label">
-            e.g. title has
+            For example
             <Link href={t('searchBox.search_textbox_label_link1')}>
               &quot;instrument calibration&quot;
             </Link>
-            , or{' '}
+            or{' '}
             <Link href={t('searchBox.search_textbox_label_link2')}>
               neutron AND scattering
             </Link>
-            .
+            . See all search options.
           </Trans>
         </Typography>
-      </Grid>
-
-      <Grid
-        container
-        item
-        justify="center"
-        style={{ paddingBottom: 8, paddingTop: 8 }}
-      >
-        <Grid item style={{ display: 'flex' }}>
-          <Box m="auto">
-            <CheckboxesGroup />
-          </Box>
-        </Grid>
-
-        <Grid item>
-          <Box px={0.75}>
-            <SelectDates initiateSearch={initiateSearch} />
-          </Box>
-        </Grid>
-      </Grid>
-
-      <Typography style={{ margin: '10px' }}>
-        {t('searchBox.limited_results_message', {
-          maxNumResults,
-        })}
-      </Typography>
-    </Grid>
+        <Typography display="inline" className={classes.rightText}>
+          {t('searchBox.limited_results_message', {
+            maxNumResults,
+          })}
+        </Typography>
+      </div>
+    </div>
   );
 };
 

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -22,23 +22,29 @@ import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    infoIcon: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      color: (theme as any).colours?.contrastGrey,
+    },
     containerBox: {
       maxWidth: '1600px',
       paddingLeft: theme.spacing(2),
       paddingRight: theme.spacing(2),
+      paddingBottom: theme.spacing(2),
       margin: 'auto',
       justifyContent: 'center',
     },
     leftText: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      color: (theme as any).colours?.contrastGrey,
       textAlign: 'left',
       fontSize: '14px',
-      textIndent: '16px',
     },
     rightText: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      color: (theme as any).colours?.contrastGrey,
       textAlign: 'right',
       fontSize: '14px',
-      right: 0,
-      paddingRight: '16px',
       marginLeft: 'auto',
     },
     bold: {
@@ -92,23 +98,23 @@ const SearchBoxContainer = (
       </Grid>
       <div style={{ display: 'flex' }}>
         <Typography className={classes.leftText}>
-          <Trans t={t} i18nKey="searchBox.search_textbox_label">
+          <Trans t={t} i18nKey="searchBox.examples_label">
             For example
             <Link
               style={{ fontWeight: 'bold' }}
-              href={t('searchBox.search_textbox_label_link1')}
+              href={t('searchBox.examples_label_link1')}
             >
               &quot;instrument calibration&quot;
             </Link>
             or{' '}
             <Link
               style={{ fontWeight: 'bold' }}
-              href={t('searchBox.search_textbox_label_link2')}
+              href={t('searchBox.examples_label_link2')}
             >
               neutron AND scattering
             </Link>
-            .{' '}
-          </Trans>
+            .
+          </Trans>{' '}
           <AdvancedHelpDialogue />
         </Typography>
 
@@ -120,7 +126,7 @@ const SearchBoxContainer = (
               flexWrap: 'nowrap',
             }}
           >
-            <InfoOutlinedIcon fontSize="small" />{' '}
+            <InfoOutlinedIcon className={classes.infoIcon} fontSize="small" />{' '}
             <Typography
               display="inline"
               style={{ paddingLeft: '6px', fontSize: '14px' }}

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -7,6 +7,7 @@ import {
   makeStyles,
   createStyles,
   Theme,
+  Box,
 } from '@material-ui/core';
 
 import SelectDates from './search/datePicker.component';
@@ -21,6 +22,13 @@ import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    containerBox: {
+      maxWidth: '1600px',
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(2),
+      margin: 'auto',
+      justifyContent: 'center',
+    },
     leftText: {
       textAlign: 'left',
       fontSize: '14px',
@@ -57,9 +65,9 @@ const SearchBoxContainer = (
   );
 
   return (
-    <div>
+    <Box className={classes.containerBox}>
       <Grid container direction="row" justify="center" id="container-searchbox">
-        <Grid item xs={6}>
+        <Grid item xs="auto" style={{ flexGrow: 1 }}>
           <SearchTextBox
             searchText={searchText}
             initiateSearch={initiateSearch}
@@ -99,7 +107,7 @@ const SearchBoxContainer = (
             >
               neutron AND scattering
             </Link>
-            .
+            .{' '}
           </Trans>
           <AdvancedHelpDialogue />
         </Typography>
@@ -109,7 +117,7 @@ const SearchBoxContainer = (
             style={{
               display: 'flex',
               alignItems: 'center',
-              flexWrap: 'wrap',
+              flexWrap: 'nowrap',
             }}
           >
             <InfoOutlinedIcon fontSize="small" />{' '}
@@ -124,7 +132,7 @@ const SearchBoxContainer = (
           </div>
         </div>
       </div>
-    </div>
+    </Box>
   );
 };
 

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -36,9 +36,10 @@ const badgeStyles = (theme: Theme): StyleRules =>
     badge: {
       backgroundColor: '#fff',
       color: '#000000',
-      fontSize: 'inherit',
+      fontSize: '14px',
+      fontWeight: 'bold',
       lineHeight: 'inherit',
-      top: '0.875em',
+      top: '1em',
     },
   });
 
@@ -238,20 +239,9 @@ const SearchPageCardView = (
               label={
                 <StyledBadge
                   id="investigation-badge"
-                  badgeContent={
-                    <span
-                      style={{
-                        fontSize: '14px',
-                        fontWeight: 'bold',
-                        marginTop: '1px',
-                      }}
-                    >
-                      {investigationDataCount ?? 0}
-                    </span>
-                  }
+                  badgeContent={investigationDataCount ?? 0}
                   showZero
                   max={999}
-                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -281,20 +271,9 @@ const SearchPageCardView = (
               label={
                 <StyledBadge
                   id="dataset-badge"
-                  badgeContent={
-                    <span
-                      style={{
-                        fontSize: '14px',
-                        fontWeight: 'bold',
-                        marginTop: '1px',
-                      }}
-                    >
-                      {datasetDataCount ?? 0}
-                    </span>
-                  }
+                  badgeContent={datasetDataCount ?? 0}
                   showZero
                   max={999}
-                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -324,20 +303,9 @@ const SearchPageCardView = (
               label={
                 <StyledBadge
                   id="datafile-badge"
-                  badgeContent={
-                    <span
-                      style={{
-                        fontSize: '14px',
-                        fontWeight: 'bold',
-                        marginTop: '1px',
-                      }}
-                    >
-                      {datafileDataCount ?? 0}
-                    </span>
-                  }
+                  badgeContent={datafileDataCount ?? 0}
                   showZero
                   max={999}
-                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -243,6 +243,7 @@ const SearchPageCardView = (
                       style={{
                         fontSize: '14px',
                         fontWeight: 'bold',
+                        marginTop: '1px',
                       }}
                     >
                       {investigationDataCount ?? 0}
@@ -285,6 +286,7 @@ const SearchPageCardView = (
                       style={{
                         fontSize: '14px',
                         fontWeight: 'bold',
+                        marginTop: '1px',
                       }}
                     >
                       {datasetDataCount ?? 0}
@@ -327,6 +329,7 @@ const SearchPageCardView = (
                       style={{
                         fontSize: '14px',
                         fontWeight: 'bold',
+                        marginTop: '1px',
                       }}
                     >
                       {datafileDataCount ?? 0}

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -35,7 +35,10 @@ const badgeStyles = (theme: Theme): StyleRules =>
   createStyles({
     badge: {
       backgroundColor: '#CCCCCC',
-      color: '#000000',
+      //Increase contrast on high contrast modes by using black text
+      color:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (theme as any).colours?.type === 'contrast' ? '#000000' : '#333333',
       fontSize: '14px',
       fontWeight: 'bold',
       lineHeight: 'inherit',

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -34,7 +34,7 @@ import { useIsFetching } from 'react-query';
 const badgeStyles = (theme: Theme): StyleRules =>
   createStyles({
     badge: {
-      backgroundColor: '#fff',
+      backgroundColor: '#CCCCCC',
       color: '#000000',
       fontSize: '14px',
       fontWeight: 'bold',
@@ -227,7 +227,7 @@ const SearchPageCardView = (
     <div>
       {/* Show loading progress if data is still being loaded */}
       {loading && <LinearProgress color="secondary" />}
-      <AppBar position="static">
+      <AppBar position="static" elevation={0}>
         <StyledTabs
           className="tour-search-tab-select"
           value={currentTab}

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -33,18 +33,6 @@ import { useIsFetching } from 'react-query';
 
 const badgeStyles = (theme: Theme): StyleRules =>
   createStyles({
-    root: {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      backgroundColor: (theme as any).colours?.tabsGrey,
-      //Fixes contrast issue for unselected tabs in darkmode
-      color:
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (theme as any).palette.type === 'dark'
-          ? '#FFFFFF'
-          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (theme as any).colours?.blue,
-      boxShadow: 'none',
-    },
     badge: {
       backgroundColor: '#CCCCCC',
       //Increase contrast on high contrast modes by using black text
@@ -60,6 +48,18 @@ const badgeStyles = (theme: Theme): StyleRules =>
 
 const tabStyles = (theme: Theme): StyleRules =>
   createStyles({
+    root: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      backgroundColor: (theme as any).colours?.tabsGrey,
+      //Fixes contrast issue for unselected tabs in darkmode
+      color:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (theme as any).palette.type === 'dark'
+          ? '#FFFFFF'
+          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (theme as any).colours?.blue,
+      boxShadow: 'none',
+    },
     indicator: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       backgroundColor: (theme as any).colours?.blue,

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -33,6 +33,18 @@ import { useIsFetching } from 'react-query';
 
 const badgeStyles = (theme: Theme): StyleRules =>
   createStyles({
+    root: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      backgroundColor: (theme as any).colours?.tabsGrey,
+      //Fixes contrast issue for unselected tabs in darkmode
+      color:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (theme as any).palette.type === 'dark'
+          ? '#FFFFFF'
+          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (theme as any).colours?.blue,
+      boxShadow: 'none',
+    },
     badge: {
       backgroundColor: '#CCCCCC',
       //Increase contrast on high contrast modes by using black text

--- a/packages/datagateway-search/src/searchPageCardView.component.tsx
+++ b/packages/datagateway-search/src/searchPageCardView.component.tsx
@@ -45,13 +45,8 @@ const badgeStyles = (theme: Theme): StyleRules =>
 const tabStyles = (theme: Theme): StyleRules =>
   createStyles({
     indicator: {
-      //Use white for all modes except use red for dark high contrast mode as this is much clearer
-      backgroundColor:
-        theme.palette.type === 'dark' &&
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (theme as any).colours?.type === 'contrast'
-          ? '#FF0000'
-          : '#FFFFFF',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      backgroundColor: (theme as any).colours?.blue,
     },
   });
 
@@ -243,9 +238,19 @@ const SearchPageCardView = (
               label={
                 <StyledBadge
                   id="investigation-badge"
-                  badgeContent={investigationDataCount ?? 0}
+                  badgeContent={
+                    <span
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {investigationDataCount ?? 0}
+                    </span>
+                  }
                   showZero
                   max={999}
+                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -256,6 +261,8 @@ const SearchPageCardView = (
                       marginLeft: `calc(-0.5 * ${badgeDigits(
                         investigation?.length
                       )}ch - 6px)`,
+                      fontSize: '16px',
+                      fontWeight: 'bold',
                     }}
                   >
                     {t('tabs.investigation')}
@@ -273,9 +280,19 @@ const SearchPageCardView = (
               label={
                 <StyledBadge
                   id="dataset-badge"
-                  badgeContent={datasetDataCount ?? 0}
+                  badgeContent={
+                    <span
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {datasetDataCount ?? 0}
+                    </span>
+                  }
                   showZero
                   max={999}
+                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -286,6 +303,8 @@ const SearchPageCardView = (
                       marginLeft: `calc(-0.5 * ${badgeDigits(
                         dataset?.length
                       )}ch - 6px)`,
+                      fontSize: '16px',
+                      fontWeight: 'bold',
                     }}
                   >
                     {t('tabs.dataset')}
@@ -303,9 +322,19 @@ const SearchPageCardView = (
               label={
                 <StyledBadge
                   id="datafile-badge"
-                  badgeContent={datafileDataCount ?? 0}
+                  badgeContent={
+                    <span
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {datafileDataCount ?? 0}
+                    </span>
+                  }
                   showZero
                   max={999}
+                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -316,6 +345,8 @@ const SearchPageCardView = (
                       marginLeft: `calc(-0.5 * ${badgeDigits(
                         datafile?.length
                       )}ch - 6px)`,
+                      fontSize: '16px',
+                      fontWeight: 'bold',
                     }}
                   >
                     {t('tabs.datafile')}

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -135,7 +135,7 @@ const searchPageStyles = makeStyles<
       // decreasing the space for the search results
       width: '95%',
       '@media (min-width: 1600px) and (min-height: 700px)': {
-        width: '70%',
+        width: '95%',
       },
       margin: '0 auto',
     },

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -134,7 +134,7 @@ const searchPageStyles = makeStyles<
       // make width of box bigger on smaller screens to prevent overflow
       // decreasing the space for the search results
       width: '100%',
-      '@media (min-width: 1600px) and (min-height: 700px)': {
+      '@media (min-width: 1000px) and (min-height: 700px)': {
         width: '98%',
       },
       margin: '0 auto',

--- a/packages/datagateway-search/src/searchPageContainer.component.tsx
+++ b/packages/datagateway-search/src/searchPageContainer.component.tsx
@@ -133,9 +133,9 @@ const searchPageStyles = makeStyles<
       height: '100%',
       // make width of box bigger on smaller screens to prevent overflow
       // decreasing the space for the search results
-      width: '95%',
+      width: '100%',
       '@media (min-width: 1600px) and (min-height: 700px)': {
-        width: '95%',
+        width: '98%',
       },
       margin: '0 auto',
     },

--- a/packages/datagateway-search/src/searchPageTable.component.tsx
+++ b/packages/datagateway-search/src/searchPageTable.component.tsx
@@ -45,13 +45,8 @@ const badgeStyles = (theme: Theme): StyleRules =>
 const tabStyles = (theme: Theme): StyleRules =>
   createStyles({
     indicator: {
-      //Use white for all modes except use red for dark high contrast mode as this is much clearer
-      backgroundColor:
-        theme.palette.type === 'dark' &&
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (theme as any).colours?.type === 'contrast'
-          ? '#FF0000'
-          : '#FFFFFF',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      backgroundColor: (theme as any).colours?.blue,
     },
   });
 
@@ -246,6 +241,7 @@ const SearchPageTable = (
                       style={{
                         fontSize: '14px',
                         fontWeight: 'bold',
+                        marginTop: '1px',
                       }}
                     >
                       {investigationDataCount ?? 0}
@@ -288,6 +284,7 @@ const SearchPageTable = (
                       style={{
                         fontSize: '14px',
                         fontWeight: 'bold',
+                        marginTop: '1px',
                       }}
                     >
                       {datasetDataCount ?? 0}
@@ -330,6 +327,7 @@ const SearchPageTable = (
                       style={{
                         fontSize: '14px',
                         fontWeight: 'bold',
+                        marginTop: '1px',
                       }}
                     >
                       {datafileDataCount ?? 0}

--- a/packages/datagateway-search/src/searchPageTable.component.tsx
+++ b/packages/datagateway-search/src/searchPageTable.component.tsx
@@ -35,7 +35,10 @@ const badgeStyles = (theme: Theme): StyleRules =>
   createStyles({
     badge: {
       backgroundColor: '#CCCCCC',
-      color: '#000000',
+      //Increase contrast on high contrast modes by using black text
+      color:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (theme as any).colours?.type === 'contrast' ? '#000000' : '#333333',
       fontSize: '14px',
       fontWeight: 'bold',
       lineHeight: 'inherit',

--- a/packages/datagateway-search/src/searchPageTable.component.tsx
+++ b/packages/datagateway-search/src/searchPageTable.component.tsx
@@ -34,7 +34,7 @@ import { useIsFetching } from 'react-query';
 const badgeStyles = (theme: Theme): StyleRules =>
   createStyles({
     badge: {
-      backgroundColor: '#fff',
+      backgroundColor: '#CCCCCC',
       color: '#000000',
       fontSize: '14px',
       fontWeight: 'bold',
@@ -225,7 +225,7 @@ const SearchPageTable = (
     <div>
       {/* Show loading progress if data is still being loaded */}
       {loading && <LinearProgress color="secondary" />}
-      <AppBar position="static">
+      <AppBar position="static" elevation={0}>
         <StyledTabs
           className="tour-search-tab-select"
           value={currentTab}

--- a/packages/datagateway-search/src/searchPageTable.component.tsx
+++ b/packages/datagateway-search/src/searchPageTable.component.tsx
@@ -241,9 +241,19 @@ const SearchPageTable = (
               label={
                 <StyledBadge
                   id="investigation-badge"
-                  badgeContent={investigationDataCount ?? 0}
+                  badgeContent={
+                    <span
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {investigationDataCount ?? 0}
+                    </span>
+                  }
                   showZero
                   max={999}
+                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -254,6 +264,8 @@ const SearchPageTable = (
                       marginLeft: `calc(-0.5 * ${badgeDigits(
                         investigation?.length
                       )}ch - 6px)`,
+                      fontSize: '16px',
+                      fontWeight: 'bold',
                     }}
                   >
                     {t('tabs.investigation')}
@@ -271,9 +283,19 @@ const SearchPageTable = (
               label={
                 <StyledBadge
                   id="dataset-badge"
-                  badgeContent={datasetDataCount ?? 0}
+                  badgeContent={
+                    <span
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {datasetDataCount ?? 0}
+                    </span>
+                  }
                   showZero
                   max={999}
+                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -284,6 +306,8 @@ const SearchPageTable = (
                       marginLeft: `calc(-0.5 * ${badgeDigits(
                         dataset?.length
                       )}ch - 6px)`,
+                      fontSize: '16px',
+                      fontWeight: 'bold',
                     }}
                   >
                     {t('tabs.dataset')}
@@ -301,9 +325,19 @@ const SearchPageTable = (
               label={
                 <StyledBadge
                   id="datafile-badge"
-                  badgeContent={datafileDataCount ?? 0}
+                  badgeContent={
+                    <span
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {datafileDataCount ?? 0}
+                    </span>
+                  }
                   showZero
                   max={999}
+                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -314,6 +348,8 @@ const SearchPageTable = (
                       marginLeft: `calc(-0.5 * ${badgeDigits(
                         datafile?.length
                       )}ch - 6px)`,
+                      fontSize: '16px',
+                      fontWeight: 'bold',
                     }}
                   >
                     {t('tabs.datafile')}

--- a/packages/datagateway-search/src/searchPageTable.component.tsx
+++ b/packages/datagateway-search/src/searchPageTable.component.tsx
@@ -36,9 +36,10 @@ const badgeStyles = (theme: Theme): StyleRules =>
     badge: {
       backgroundColor: '#fff',
       color: '#000000',
-      fontSize: 'inherit',
+      fontSize: '14px',
+      fontWeight: 'bold',
       lineHeight: 'inherit',
-      top: '0.875em',
+      top: '1em',
     },
   });
 
@@ -249,7 +250,6 @@ const SearchPageTable = (
                   }
                   showZero
                   max={999}
-                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -279,20 +279,9 @@ const SearchPageTable = (
               label={
                 <StyledBadge
                   id="dataset-badge"
-                  badgeContent={
-                    <span
-                      style={{
-                        fontSize: '14px',
-                        fontWeight: 'bold',
-                        marginTop: '1px',
-                      }}
-                    >
-                      {datasetDataCount ?? 0}
-                    </span>
-                  }
+                  badgeContent={datasetDataCount ?? 0}
                   showZero
                   max={999}
-                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{
@@ -322,20 +311,9 @@ const SearchPageTable = (
               label={
                 <StyledBadge
                   id="datafile-badge"
-                  badgeContent={
-                    <span
-                      style={{
-                        fontSize: '14px',
-                        fontWeight: 'bold',
-                        marginTop: '1px',
-                      }}
-                    >
-                      {datafileDataCount ?? 0}
-                    </span>
-                  }
+                  badgeContent={datafileDataCount ?? 0}
                   showZero
                   max={999}
-                  style={{ marginTop: '1px' }}
                 >
                   <span
                     style={{

--- a/packages/datagateway-search/src/searchPageTable.component.tsx
+++ b/packages/datagateway-search/src/searchPageTable.component.tsx
@@ -48,6 +48,18 @@ const badgeStyles = (theme: Theme): StyleRules =>
 
 const tabStyles = (theme: Theme): StyleRules =>
   createStyles({
+    root: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      backgroundColor: (theme as any).colours?.tabsGrey,
+      //Fixes contrast issue for unselected tabs in darkmode
+      color:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (theme as any).palette.type === 'dark'
+          ? '#FFFFFF'
+          : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (theme as any).colours?.blue,
+      boxShadow: 'none',
+    },
     indicator: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       backgroundColor: (theme as any).colours?.blue,


### PR DESCRIPTION
## Description
- Changes the search box to match the redesign in #1066 
- Fixes wrong text colour being used in download no selections message

![image](https://user-images.githubusercontent.com/90245114/150106016-ee9f93f4-283c-425f-95f8-2de1ebe6a1c8.png)
![image](https://user-images.githubusercontent.com/90245114/150106309-1712809e-dc22-42bb-af47-d621e3e39fa2.png)

## Light mode:
![image](https://user-images.githubusercontent.com/90245114/150106239-38b20872-2b21-4ce1-b14e-895ec811b42e.png)
![image](https://user-images.githubusercontent.com/90245114/150106892-3b2fd878-971d-48a2-8d51-f67d2939a6db.png)
## Dark mode:
![image](https://user-images.githubusercontent.com/90245114/150106511-077bc6d6-e71d-4da3-bd96-7eddced53285.png)
## Dark high contrast mode:
![image](https://user-images.githubusercontent.com/90245114/150106572-2a64bad1-30e0-470e-bce3-f31ab2d0c367.png)


The search box also has a maximum size so that for higher resolutions it doesn't span the full width:
![image](https://user-images.githubusercontent.com/90245114/150334981-16434ee1-e407-4029-a271-59f36a72e3a2.png)


## Testing instructions
Requires https://github.com/ral-facilities/scigateway/pull/911.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1066
