### PR TITLE
Fixing vertical scroll bar appearing when extra elements are on-screen #1178

### DIFF
--- a/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
+++ b/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
@@ -317,7 +317,7 @@ const PageBreadcrumbs: React.FC<PageBreadcrumbsProps> = (
 
   const viewString = view ? `?view=${view}` : '';
   return (
-    <div>
+    <div id="breadcrumbs">
       <Paper square elevation={0}>
         {/* // Ensure that there is a path to render, otherwise do not show any breadcrumb. */}
         {currentPathnames.length > 0 ? (

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -368,10 +368,23 @@ const StyledRouting = (props: {
     linearProgressHeight,
   } = props;
 
+  const breadcrumbDiv = document.getElementById('breadcrumbs');
+
+  const [breadcrumbHeight, setBreadcrumbHeight] = React.useState(
+    breadcrumbDiv ? `${breadcrumbDiv.clientHeight}px` : '30px'
+  );
+
+  React.useEffect(() => {
+    breadcrumbDiv
+      ? setBreadcrumbHeight(`${breadcrumbDiv.clientHeight}px`)
+      : setBreadcrumbHeight('30px');
+  }, [breadcrumbDiv, breadcrumbDiv?.clientHeight]);
+
   // Footer is 36px
   // Chrome's display is 1px shorter than Firefox's, so we subtract 1px extra to account for this
   // We also don't want the <LinearProgress> bar to push the page down so subtract the height of this (4px if on-screen)
-  const tablePaperHeight = `calc(100vh - 180px - 36px - 1px - ${linearProgressHeight})`;
+  // Additional rows of breadcrumbs also push the page down so subtract the height of the breadcrumb div
+  const tablePaperHeight = `calc(100vh - 180px - 36px - 1px - ${linearProgressHeight} - ${breadcrumbHeight})`;
 
   const [t] = useTranslation();
   const paperClasses = usePaperStyles({ tablePaperHeight });


### PR DESCRIPTION
## Description
The original issue describes how, when the <LinearProgress> loading bar is present in table view, a vertical scroll bar appears because the height of the page is extended temporarily. This is unwanted and messes with the page's appearance. As such, when the loading bar appears, its height (4px) is subtracted from the page height to keep it at the correct setting.

During testing, I also noticed the same thing happened when additional rows of breadcrumbs are present. When the breadcrumbs become too long for one line, they wrap to a new line, which also increases the height of the page. I have now factored the height of the containing breadcrumb div into the page height calculation as well. As the breadcrumbs are 30px tall each, the div element will be a multiple of this number.

The breadcrumb fix seems to work well in normal, 100% zoom, although I've noticed some issues when zooming in beyond this. I don't think this is too big of an issue, as zooming in causes most of the rest of the page to increase in height anyway, so we'd expect a vertical scroll bar to appear in this scenario.

## Testing instructions
This should be run through SciGateway to observe the effect. Navigate through table view into various pages and check that a vertical scroll bar does not appear when the page is loading results. Also navigate deep into instruments and investigations to build up the breadcrumb length to demonstrate that no vertical scroll bar should appear because of this either.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1178