### PR TITLE
Changing the admin download table pathname #958

### DIFF
--- a/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
@@ -18,7 +18,7 @@ describe('Admin Download Status', () => {
     cy.clearDownloads();
 
     cy.seedDownloads().then(() => {
-      cy.visit('/admin-download');
+      cy.visit('/admin/download');
     });
   });
 

--- a/packages/datagateway-download/public/datagateway-download-settings.example.json
+++ b/packages/datagateway-download/public/datagateway-download-settings.example.json
@@ -56,7 +56,7 @@
     },
     {
       "section": "Admin",
-      "link": "/admin-download",
+      "link": "/admin/download",
       "displayName": "Admin Download",
       "admin": true,
       "order": 1

--- a/packages/datagateway-download/server/e2e-settings.json
+++ b/packages/datagateway-download/server/e2e-settings.json
@@ -56,7 +56,7 @@
     },
     {
       "section": "Admin",
-      "link": "/admin-download",
+      "link": "/admin/download",
       "displayName": "Admin Download",
       "admin": true,
       "order": 0

--- a/packages/datagateway-download/src/App.tsx
+++ b/packages/datagateway-download/src/App.tsx
@@ -91,7 +91,7 @@ class App extends Component<unknown, { hasError: boolean }> {
               >
                 <Router>
                   <Switch>
-                    <Route path="/admin-download">
+                    <Route path="/admin/download">
                       <AdminDownloadStatusTable />
                     </Route>
                     <Route path="/download">


### PR DESCRIPTION
## Description
- Changing the admin download pathname from "/admin-download" to "/admin/download"

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes ral-facilities/scigateway/pull/974
