### PR TITLE
Make AdminDownloadTable text filtering case insensitive and modify invalid date message (#1075)

### DIFF
--- a/packages/datagateway-common/src/table/columnFilters/__snapshots__/dateColumnFilter.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/columnFilters/__snapshots__/dateColumnFilter.component.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Date filter component renders correctly 1`] = `
           "aria-label": "test filter",
         }
       }
-      invalidDateMessage="Please enter the date in the format yyyy-MM-dd."
+      invalidDateMessage="Date format: yyyy-MM-dd."
       maxDate={2000-01-01T00:00:00.000Z}
       maxDateMessage="Invalid date range"
       minDate={1900-01-01T00:00:00.000Z}
@@ -118,7 +118,7 @@ exports[`Date filter component renders correctly 1`] = `
           "aria-label": "test filter",
         }
       }
-      invalidDateMessage="Please enter the date in the format yyyy-MM-dd."
+      invalidDateMessage="Date format: yyyy-MM-dd."
       maxDate={2100-01-01T00:00:00.000Z}
       maxDateMessage="Date should not be after maximal date"
       minDate={1999-01-01T00:00:00.000Z}
@@ -200,7 +200,7 @@ exports[`Date filter component useTextFilter hook returns a function which can g
           "aria-label": "Start Date filter",
         }
       }
-      invalidDateMessage="Please enter the date in the format yyyy-MM-dd."
+      invalidDateMessage="Date format: yyyy-MM-dd."
       maxDate={2100-01-01T00:00:00.000Z}
       maxDateMessage="Invalid date range"
       minDate={1900-01-01T00:00:00.000Z}
@@ -273,7 +273,7 @@ exports[`Date filter component useTextFilter hook returns a function which can g
           "aria-label": "Start Date filter",
         }
       }
-      invalidDateMessage="Please enter the date in the format yyyy-MM-dd."
+      invalidDateMessage="Date format: yyyy-MM-dd."
       maxDate={2100-01-01T00:00:00.000Z}
       maxDateMessage="Date should not be after maximal date"
       minDate={1984-01-01T00:00:00.000Z}

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.test.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.test.tsx
@@ -338,7 +338,7 @@ describe('Date filter component', () => {
 
     expect(wrapper.find('p.Mui-error')).toHaveLength(2);
     expect(wrapper.find('p.Mui-error').first().text()).toEqual(
-      'Please enter the date in the format yyyy-MM-dd.'
+      'Date format: yyyy-MM-dd.'
     );
   });
 

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -85,7 +85,7 @@ const DateColumnFilter = (props: {
           allowKeyboardControl
           style={{ whiteSpace: 'nowrap' }}
           inputProps={{ 'aria-label': `${props.label} filter` }}
-          invalidDateMessage="Please enter the date in the format yyyy-MM-dd."
+          invalidDateMessage="Date format: yyyy-MM-dd."
           KeyboardButtonProps={{
             size: 'small',
             'aria-label': `${props.label} filter from, date picker`,
@@ -118,7 +118,7 @@ const DateColumnFilter = (props: {
           allowKeyboardControl
           style={{ whiteSpace: 'nowrap' }}
           inputProps={{ 'aria-label': `${props.label} filter` }}
-          invalidDateMessage="Please enter the date in the format yyyy-MM-dd."
+          invalidDateMessage="Date format: yyyy-MM-dd."
           KeyboardButtonProps={{
             size: 'small',
             'aria-label': `${props.label} filter to, date picker`,

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -349,7 +349,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.userName) LIKE CONCAT('%', 'test user', '%') ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.userName) LIKE CONCAT('%', 'TEST USER', '%') ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
     );
     usernameFilterInput.instance().value = '';
     usernameFilterInput.simulate('change');

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -100,10 +100,16 @@ const AdminDownloadStatusTable: React.FC = () => {
           }
 
           if ('type' in filter && filter.type) {
+            // As UPPER is used need to pass text filters in upper case to avoid case sensitivity
+            const filterValue =
+              typeof filter.value === 'string'
+                ? (filter.value as string).toUpperCase()
+                : filter.value;
+
             if (filter.type === 'include') {
-              queryOffset += ` AND UPPER(download.${column}) LIKE CONCAT('%', '${filter.value}', '%')`;
+              queryOffset += ` AND UPPER(download.${column}) LIKE CONCAT('%', '${filterValue}', '%')`;
             } else {
-              queryOffset += ` AND UPPER(download.${column}) NOT LIKE CONCAT('%', '${filter.value}', '%')`;
+              queryOffset += ` AND UPPER(download.${column}) NOT LIKE CONCAT('%', '${filterValue}', '%')`;
             }
           }
         }


### PR DESCRIPTION
## Description
Makes the text filter values uppercase before sending to resolve https://github.com/ral-facilities/datagateway/issues/1075.

Also changes the invalid date message used in `dateColumnFilter` as it was not updated with the recent search box redesign and the old one overflowed in the admin download table.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1075
