### PR TITLE
fixing the calculate button when value is 0 #1122

### DIFF
--- a/packages/datagateway-common/src/detailsPanels/dls/datasetDetailsPanel.component.tsx
+++ b/packages/datagateway-common/src/detailsPanels/dls/datasetDetailsPanel.component.tsx
@@ -130,7 +130,7 @@ const DatasetDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {datasetData.size ? (
+                {datasetData.size !== undefined ? (
                   formatBytes(datasetData.size)
                 ) : (
                   <Button

--- a/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.tsx
+++ b/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.tsx
@@ -171,7 +171,7 @@ const VisitDetailsPanel = (
             </Typography>
             <Typography>
               <b>
-                {investigationData.size ? (
+                {investigationData.size !== undefined ? (
                   formatBytes(investigationData.size)
                 ) : (
                   <Button

--- a/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
@@ -265,9 +265,11 @@ describe('DLS - Datasets Table', () => {
     });
 
     it('and then calculate file size when the value is 0 ', () => {
+      cy.intercept('/getSize', '0');
+
       // need to wait for counts to finish, otherwise cypress might interact with the details panel
       // too quickly and it rerenders during the test
-      cy.intercept('/getSize', '0');
+
       cy.contains('[aria-rowindex="1"] [aria-colindex="4"]', '55').should(
         'exist'
       );

--- a/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/datasets.spec.ts
@@ -264,6 +264,25 @@ describe('DLS - Datasets Table', () => {
       cy.contains('4.55 GB', { timeout: 10000 }).should('be.visible');
     });
 
+    it('and then calculate file size when the value is 0 ', () => {
+      // need to wait for counts to finish, otherwise cypress might interact with the details panel
+      // too quickly and it rerenders during the test
+      cy.intercept('/getSize', '0');
+      cy.contains('[aria-rowindex="1"] [aria-colindex="4"]', '55').should(
+        'exist'
+      );
+      cy.contains('[aria-rowindex="2"] [aria-colindex="4"]', '55').should(
+        'exist'
+      );
+
+      cy.get('[aria-label="Show details"]').first().click();
+
+      cy.contains('#calculate-size-btn', 'Calculate')
+        .should('exist')
+        .click({ force: true });
+      cy.contains('0 B', { timeout: 10000 }).should('be.visible');
+    });
+
     it('and view the dataset type panel', () => {
       // need to wait for counts to finish, otherwise cypress might interact with the details panel
       // too quickly and it rerenders during the test

--- a/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
@@ -216,11 +216,12 @@ describe('DLS - Visits Table', () => {
     });
 
     it('and then calculate file size when the value is 0', () => {
+      cy.intercept('/getSize', '0');
+
       // We need to wait for counts to finish, otherwise cypress
       // might interact with the details panel too quickly and
       // it re-renders during the test.
 
-      cy.intercept('/getSize', '0');
       cy.contains('[aria-rowindex="1"] [aria-colindex="3"]', '2').should(
         'exist'
       );

--- a/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
+++ b/packages/datagateway-dataview/cypress/integration/table/dls/visits.spec.ts
@@ -215,6 +215,23 @@ describe('DLS - Visits Table', () => {
       cy.contains('11.01 GB', { timeout: 10000 }).should('be.visible');
     });
 
+    it('and then calculate file size when the value is 0', () => {
+      // We need to wait for counts to finish, otherwise cypress
+      // might interact with the details panel too quickly and
+      // it re-renders during the test.
+
+      cy.intercept('/getSize', '0');
+      cy.contains('[aria-rowindex="1"] [aria-colindex="3"]', '2').should(
+        'exist'
+      );
+      cy.get('[aria-label="Show details"]').first().click();
+
+      cy.contains('#calculate-size-btn', 'Calculate')
+        .should('exist')
+        .click({ force: true });
+      cy.contains('0 B', { timeout: 10000 }).should('be.visible');
+    });
+
     // TODO: Since we only have one investigation, we cannot test
     // showing details when another row is showing details at the moment.
 


### PR DESCRIPTION
## Description
The Calculate button on the DLS proposals on the investigation and dataset details panel
 doesn't recognise the result 0
## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #1122 
