### PR TITLE
Add no parameters message to datafile details panels (#1081)

### DIFF
--- a/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.test.tsx
@@ -139,7 +139,7 @@ describe('Visit details panel component', () => {
     expect(wrapper.find('VisitDetailsPanel').props()).toMatchSnapshot();
   });
 
-  it('renders publication tab and text "No Publications" when no data is prsent', () => {
+  it('renders publications tab and text "No publications" when no data is present', () => {
     rowData.publications = [];
     const wrapper = createWrapper();
     expect(
@@ -149,7 +149,7 @@ describe('Visit details panel component', () => {
     ).toBeTruthy();
   });
 
-  it('renders publication tab and text "No Samples" when no data is prsent', () => {
+  it('renders samples tab and text "No samples" when no data is present', () => {
     rowData.samples = [];
     const wrapper = createWrapper();
     expect(
@@ -157,7 +157,7 @@ describe('Visit details panel component', () => {
     ).toBeTruthy();
   });
 
-  it('renders publication tab and text "No Users" when no data is prsent', () => {
+  it('renders users tab and text "No users" when no data is present', () => {
     rowData.investigationUsers = [];
     const wrapper = createWrapper();
     expect(

--- a/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -223,7 +223,7 @@ const VisitDetailsPanel = (
               })
             ) : (
               <Typography data-testid="visit-details-panel-no-name">
-                {t('investigations.details.users.no_name')}
+                <b>{t('investigations.details.users.no_name')}</b>
               </Typography>
             )}
           </Grid>
@@ -254,7 +254,7 @@ const VisitDetailsPanel = (
               })
             ) : (
               <Typography data-testid="visit-details-panel-no-samples">
-                {t('investigations.details.samples.no_samples')}
+                <b>{t('investigations.details.samples.no_samples')}</b>
               </Typography>
             )}
           </Grid>
@@ -285,7 +285,9 @@ const VisitDetailsPanel = (
               })
             ) : (
               <Typography data-testid="visit-details-panel-no-publications">
-                {t('investigations.details.publications.no_publications')}
+                <b>
+                  {t('investigations.details.publications.no_publications')}
+                </b>
               </Typography>
             )}
           </Grid>

--- a/packages/datagateway-common/src/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/isis/datafileDetailsPanel.component.test.tsx
@@ -180,4 +180,14 @@ describe('Datafile details panel component', () => {
       '<b>datafiles.details.description not provided</b>'
     );
   });
+
+  it('renders datafile parameters tab and text "No parameters" when no data is present', () => {
+    rowData.parameters = [];
+    const wrapper = createWrapper();
+    expect(
+      wrapper
+        .find('[data-testid="datafile-details-panel-no-parameters"]')
+        .exists()
+    ).toBeTruthy();
+  });
 });

--- a/packages/datagateway-common/src/detailsPanels/isis/datafileDetailsPanel.component.tsx
+++ b/packages/datagateway-common/src/detailsPanels/isis/datafileDetailsPanel.component.tsx
@@ -127,52 +127,58 @@ const DatafileDetailsPanel = (
             className={classes.root}
             direction="column"
           >
-            {datafileData.parameters.map((parameter) => {
-              if (parameter.type) {
-                switch (parameter.type.valueType) {
-                  case 'STRING':
-                    return (
-                      <Grid key={parameter.id} item xs>
-                        <Typography variant="overline">
-                          {parameter.type.name}
-                        </Typography>
-                        <Typography>
-                          <b>{parameter.stringValue}</b>
-                        </Typography>
-                      </Grid>
-                    );
-                  case 'NUMERIC':
-                    return (
-                      <Grid key={parameter.id} item xs>
-                        <Typography variant="overline">
-                          {parameter.type.name}
-                        </Typography>
-                        <Typography>
-                          <b>{parameter.numericValue}</b>
-                        </Typography>
-                      </Grid>
-                    );
-                  case 'DATE_AND_TIME':
-                    return (
-                      <Grid key={parameter.id} item xs>
-                        <Typography variant="overline">
-                          {parameter.type.name}
-                        </Typography>
-                        <Typography>
-                          <b>
-                            {parameter.dateTimeValue &&
-                              parameter.dateTimeValue.split(' ')[0]}
-                          </b>
-                        </Typography>
-                      </Grid>
-                    );
-                  default:
-                    return null;
+            {datafileData.parameters.length > 0 ? (
+              datafileData.parameters.map((parameter) => {
+                if (parameter.type) {
+                  switch (parameter.type.valueType) {
+                    case 'STRING':
+                      return (
+                        <Grid key={parameter.id} item xs>
+                          <Typography variant="overline">
+                            {parameter.type.name}
+                          </Typography>
+                          <Typography>
+                            <b>{parameter.stringValue}</b>
+                          </Typography>
+                        </Grid>
+                      );
+                    case 'NUMERIC':
+                      return (
+                        <Grid key={parameter.id} item xs>
+                          <Typography variant="overline">
+                            {parameter.type.name}
+                          </Typography>
+                          <Typography>
+                            <b>{parameter.numericValue}</b>
+                          </Typography>
+                        </Grid>
+                      );
+                    case 'DATE_AND_TIME':
+                      return (
+                        <Grid key={parameter.id} item xs>
+                          <Typography variant="overline">
+                            {parameter.type.name}
+                          </Typography>
+                          <Typography>
+                            <b>
+                              {parameter.dateTimeValue &&
+                                parameter.dateTimeValue.split(' ')[0]}
+                            </b>
+                          </Typography>
+                        </Grid>
+                      );
+                    default:
+                      return null;
+                  }
+                } else {
+                  return null;
                 }
-              } else {
-                return null;
-              }
-            })}
+              })
+            ) : (
+              <Typography data-testid="datafile-details-panel-no-parameters">
+                <b>{t('datafiles.details.parameters.no_parameters')}</b>
+              </Typography>
+            )}
           </Grid>
         </div>
       )}

--- a/packages/datagateway-common/src/detailsPanels/isis/instrumentDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/isis/instrumentDetailsPanel.component.test.tsx
@@ -139,7 +139,7 @@ describe('Instrument details panel component', () => {
     expect(wrapper.find('InstrumentDetailsPanel').props()).toMatchSnapshot();
   });
 
-  it('renders publication tab and text "No Scientists" when no data is prsent', () => {
+  it('renders users tab and text "No Scientists" when no data is present', () => {
     rowData.instrumentScientists = [];
     const wrapper = createWrapper();
     expect(

--- a/packages/datagateway-common/src/detailsPanels/isis/instrumentDetailsPanel.component.tsx
+++ b/packages/datagateway-common/src/detailsPanels/isis/instrumentDetailsPanel.component.tsx
@@ -155,7 +155,7 @@ const InstrumentDetailsPanel = (
               })
             ) : (
               <Typography data-testid="instrument-details-panel-no-name">
-                {t('instruments.details.instrument_scientists.no_name')}
+                <b>{t('instruments.details.instrument_scientists.no_name')}</b>
               </Typography>
             )}
           </Grid>

--- a/packages/datagateway-common/src/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
@@ -143,7 +143,7 @@ describe('Investigation details panel component', () => {
     expect(wrapper.find('InvestigationDetailsPanel').props()).toMatchSnapshot();
   });
 
-  it('renders publication tab and text "No Publications" when no data is prsent', () => {
+  it('renders publications tab and text "No publications" when no data is present', () => {
     rowData.publications = [];
     const wrapper = createWrapper();
     expect(
@@ -153,7 +153,7 @@ describe('Investigation details panel component', () => {
     ).toBeTruthy();
   });
 
-  it('renders publication tab and text "No Samples" when no data is prsent', () => {
+  it('renders samples tab and text "No samples" when no data is present', () => {
     rowData.samples = [];
     const wrapper = createWrapper();
     expect(
@@ -163,7 +163,7 @@ describe('Investigation details panel component', () => {
     ).toBeTruthy();
   });
 
-  it('renders publication tab and text "No Users" when no data is prsent', () => {
+  it('renders users tab and text "No users" when no data is present', () => {
     rowData.investigationUsers = [];
     const wrapper = createWrapper();
     expect(

--- a/packages/datagateway-common/src/detailsPanels/isis/investigationDetailsPanel.component.tsx
+++ b/packages/datagateway-common/src/detailsPanels/isis/investigationDetailsPanel.component.tsx
@@ -241,7 +241,7 @@ const InvestigationDetailsPanel = (
               })
             ) : (
               <Typography data-testid="investigation-details-panel-no-name">
-                {t('investigations.details.users.no_name')}
+                <b>{t('investigations.details.users.no_name')}</b>
               </Typography>
             )}
           </Grid>
@@ -272,7 +272,7 @@ const InvestigationDetailsPanel = (
               })
             ) : (
               <Typography data-testid="investigation-details-panel-no-samples">
-                {t('investigations.details.samples.no_samples')}
+                <b>{t('investigations.details.samples.no_samples')}</b>
               </Typography>
             )}
           </Grid>
@@ -303,7 +303,9 @@ const InvestigationDetailsPanel = (
               })
             ) : (
               <Typography data-testid="investigation-details-panel-no-publications">
-                {t('investigations.details.publications.no_publications')}
+                <b>
+                  {t('investigations.details.publications.no_publications')}
+                </b>
               </Typography>
             )}
           </Grid>

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -38,7 +38,7 @@
         "label": "Instrument Scientists",
         "name": "Name",
         "name_plural": "Names",
-        "no_name": "No Scientists"
+        "no_name": "No scientists"
       }
     }
   },
@@ -117,13 +117,13 @@
         "label": "Investigation Users",
         "name": "Name",
         "name_plural": "Names",
-        "no_name": "No Users"
+        "no_name": "No users"
       },
       "samples": {
         "label": "Investigation Samples",
         "name": "Sample",
         "name_plural": "Samples",
-        "no_samples": "No Samples"
+        "no_samples": "No samples"
       },
       "publications": {
         "label": "Publications",
@@ -190,7 +190,8 @@
       "size": "Size",
       "location": "Location",
       "parameters": {
-        "label": "Datafile Parameters"
+        "label": "Datafile Parameters",
+        "no_parameters": "No parameters"
       }
     }
   },

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -74,13 +74,13 @@
         "label": "Investigation Users",
         "name": "Name",
         "name_plural": "Names",
-        "no_name": "No Users"
+        "no_name": "No users"
       },
       "samples": {
         "label": "Investigation Samples",
         "name": "Sample",
         "name_plural": "Samples",
-        "no_samples": "No Samples"
+        "no_samples": "No samples"
       },
       "publications": {
         "label": "Publications",
@@ -139,7 +139,8 @@
       "size": "Size",
       "location": "Location",
       "parameters": {
-        "label": "Datafile Parameters"
+        "label": "Datafile Parameters",
+        "no_parameters": "No parameters"
       }
     }
   },


### PR DESCRIPTION
## Description
Adds a message displayed when datafile details panels don't have anything to display under 'Datafile Parameters'.
![image](https://user-images.githubusercontent.com/90245114/150941999-c5285d73-9c7b-4465-93c9-78fd6ac85357.png)
(found here /browse/instrument/25/facilityCycle/54/investigation/24080890/dataset/24079960/datafile?view=card&sort=%7B%22modTime%22%3A%22desc%22%7D)

Also modifies some of the existing messages to make them all look the same, using bold text for the messages e.g.
![image](https://user-images.githubusercontent.com/90245114/150942286-2be93867-7446-478d-a32b-4ec7ebcf1d94.png)
so that it matches the filled details panels like
![image](https://user-images.githubusercontent.com/90245114/150942345-2ac8ded6-1f50-44ae-8af0-c590c598a56b.png)


## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1081 