### PR TITLE
#927 - Fix incorrect counts (take 2)

### DIFF
--- a/packages/datagateway-common/src/api/datasets.tsx
+++ b/packages/datagateway-common/src/api/datasets.tsx
@@ -270,9 +270,10 @@ export const useDatasetSizes = (
   const countAppliedRef = React.useRef(0);
 
   // when data changes (i.e. due to sorting or filtering) set the countAppliedRef
-  // back to 0 so we can restart the process
+  // back to 0 so we can restart the process, as well as clear sizes
   React.useEffect(() => {
     countAppliedRef.current = 0;
+    setSizes([]);
   }, [data]);
 
   // need to use useDeepCompareEffect here because the array returned by useQueries
@@ -291,7 +292,7 @@ export const useDatasetSizes = (
       setSizes(queries);
       countAppliedRef.current = currCountReturned;
     }
-  }, [queries]);
+  }, [sizes, queries]);
 
   return sizes;
 };
@@ -342,16 +343,17 @@ export const useDatasetsDatafileCount = (
   // prettier-ignore
   const queries: UseQueryResult<number, AxiosError>[] = useQueries(queryConfigs);
 
-  const [datasetCounts, setDatasetCounts] = React.useState<
+  const [datafileCounts, setDatafileCounts] = React.useState<
     UseQueryResult<number, AxiosError>[]
   >([]);
 
   const countAppliedRef = React.useRef(0);
 
   // when data changes (i.e. due to sorting or filtering) set the countAppliedRef
-  // back to 0 so we can restart the process
+  // back to 0 so we can restart the process, as well as clear datafileCounts
   React.useEffect(() => {
     countAppliedRef.current = 0;
+    setDatafileCounts([]);
   }, [data]);
 
   // need to use useDeepCompareEffect here because the array returned by useQueries
@@ -362,17 +364,17 @@ export const useDatasetsDatafileCount = (
       0
     );
     const batchMax =
-      datasetCounts.length - currCountReturned < 5
-        ? datasetCounts.length - currCountReturned
+      datafileCounts.length - currCountReturned < 5
+        ? datafileCounts.length - currCountReturned
         : 5;
     // this in effect batches our updates to only happen in batches >= 5
     if (currCountReturned - countAppliedRef.current >= batchMax) {
-      setDatasetCounts(queries);
+      setDatafileCounts(queries);
       countAppliedRef.current = currCountReturned;
     }
-  }, [queries]);
+  }, [datafileCounts, queries]);
 
