### PR TITLE
Close advanced help when an example link is clicked (#1160)

### DIFF
--- a/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
@@ -156,6 +156,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
                 "render": [Function],
               }
             }
+            onClick={[Function]}
             to="advanced_search_help.logic_operators.link3"
           >
             scattering NOT elastic

--- a/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/advancedHelpDialogue.component.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
                 "render": [Function],
               }
             }
+            onClick={[Function]}
             to="advanced_search_help.exact_phrase.link1"
           >
             "neutron scattering"
@@ -111,6 +112,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
               }
             }
             data-testid="advanced-help-link"
+            onClick={[Function]}
             to="advanced_search_help.logic_operators.link1"
           >
             neutron AND scattering
@@ -132,6 +134,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
                 "render": [Function],
               }
             }
+            onClick={[Function]}
             to="advanced_search_help.logic_operators.link2"
           >
             neutron OR scattering
@@ -174,6 +177,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
                 "render": [Function],
               }
             }
+            onClick={[Function]}
             to="advanced_search_help.logic_operators.link4"
           >
             scattering NOT (elastic OR neutron)
@@ -210,6 +214,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
                 "render": [Function],
               }
             }
+            onClick={[Function]}
             to="advanced_search_help.wildcards.link1"
           >
             te?t
@@ -230,6 +235,7 @@ exports[`Advanced help dialogue component tests renders correctly 1`] = `
                 "render": [Function],
               }
             }
+            onClick={[Function]}
             to="advanced_search_help.wildcards.link2"
           >
             *ium

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
@@ -124,6 +124,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               <Link
                 component={RouterLink}
                 to={t('advanced_search_help.exact_phrase.link1')}
+                onClick={handleClose}
               >
                 &quot;neutron scattering&quot;
               </Link>
@@ -146,6 +147,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
                 data-testid="advanced-help-link"
                 component={RouterLink}
                 to={t('advanced_search_help.logic_operators.link1')}
+                onClick={handleClose}
               >
                 neutron AND scattering
               </Link>
@@ -154,6 +156,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               <Link
                 component={RouterLink}
                 to={t('advanced_search_help.logic_operators.link2')}
+                onClick={handleClose}
               >
                 neutron OR scattering
               </Link>
@@ -170,6 +173,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               <Link
                 component={RouterLink}
                 to={t('advanced_search_help.logic_operators.link4')}
+                onClick={handleClose}
               >
                 scattering NOT (elastic OR neutron)
               </Link>
@@ -189,6 +193,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               <Link
                 component={RouterLink}
                 to={t('advanced_search_help.wildcards.link1')}
+                onClick={handleClose}
               >
                 te?t
               </Link>
@@ -198,6 +203,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               <Link
                 component={RouterLink}
                 to={t('advanced_search_help.wildcards.link2')}
+                onClick={handleClose}
               >
                 *ium
               </Link>

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
@@ -165,6 +165,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
               <Link
                 component={RouterLink}
                 to={t('advanced_search_help.logic_operators.link3')}
+                onClick={handleClose}
               >
                 scattering NOT elastic
               </Link>


### PR DESCRIPTION
## Description
Closes the advanced help dialogue when an example link is clicked.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1160
