### PR TITLE
Sort DLS proposal views by title rather than ID #1084

### DIFF
--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -282,6 +282,39 @@ describe('generic api functions', () => {
         params.toString()
       );
     });
+
+    it('parses all filter types to api params successfully when ignoreIDSort is true', () => {
+      const sortAndFilters: { sort: SortType; filters: FiltersType } = {
+        filters: {
+          name: { value: 'test', type: 'include' },
+          title: { value: 'test', type: 'exclude' },
+          startDate: {
+            startDate: '2021-08-05',
+            endDate: '2021-08-06',
+          },
+          type: ['1', '2', '3'],
+        },
+        sort: { name: 'asc' },
+      };
+
+      const params = new URLSearchParams();
+      params.append('order', JSON.stringify('name asc'));
+      params.append('where', JSON.stringify({ name: { ilike: 'test' } }));
+      params.append('where', JSON.stringify({ title: { nilike: 'test' } }));
+      params.append(
+        'where',
+        JSON.stringify({ startDate: { gte: '2021-08-05 00:00:00' } })
+      );
+      params.append(
+        'where',
+        JSON.stringify({ startDate: { lte: '2021-08-06 23:59:59' } })
+      );
+      params.append('where', JSON.stringify({ type: { in: ['1', '2', '3'] } }));
+
+      expect(getApiParams(sortAndFilters, true).toString()).toEqual(
+        params.toString()
+      );
+    });
   });
 
   describe('push functions', () => {

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -186,10 +186,13 @@ export const parseQueryToSearch = (query: QueryParams): URLSearchParams => {
 /**
  * Convert Sort and Filter types to datagateway-api compatible URLSearchParams
  */
-export const getApiParams = (props: {
-  sort: SortType;
-  filters: FiltersType;
-}): URLSearchParams => {
+export const getApiParams = (
+  props: {
+    sort: SortType;
+    filters: FiltersType;
+  },
+  ignoreIDSort?: boolean
+): URLSearchParams => {
   const { sort, filters } = props;
   const searchParams = new URLSearchParams();
 
@@ -197,8 +200,9 @@ export const getApiParams = (props: {
     searchParams.append('order', JSON.stringify(`${key} ${value}`));
   }
 
-  // sort by ID first to guarantee order
-  searchParams.append('order', JSON.stringify(`id asc`));
+  if (!ignoreIDSort)
+    // sort by ID first to guarantee order
+    searchParams.append('order', JSON.stringify(`id asc`));
 
   for (const [column, filter] of Object.entries(filters)) {
     if (typeof filter === 'object') {

--- a/packages/datagateway-common/src/api/investigations.test.tsx
+++ b/packages/datagateway-common/src/api/investigations.test.tsx
@@ -181,6 +181,59 @@ describe('investigation api functions', () => {
       expect(result.current.data).toEqual(mockData);
     });
 
+    it('sends axios request to fetch paginated investigations and returns successful response when ignoreIDSort is true', async () => {
+      (axios.get as jest.Mock).mockResolvedValue({
+        data: mockData,
+      });
+
+      const { result, waitFor } = renderHook(
+        () =>
+          useInvestigationsPaginated(
+            [
+              {
+                filterType: 'include',
+                filterValue: JSON.stringify({
+                  investigationInstruments: 'instrument',
+                }),
+              },
+            ],
+            true
+          ),
+        {
+          wrapper: createReactQueryWrapper(history),
+        }
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      params.append('order', JSON.stringify('name asc'));
+      params.append(
+        'where',
+        JSON.stringify({
+          name: { ilike: 'test' },
+        })
+      );
+      params.append('skip', JSON.stringify(20));
+      params.append('limit', JSON.stringify(20));
+      params.append(
+        'include',
+        JSON.stringify({
+          investigationInstruments: 'instrument',
+        })
+      );
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://example.com/api/investigations',
+        expect.objectContaining({
+          params,
+        })
+      );
+      expect((axios.get as jest.Mock).mock.calls[0][1].params.toString()).toBe(
+        params.toString()
+      );
+      expect(result.current.data).toEqual(mockData);
+    });
+
     it('sends axios request to fetch paginated investigations and calls handleICATError on failure', async () => {
       (axios.get as jest.Mock).mockRejectedValue({
         message: 'Test error',
@@ -238,6 +291,87 @@ describe('investigation api functions', () => {
 
       params.append('order', JSON.stringify('name asc'));
       params.append('order', JSON.stringify('id asc'));
+      params.append(
+        'where',
+        JSON.stringify({
+          name: { ilike: 'test' },
+        })
+      );
+      params.append('skip', JSON.stringify(0));
+      params.append('limit', JSON.stringify(50));
+      params.append(
+        'include',
+        JSON.stringify({
+          investigationInstruments: 'instrument',
+        })
+      );
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://example.com/api/investigations',
+        expect.objectContaining({
+          params,
+        })
+      );
+      expect((axios.get as jest.Mock).mock.calls[0][1].params.toString()).toBe(
+        params.toString()
+      );
+      expect(result.current.data.pages).toStrictEqual([mockData[0]]);
+
+      result.current.fetchNextPage({
+        pageParam: { startIndex: 50, stopIndex: 74 },
+      });
+
+      await waitFor(() => result.current.isFetching);
+
+      await waitFor(() => !result.current.isFetching);
+
+      expect(axios.get).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/api/investigations',
+        expect.objectContaining({
+          params,
+        })
+      );
+      params.set('skip', JSON.stringify(50));
+      params.set('limit', JSON.stringify(25));
+      expect((axios.get as jest.Mock).mock.calls[1][1].params.toString()).toBe(
+        params.toString()
+      );
+
+      expect(result.current.data.pages).toStrictEqual([
+        mockData[0],
+        mockData[1],
+      ]);
+    });
+
+    it('sends axios request to fetch infinite investigations and returns successful response when ignoreIDSort is true', async () => {
+      (axios.get as jest.Mock).mockImplementation((url, options) =>
+        options.params.get('skip') === '0'
+          ? Promise.resolve({ data: mockData[0] })
+          : Promise.resolve({ data: mockData[1] })
+      );
+
+      const { result, waitFor } = renderHook(
+        () =>
+          useInvestigationsInfinite(
+            [
+              {
+                filterType: 'include',
+                filterValue: JSON.stringify({
+                  investigationInstruments: 'instrument',
+                }),
+              },
+            ],
+            true
+          ),
+        {
+          wrapper: createReactQueryWrapper(history),
+        }
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      params.append('order', JSON.stringify('name asc'));
       params.append(
         'where',
         JSON.stringify({

--- a/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/card/dls/proposals.spec.ts
@@ -22,11 +22,11 @@ describe('DLS - Proposals Cards', () => {
   it('should be able to click an investigation to see its datasets', () => {
     cy.get('[data-testid="card"]')
       .first()
-      .contains('Including spend increase ability music skill former.')
+      .contains('About quickly both stop.')
       .click({ force: true });
     cy.location('pathname').should(
       'eq',
-      '/browse/proposal/INVESTIGATION%201/investigation'
+      '/browse/proposal/INVESTIGATION%2030/investigation'
     );
   });
 
@@ -72,7 +72,7 @@ describe('DLS - Proposals Cards', () => {
         .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
           timeout: 10000,
         });
-      cy.get('[data-testid="card"]').first().contains('INVESTIGATION 192');
+      cy.get('[data-testid="card"]').first().contains('INVESTIGATION 217');
     });
   });
 });

--- a/packages/datagateway-dataview/cypress/integration/table/dls/proposals.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/proposals.spec.ts
@@ -16,7 +16,7 @@ describe('DLS - Proposals Table', () => {
 
     cy.location('pathname').should(
       'eq',
-      '/browse/proposal/INVESTIGATION%201/investigation'
+      '/browse/proposal/INVESTIGATION%2030/investigation'
     );
   });
 

--- a/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsProposalsCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/dls/__snapshots__/dlsProposalsCardView.component.test.tsx.snap
@@ -25,10 +25,13 @@ Object {
   "onSort": [Function],
   "page": null,
   "results": null,
-  "sort": Object {},
+  "sort": Object {
+    "title": "asc",
+  },
   "title": Object {
     "content": [Function],
     "dataKey": "title",
+    "defaultSort": "asc",
     "disableSort": true,
     "filterComponent": [Function],
     "label": "investigations.title",

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
@@ -101,12 +101,15 @@ describe('DLS Proposals - Card View', () => {
         filterValue: JSON.stringify(['name', 'title']),
       },
     ]);
-    expect(useInvestigationsPaginated).toHaveBeenCalledWith([
-      {
-        filterType: 'distinct',
-        filterValue: JSON.stringify(['name', 'title']),
-      },
-    ]);
+    expect(useInvestigationsPaginated).toHaveBeenCalledWith(
+      [
+        {
+          filterType: 'distinct',
+          filterValue: JSON.stringify(['name', 'title']),
+        },
+      ],
+      true
+    );
   });
 
   it('updates filter query params on text filter', () => {
@@ -131,6 +134,16 @@ describe('DLS Proposals - Card View', () => {
       .simulate('change', { target: { value: '' } });
 
     expect(history.location.search).toBe('?');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"title":"asc"}')}`
+    );
   });
 
   it('renders fine with incomplete data', () => {

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
@@ -40,12 +40,17 @@ const DLSProposalsCardView = (): React.ReactElement => {
       filterValue: JSON.stringify(['name', 'title']),
     },
   ]);
-  const { isLoading: dataLoading, data } = useInvestigationsPaginated([
-    {
-      filterType: 'distinct',
-      filterValue: JSON.stringify(['name', 'title']),
-    },
-  ]);
+  const { isLoading: dataLoading, data } = useInvestigationsPaginated(
+    [
+      {
+        filterType: 'distinct',
+        filterValue: JSON.stringify(['name', 'title']),
+      },
+    ],
+    //Do not add order by id as id is not a distinct field above and will otherwise
+    //cause missing results
+    true
+  );
 
   const title: CardViewDetails = React.useMemo(
     () => ({
@@ -59,6 +64,9 @@ const DLSProposalsCardView = (): React.ReactElement => {
           'dls-proposal-card-title'
         ),
       filterComponent: textFilter,
+      //Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
+      //used above in useInvestigationsPaginated)
+      defaultSort: 'asc',
       disableSort: true,
     }),
     [t, textFilter, view]

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
@@ -47,8 +47,8 @@ const DLSProposalsCardView = (): React.ReactElement => {
         filterValue: JSON.stringify(['name', 'title']),
       },
     ],
-    //Do not add order by id as id is not a distinct field above and will otherwise
-    //cause missing results
+    // Do not add order by id as id is not a distinct field above and will otherwise
+    // cause missing results
     true
   );
 
@@ -64,8 +64,8 @@ const DLSProposalsCardView = (): React.ReactElement => {
           'dls-proposal-card-title'
         ),
       filterComponent: textFilter,
-      //Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
-      //used above in useInvestigationsPaginated)
+      // Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
+      // used above in useInvestigationsPaginated)
       defaultSort: 'asc',
       disableSort: true,
     }),

--- a/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsProposalsTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/dls/__snapshots__/dlsProposalsTable.component.test.tsx.snap
@@ -16,6 +16,7 @@ Object {
     Object {
       "cellContentRenderer": [Function],
       "dataKey": "title",
+      "defaultSort": "asc",
       "disableSort": true,
       "filterComponent": [Function],
       "icon": Object {
@@ -68,7 +69,9 @@ Object {
   ],
   "loadMoreRows": [Function],
   "onSort": [Function],
-  "sort": Object {},
+  "sort": Object {
+    "title": "asc",
+  },
   "totalRowCount": 1,
 }
 `;

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
@@ -110,12 +110,15 @@ describe('DLS Proposals table component', () => {
         filterValue: JSON.stringify(['name', 'title']),
       },
     ]);
-    expect(useInvestigationsInfinite).toHaveBeenCalledWith([
-      {
-        filterType: 'distinct',
-        filterValue: JSON.stringify(['name', 'title']),
-      },
-    ]);
+    expect(useInvestigationsInfinite).toHaveBeenCalledWith(
+      [
+        {
+          filterType: 'distinct',
+          filterValue: JSON.stringify(['name', 'title']),
+        },
+      ],
+      true
+    );
   });
 
   it('calls useInvestigationsInfinite when loadMoreRows is called', () => {
@@ -155,6 +158,16 @@ describe('DLS Proposals table component', () => {
 
     expect(history.length).toBe(3);
     expect(history.location.search).toBe('?');
+  });
+
+  it('uses default sort', () => {
+    const wrapper = createWrapper();
+    wrapper.update();
+
+    expect(history.length).toBe(1);
+    expect(history.location.search).toBe(
+      `?sort=${encodeURIComponent('{"title":"asc"}')}`
+    );
   });
 
   it('renders title and name as links', () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -30,12 +30,17 @@ const DLSProposalsTable = (): React.ReactElement => {
       filterValue: JSON.stringify(['name', 'title']),
     },
   ]);
-  const { fetchNextPage, data } = useInvestigationsInfinite([
-    {
-      filterType: 'distinct',
-      filterValue: JSON.stringify(['name', 'title']),
-    },
-  ]);
+  const { fetchNextPage, data } = useInvestigationsInfinite(
+    [
+      {
+        filterType: 'distinct',
+        filterValue: JSON.stringify(['name', 'title']),
+      },
+    ],
+    //Do not add order by id as id is not a distinct field above and will otherwise
+    //cause missing results
+    true
+  );
 
   const aggregatedData: Investigation[] = React.useMemo(
     () => (data ? ('pages' in data ? data.pages.flat() : data) : []),
@@ -66,6 +71,9 @@ const DLSProposalsTable = (): React.ReactElement => {
           );
         },
         filterComponent: textFilter,
+        //Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
+        //used above in useInvestigationsInfinite)
+        defaultSort: 'asc',
         disableSort: true,
       },
       {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -37,8 +37,8 @@ const DLSProposalsTable = (): React.ReactElement => {
         filterValue: JSON.stringify(['name', 'title']),
       },
     ],
-    //Do not add order by id as id is not a distinct field above and will otherwise
-    //cause missing results
+    // Do not add order by id as id is not a distinct field above and will otherwise
+    // cause missing results
     true
   );
 
@@ -71,8 +71,8 @@ const DLSProposalsTable = (): React.ReactElement => {
           );
         },
         filterComponent: textFilter,
-        //Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
-        //used above in useInvestigationsInfinite)
+        // Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
+        // used above in useInvestigationsInfinite)
         defaultSort: 'asc',
         disableSort: true,
       },

--- a/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageCardView.component.test.tsx.snap
@@ -1561,7 +1561,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -1580,6 +1580,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "currentResultState": Object {
@@ -1604,7 +1605,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -1623,6 +1624,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "previousQueryResult": undefined,
@@ -1639,7 +1641,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                     "queryKey": Array [
                       "investigation",
                       Object {
@@ -1658,10 +1660,11 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                           "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                         },
                       ],
+                      undefined,
                     ],
                   },
                   "promise": Promise {},
-                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                   "queryKey": Array [
                     "investigation",
                     Object {
@@ -1680,6 +1683,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                       },
                     ],
+                    undefined,
                   ],
                   "retryer": Retryer {
                     "cancel": [Function],
@@ -2552,7 +2556,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "status": "idle",
                   },
                 },
-                "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]": Query {
+                "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -2616,7 +2620,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -2635,6 +2639,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "currentResultState": Object {
@@ -2659,7 +2664,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -2678,6 +2683,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "previousQueryResult": undefined,
@@ -2694,7 +2700,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                     "queryKey": Array [
                       "investigation",
                       Object {
@@ -2713,10 +2719,11 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                           "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                         },
                       ],
+                      undefined,
                     ],
                   },
                   "promise": Promise {},
-                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"page\\":1,\\"results\\":10,\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                   "queryKey": Array [
                     "investigation",
                     Object {
@@ -2735,6 +2742,7 @@ exports[`SearchPageCardView renders correctly when request received 1`] = `
                         "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                       },
                     ],
+                    undefined,
                   ],
                   "retryer": Retryer {
                     "cancel": [Function],

--- a/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchPageTable.component.test.tsx.snap
@@ -1570,7 +1570,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -1587,6 +1587,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "currentResultState": Object {
@@ -1616,7 +1617,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -1633,6 +1634,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "previousQueryResult": undefined,
@@ -1652,7 +1654,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                     "queryKey": Array [
                       "investigation",
                       Object {
@@ -1669,10 +1671,11 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                           "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                         },
                       ],
+                      undefined,
                     ],
                   },
                   "promise": Promise {},
-                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                   "queryKey": Array [
                     "investigation",
                     Object {
@@ -1689,6 +1692,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                       },
                     ],
+                    undefined,
                   ],
                   "retryer": Retryer {
                     "cancel": [Function],
@@ -3023,7 +3027,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "status": "idle",
                   },
                 },
-                "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]": Query {
+                "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]": Query {
                   "cache": [Circular],
                   "cacheTime": 300000,
                   "defaultOptions": undefined,
@@ -3096,7 +3100,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -3113,6 +3117,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "currentResultState": Object {
@@ -3142,7 +3147,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "onError": [Function],
                         "optimisticResults": true,
                         "queryFn": [Function],
-                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                        "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                         "queryKey": Array [
                           "investigation",
                           Object {
@@ -3159,6 +3164,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                               "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                             },
                           ],
+                          undefined,
                         ],
                       },
                       "previousQueryResult": undefined,
@@ -3178,7 +3184,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                     "onError": [Function],
                     "optimisticResults": true,
                     "queryFn": [Function],
-                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                    "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                     "queryKey": Array [
                       "investigation",
                       Object {
@@ -3195,10 +3201,11 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                           "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                         },
                       ],
+                      undefined,
                     ],
                   },
                   "promise": Promise {},
-                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}]]",
+                  "queryHash": "[\\"investigation\\",{\\"filters\\":{},\\"sort\\":{}},[{\\"filterType\\":\\"where\\",\\"filterValue\\":\\"{\\\\\\"id\\\\\\":{\\\\\\"in\\\\\\":[]}}\\"},{\\"filterType\\":\\"include\\",\\"filterValue\\":\\"{\\\\\\"investigationInstruments\\\\\\":\\\\\\"instrument\\\\\\"}\\"}],null]",
                   "queryKey": Array [
                     "investigation",
                     Object {
@@ -3215,6 +3222,7 @@ exports[`SearchPageTable renders correctly when request received 1`] = `
                         "filterValue": "{\\"investigationInstruments\\":\\"instrument\\"}",
                       },
                     ],
+                    undefined,
                   ],
                   "retryer": Retryer {
                     "cancel": [Function],


### PR DESCRIPTION
## Description
This removes the default sorting by ID and replaces it with a default sort on titles for DLS proposal views as in https://github.com/ral-facilities/datagateway/issues/1084.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1084