-  return datasetCounts;
+  return datafileCounts;
 };
 
 export const fetchDatasetCountQuery = (

--- a/packages/datagateway-common/src/api/investigations.test.tsx
+++ b/packages/datagateway-common/src/api/investigations.test.tsx
@@ -1,5 +1,5 @@
 import { Investigation } from '../app.types';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { createMemoryHistory, History } from 'history';
 import axios from 'axios';
 import handleICATError from '../handleICATError';
@@ -64,6 +64,7 @@ describe('investigation api functions', () => {
   afterEach(() => {
     (handleICATError as jest.Mock).mockClear();
     (axios.get as jest.Mock).mockClear();
+    jest.useRealTimers();
   });
 
   describe('useInvestigation', () => {
@@ -565,8 +566,9 @@ describe('investigation api functions', () => {
         })
       );
 
+      const pagedData = { pages: [mockData], pageParams: null };
       const { result, waitFor } = renderHook(
-        () => useInvestigationSizes({ pages: [mockData], pageParams: null }),
+        () => useInvestigationSizes(pagedData),
         {
           wrapper: createReactQueryWrapper(),
         }
@@ -631,8 +633,9 @@ describe('investigation api functions', () => {
     });
 
     it("doesn't send any requests if the array supplied is empty to undefined", () => {
+      let data = [];
       const { result: emptyResult } = renderHook(
-        () => useInvestigationSizes([]),
+        () => useInvestigationSizes(data),
         {
           wrapper: createReactQueryWrapper(),
         }
@@ -641,8 +644,9 @@ describe('investigation api functions', () => {
       expect(emptyResult.current.length).toBe(0);
       expect(axios.get).not.toHaveBeenCalled();
 
+      data = undefined;
       const { result: undefinedResult } = renderHook(
-        () => useInvestigationSizes(undefined),
+        () => useInvestigationSizes(data),
         {
           wrapper: createReactQueryWrapper(),
         }
@@ -650,6 +654,111 @@ describe('investigation api functions', () => {
 
       expect(undefinedResult.current.length).toBe(0);
       expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    it('batches updates correctly & updates results correctly when data updates', async () => {
+      jest.useFakeTimers();
+      mockData = [
+        {
+          id: 1,
+          title: 'Test 1',
+          name: 'Test 1',
+          visitId: '1',
+        },
+        {
+          id: 2,
+          title: 'Test 2',
+          name: 'Test 2',
+          visitId: '2',
+        },
+        {
+          id: 3,
+          title: 'Test 3',
+          name: 'Test 3',
+          visitId: '3',
+        },
+        {
+          id: 4,
+          title: 'Test 4',
+          name: 'Test 4',
+          visitId: '4',
+        },
+        {
+          id: 5,
+          title: 'Test 5',
+          name: 'Test 5',
+          visitId: '5',
+        },
+        {
+          id: 6,
+          title: 'Test 6',
+          name: 'Test 6',
+          visitId: '6',
+        },
+        {
+          id: 7,
+          title: 'Test 7',
+          name: 'Test 7',
+          visitId: '7',
+        },
+      ];
+      (axios.get as jest.Mock).mockImplementation(
+        (url, options) =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  data: options.params.entityId ?? 0,
+                }),
+              options.params.entityId * 10
+            )
+          )
+      );
+
+      const { result, rerender, waitForNextUpdate } = renderHook(
+        () => useInvestigationSizes(mockData),
+        {
+          wrapper: createReactQueryWrapper(),
+        }
+      );
+
+      jest.advanceTimersByTime(30);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.map((query) => query.data)).toEqual(
+        Array(7).fill(undefined)
+      );
+
+      jest.advanceTimersByTime(40);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.map((query) => query.data)).toEqual([
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+      ]);
+
+      mockData = [
+        {
+          id: 4,
+          title: 'Test 4',
+          name: 'Test 4',
+          visitId: '4',
+        },
+      ];
+
+      await act(async () => {
+        rerender();
+        await waitForNextUpdate();
+      });
+
+      expect(result.current.map((query) => query.data)).toEqual([4]);
     });
   });
 
@@ -733,12 +842,12 @@ describe('investigation api functions', () => {
         })
       );
 
+      const pagedData = {
+        pages: [mockData],
+        pageParams: null,
+      };
       const { result, waitFor } = renderHook(
-        () =>
-          useInvestigationsDatasetCount({
-            pages: [mockData],
-            pageParams: null,
-          }),
+        () => useInvestigationsDatasetCount(pagedData),
         {
           wrapper: createReactQueryWrapper(),
         }
@@ -821,8 +930,9 @@ describe('investigation api functions', () => {
     });
 
     it("doesn't send any requests if the array supplied is empty to undefined", () => {
+      let data = [];
       const { result: emptyResult } = renderHook(
-        () => useInvestigationsDatasetCount([]),
+        () => useInvestigationsDatasetCount(data),
         {
           wrapper: createReactQueryWrapper(),
         }
@@ -831,8 +941,9 @@ describe('investigation api functions', () => {
       expect(emptyResult.current.length).toBe(0);
       expect(axios.get).not.toHaveBeenCalled();
 
+      data = undefined;
       const { result: undefinedResult } = renderHook(
-        () => useInvestigationsDatasetCount(undefined),
+        () => useInvestigationsDatasetCount(data),
         {
           wrapper: createReactQueryWrapper(),
         }
@@ -840,6 +951,114 @@ describe('investigation api functions', () => {
 
       expect(undefinedResult.current.length).toBe(0);
       expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    it('batches updates correctly & updates results correctly when data updates', async () => {
+      jest.useFakeTimers();
+      mockData = [
+        {
+          id: 1,
+          title: 'Test 1',
+          name: 'Test 1',
+          visitId: '1',
+        },
+        {
+          id: 2,
+          title: 'Test 2',
+          name: 'Test 2',
+          visitId: '2',
+        },
+        {
+          id: 3,
+          title: 'Test 3',
+          name: 'Test 3',
+          visitId: '3',
+        },
+        {
+          id: 4,
+          title: 'Test 4',
+          name: 'Test 4',
+          visitId: '4',
+        },
+        {
+          id: 5,
+          title: 'Test 5',
+          name: 'Test 5',
+          visitId: '5',
+        },
+        {
+          id: 6,
+          title: 'Test 6',
+          name: 'Test 6',
+          visitId: '6',
+        },
+        {
+          id: 7,
+          title: 'Test 7',
+          name: 'Test 7',
+          visitId: '7',
+        },
+      ];
+      (axios.get as jest.Mock).mockImplementation(
+        (url, options) =>
+          new Promise((resolve) => {
+            const id = JSON.parse(options.params.get('where'))[
+              'investigation.id'
+            ].eq;
+            return setTimeout(
+              () =>
+                resolve({
+                  data: id ?? 0,
+                }),
+              id * 10
+            );
+          })
+      );
+
+      const { result, rerender, waitForNextUpdate } = renderHook(
+        () => useInvestigationsDatasetCount(mockData),
+        {
+          wrapper: createReactQueryWrapper(),
+        }
+      );
+
+      jest.advanceTimersByTime(30);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.map((query) => query.data)).toEqual(
+        Array(7).fill(undefined)
+      );
+
+      jest.advanceTimersByTime(40);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.map((query) => query.data)).toEqual([
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+      ]);
+
+      mockData = [
+        {
+          id: 4,
+          title: 'Test 4',
+          name: 'Test 4',
+          visitId: '4',
+        },
+      ];
+
+      await act(async () => {
+        rerender();
+        await waitForNextUpdate();
+      });
+
+      expect(result.current.map((query) => query.data)).toEqual([4]);
     });
   });
 

--- a/packages/datagateway-common/src/api/investigations.tsx
+++ b/packages/datagateway-common/src/api/investigations.tsx
@@ -293,9 +293,10 @@ export const useInvestigationSizes = (
   const countAppliedRef = React.useRef(0);
 
   // when data changes (i.e. due to sorting or filtering) set the countAppliedRef
-  // back to 0 so we can restart the process
+  // back to 0 so we can restart the process, as well as clear sizes
   React.useEffect(() => {
     countAppliedRef.current = 0;
+    setSizes([]);
   }, [data]);
 
   // need to use useDeepCompareEffect here because the array returned by useQueries
@@ -309,12 +310,13 @@ export const useInvestigationSizes = (
       sizes.length - currCountReturned < 5
         ? sizes.length - currCountReturned
         : 5;
+
     // this in effect batches our updates to only happen in batches >= 5
     if (currCountReturned - countAppliedRef.current >= batchMax) {
       setSizes(queries);
       countAppliedRef.current = currCountReturned;
     }
-  }, [queries]);
+  }, [sizes, queries]);
 
   return sizes;
 };
@@ -372,9 +374,10 @@ export const useInvestigationsDatasetCount = (
   const countAppliedRef = React.useRef(0);
 
   // when data changes (i.e. due to sorting or filtering) set the countAppliedRef
-  // back to 0 so we can restart the process
+  // back to 0 so we can restart the process, as well as clear datasetCounts
   React.useEffect(() => {
     countAppliedRef.current = 0;
+    setDatasetCounts([]);
   }, [data]);
 
   // need to use useDeepCompareEffect here because the array returned by useQueries
@@ -388,12 +391,13 @@ export const useInvestigationsDatasetCount = (
       datasetCounts.length - currCountReturned < 5
         ? datasetCounts.length - currCountReturned
         : 5;
+
     // this in effect batches our updates to only happen in batches >= 5
     if (currCountReturned - countAppliedRef.current >= batchMax) {
       setDatasetCounts(queries);
       countAppliedRef.current = currCountReturned;
     }
-  }, [queries]);
+  }, [datasetCounts, queries]);
 
   return datasetCounts;
 };


### PR DESCRIPTION
## Description
There was still a bug in the size/counts batching code, which meant if the number of results decreased from a lot to less than the batch size (i.e. 5) then they would never update, causing the UI to display incorrect sizes/counts. This was fixed by ensuring we clear the sizes/counts array when we detect the data has changed.

I also added unit tests for both the overall batching behaviour & this specific bug (and I tested that removing my fix causes the unit tests to fail)

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Ensure that filtering to a small number of results still shows the correct sizes/counts

## Agile board tracking
Closes #927 