### PR TITLE
Bugfix/display no publications in investigation landing #1053

### DIFF
--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -129,7 +129,7 @@
         "label": "Publications",
         "reference": "Reference",
         "reference_plural": "References",
-        "no_publications": "No publications"
+        "no_publications": "No Publications"
       },
       "type": {
         "id": "Type ID"

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -117,19 +117,19 @@
         "label": "Investigation Users",
         "name": "Name",
         "name_plural": "Names",
-        "no_name": "No Users"
+        "no_name": "No users"
       },
       "samples": {
         "label": "Investigation Samples",
         "name": "Sample",
         "name_plural": "Samples",
-        "no_samples": "No Samples"
+        "no_samples": "No samples"
       },
       "publications": {
         "label": "Publications",
         "reference": "Reference",
         "reference_plural": "References",
-        "no_publications": "No Publications"
+        "no_publications": "No publications"
       },
       "type": {
         "id": "Type ID"

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
@@ -164,7 +164,6 @@ describe('ISIS Investigation Landing page', () => {
       fullReference: 'Journal, Author, Date, DOI',
     },
   ];
-  const noUsers: never[] = [];
   const noSamples: never[] = [];
   const noPublication: never[] = [];
 
@@ -272,20 +271,6 @@ describe('ISIS Investigation Landing page', () => {
     expect(
       wrapper.find('[aria-label="landing-investigation-user-3"]')
     ).toHaveLength(0);
-  });
-
-  it('renders text "No users" when no data is present', () => {
-    let wrapper = createWrapper();
-    (useInvestigation as jest.Mock).mockReturnValue({
-      data: [{ ...initialData[0], investigationUsers: noUsers }],
-    });
-    wrapper = createWrapper();
-
-    expect(
-      wrapper
-        .find('[data-testid="investigation-details-panel-no-name"]')
-        .exists()
-    ).toBeTruthy();
   });
 
   it('renders text "No samples" when no data is present', () => {

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
@@ -164,6 +164,9 @@ describe('ISIS Investigation Landing page', () => {
       fullReference: 'Journal, Author, Date, DOI',
     },
   ];
+  const noUsers: never[] = [];
+  const noSamples: never[] = [];
+  const noPublication: never[] = [];
 
   beforeEach(() => {
     mount = createMount();
@@ -269,6 +272,48 @@ describe('ISIS Investigation Landing page', () => {
     expect(
       wrapper.find('[aria-label="landing-investigation-user-3"]')
     ).toHaveLength(0);
+  });
+
+  it('renders text "No users" when no data is present', () => {
+    let wrapper = createWrapper();
+    (useInvestigation as jest.Mock).mockReturnValue({
+      data: [{ ...initialData[0], investigationUsers: noUsers }],
+    });
+    wrapper = createWrapper();
+
+    expect(
+      wrapper
+        .find('[data-testid="investigation-details-panel-no-name"]')
+        .exists()
+    ).toBeTruthy();
+  });
+
+  it('renders text "No samples" when no data is present', () => {
+    let wrapper = createWrapper();
+    (useInvestigation as jest.Mock).mockReturnValue({
+      data: [{ ...initialData[0], samples: noSamples }],
+    });
+    wrapper = createWrapper();
+
+    expect(
+      wrapper
+        .find('[data-testid="investigation-details-panel-no-samples"]')
+        .exists()
+    ).toBeTruthy();
+  });
+
+  it('renders text "No publications" when no data is present', () => {
+    let wrapper = createWrapper();
+    (useInvestigation as jest.Mock).mockReturnValue({
+      data: [{ ...initialData[0], publications: noPublication }],
+    });
+    wrapper = createWrapper();
+
+    expect(
+      wrapper
+        .find('[data-testid="investigation-details-panel-no-publications"]')
+        .exists()
+    ).toBeTruthy();
   });
 
   it('publications displayed correctly', () => {

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -425,6 +425,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.publications.label')}
                 </Typography>
+                {formattedPublications.length > 0 ? '' : 'No Publications'}
                 {formattedPublications.map((reference, i) => (
                   <Typography
                     aria-label={`landing-investigation-reference-${i}`}

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -365,7 +365,13 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.users.label')}
                 </Typography>
-                {formattedUsers.length > 0 ? '' : 'No Users'}
+                {formattedUsers.length > 0 ? (
+                  ''
+                ) : (
+                  <Typography data-testid="investigation-details-panel-no-name">
+                    <b>{t('investigations.details.users.no_name')}</b>
+                  </Typography>
+                )}
                 {formattedUsers.map((user, i) => (
                   <Typography
                     aria-label={`landing-investigation-user-${i}`}
@@ -405,7 +411,13 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.samples.label')}
                 </Typography>
-                {formattedSamples.length > 0 ? '' : 'No Samples'}
+                {formattedSamples.length > 0 ? (
+                  ''
+                ) : (
+                  <Typography data-testid="investigation-details-panel-no-samples">
+                    <b>{t('investigations.details.samples.no_samples')}</b>
+                  </Typography>
+                )}
                 {formattedSamples.map((name, i) => (
                   <Typography
                     aria-label={`landing-investigation-sample-${i}`}
@@ -427,7 +439,15 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.publications.label')}
                 </Typography>
-                {formattedPublications.length > 0 ? '' : 'No Publications'}
+                {formattedPublications.length > 0 ? (
+                  ''
+                ) : (
+                  <Typography data-testid="investigation-details-panel-no-publications">
+                    <b>
+                      {t('investigations.details.publications.no_publications')}
+                    </b>
+                  </Typography>
+                )}
                 {formattedPublications.map((reference, i) => (
                   <Typography
                     aria-label={`landing-investigation-reference-${i}`}

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -369,7 +369,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                   ''
                 ) : (
                   <Typography data-testid="investigation-details-panel-no-name">
-                    <b>{t('investigations.details.users.no_name')}</b>
+                    {t('investigations.details.users.no_name')}
                   </Typography>
                 )}
                 {formattedUsers.map((user, i) => (
@@ -415,7 +415,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                   ''
                 ) : (
                   <Typography data-testid="investigation-details-panel-no-samples">
-                    <b>{t('investigations.details.samples.no_samples')}</b>
+                    {t('investigations.details.samples.no_samples')}
                   </Typography>
                 )}
                 {formattedSamples.map((name, i) => (
@@ -443,9 +443,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                   ''
                 ) : (
                   <Typography data-testid="investigation-details-panel-no-publications">
-                    <b>
-                      {t('investigations.details.publications.no_publications')}
-                    </b>
+                    {t('investigations.details.publications.no_publications')}
                   </Typography>
                 )}
                 {formattedPublications.map((reference, i) => (

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -365,6 +365,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.users.label')}
                 </Typography>
+                {formattedUsers.length > 0 ? '' : 'No Users'}
                 {formattedUsers.map((user, i) => (
                   <Typography
                     aria-label={`landing-investigation-user-${i}`}
@@ -404,6 +405,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.samples.label')}
                 </Typography>
+                {formattedSamples.length > 0 ? '' : 'No Samples'}
                 {formattedSamples.map((name, i) => (
                   <Typography
                     aria-label={`landing-investigation-sample-${i}`}

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -354,14 +354,6 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 ? data[0].summary
                 : 'Description not provided'}
             </Typography>
-            {formattedUsers.length > 0 ? (
-              ''
-            ) : (
-              <Typography data-testid="investigation-details-panel-no-name">
-                {t('investigations.details.users.no_name')}
-              </Typography>
-            )}
-
             {formattedUsers.length > 0 && (
               <div>
                 <Typography
@@ -411,9 +403,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.samples.label')}
                 </Typography>
-                {formattedSamples.length > 0 ? (
-                  ''
-                ) : (
+                {formattedSamples.length === 0 && (
                   <Typography data-testid="investigation-details-panel-no-samples">
                     {t('investigations.details.samples.no_samples')}
                   </Typography>
@@ -439,9 +429,7 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.publications.label')}
                 </Typography>
-                {formattedPublications.length > 0 ? (
-                  ''
-                ) : (
+                {formattedPublications.length === 0 && (
                   <Typography data-testid="investigation-details-panel-no-publications">
                     {t('investigations.details.publications.no_publications')}
                   </Typography>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -354,6 +354,13 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 ? data[0].summary
                 : 'Description not provided'}
             </Typography>
+            {formattedUsers.length > 0 ? (
+              ''
+            ) : (
+              <Typography data-testid="investigation-details-panel-no-name">
+                {t('investigations.details.users.no_name')}
+              </Typography>
+            )}
 
             {formattedUsers.length > 0 && (
               <div>
@@ -365,13 +372,6 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 >
                   {t('investigations.details.users.label')}
                 </Typography>
-                {formattedUsers.length > 0 ? (
-                  ''
-                ) : (
-                  <Typography data-testid="investigation-details-panel-no-name">
-                    {t('investigations.details.users.no_name')}
-                  </Typography>
-                )}
                 {formattedUsers.map((user, i) => (
                   <Typography
                     aria-label={`landing-investigation-user-${i}`}

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -86,7 +86,7 @@
         "label": "Publications",
         "reference": "Reference",
         "reference_plural": "References",
-        "no_publications": "No publications"
+        "no_publications": "No Publications"
       },
       "type": {
         "id": "Type ID"

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -74,19 +74,19 @@
         "label": "Investigation Users",
         "name": "Name",
         "name_plural": "Names",
-        "no_name": "No Users"
+        "no_name": "No users"
       },
       "samples": {
         "label": "Investigation Samples",
         "name": "Sample",
         "name_plural": "Samples",
-        "no_samples": "No Samples"
+        "no_samples": "No samples"
       },
       "publications": {
         "label": "Publications",
         "reference": "Reference",
         "reference_plural": "References",
-        "no_publications": "No Publications"
+        "no_publications": "No publications"
       },
       "type": {
         "id": "Type ID"


### PR DESCRIPTION
## Description
Added fixes so that the message 'No Publications' is shown when no publications are there for the investigation. Added this fix for samples and users too.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1053 
