### PR TITLE
DG download "remove all" button disables once pressed #1177

### DIFF
--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -245,6 +245,37 @@ describe('Download cart table component', () => {
     expect(wrapper.exists('[data-testid="no-selections-message"]')).toBe(true);
   });
 
+  it('disables remove all button while request is processing', async () => {
+    (removeAllDownloadCartItems as jest.Mock).mockImplementation(() => {
+      return new Promise((resolve) => setTimeout(resolve, 2000));
+    });
+
+    const wrapper = createWrapper();
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+      await flushPromises();
+      wrapper.update();
+    });
+
+    await act(async () => {
+      wrapper.find('button#removeAllButton').simulate('click');
+      await flushPromises();
+      wrapper.update();
+    });
+    expect(
+      wrapper.find('button#removeAllButton').prop('disabled')
+    ).toBeTruthy();
+
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.exists('[data-testid="no-selections-message"]')).toBe(
+        true
+      );
+    }, 2001);
+  });
+
   it("removes an item when said item's remove button is clicked", async () => {
     const wrapper = createWrapper();
 

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -20,6 +20,7 @@ import {
   makeStyles,
   Theme,
   Link,
+  CircularProgress,
 } from '@material-ui/core';
 import { RemoveCircle } from '@material-ui/icons';
 import {
@@ -66,6 +67,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
   const [dataLoaded, setDataLoaded] = React.useState(false);
   const [sizesLoaded, setSizesLoaded] = React.useState(true);
   const [sizesFinished, setSizesFinished] = React.useState(true);
+  const [removingAll, setRemovingAll] = React.useState(false);
 
   const fileCountMax = settings.fileCountMax;
   const totalSizeMax = settings.totalSizeMax;
@@ -416,17 +418,24 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             style={{ marginRight: '1em' }}
           >
             <Grid item>
+              {/* Request to remove all selections is in progress. To prevent excessive requests, disable button during request */}
               <Button
                 className="tour-download-remove-button"
                 id="removeAllButton"
                 variant="contained"
                 color="primary"
-                onClick={() =>
+                disabled={removingAll}
+                startIcon={removingAll && <CircularProgress size={20} />}
+                onClick={() => {
+                  setRemovingAll(true);
                   removeAllDownloadCartItems({
                     facilityName: settings.facilityName,
                     downloadApiUrl: settings.downloadApiUrl,
-                  }).then(() => setData([]))
-                }
+                  }).then(() => {
+                    setData([]);
+                    setRemovingAll(false);
+                  });
+                }}
               >
                 {t('downloadCart.remove_all')}
               </Button>


### PR DESCRIPTION
## Description
Once pressed, the remove all button is disabled and displays an indeterminate loading spinner until the request completes. This prevents excessive requests as the user was previously able to click this button several times, which could cause an error.

I found it difficult to get Jest's fake timers to work properly, which resulted in a unit test that isn't the best but works for now. I think this is due to multiple levels of promises trying to resolve and becoming conflicted. So anytime I try to use `jest.useFakeTimers()` I get an exceeded timeout error. See my comment below which points out the test in question. Any feedback on how to properly test this would be appreciated!

## Testing instructions
This behaviour usually only presents itself when there are a large number of items in the cart. Try adding a lot of individual datafiles to the cart. This will hopefully allow for the new behaviour to display for long enough to see in action.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1177