### PR TITLE
Prevent users from downloading carts with empty items

### DIFF
--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -75,6 +75,7 @@
     "name": "Name",
     "type": "Type",
     "size": "Size",
+    "fileCount": "File Count",
     "remove": "Remove {{name}} from selection",
     "remove_all": "Remove All",
     "download": "Download Selection",
@@ -82,6 +83,7 @@
     "total_size": "Total size",
     "no_selections": "No data selected. <2>Browse</2> or <6>search</6> for data.",
     "browse_link": "/browse/investigation",
-    "search_link": "/search/data"
+    "search_link": "/search/data",
+    "empty_items_warning": "You have selected some empty items - please remove them to proceed with downloading your selection"
   }
 }

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -330,6 +330,14 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                     return formatBytes(props.cellData);
                   },
                 },
+                {
+                  label: t('downloadCart.fileCount'),
+                  dataKey: 'fileCount',
+                  cellContentRenderer: (props) => {
+                    if (props.cellData === -1) return 'Loading...';
+                    return props.cellData;
+                  },
+                },
               ]}
               sort={sort}
               onSort={(column: string, order: 'desc' | 'asc' | null) => {
@@ -396,6 +404,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             direction="column"
             xs
             alignContent="flex-end"
+            alignItems="flex-end"
             style={{ marginRight: '1.2em' }}
           >
             <Typography id="fileCountDisplay">
@@ -408,6 +417,9 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
               {totalSize !== -1 ? formatBytes(totalSize) : 'Calculating...'}
               {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
             </Typography>
+            {data.some((item) => item.size === 0 || item.fileCount === 0) && (
+              <Typography>{t('downloadCart.empty_items_warning')}</Typography>
+            )}
           </Grid>
           <Grid
             container
@@ -450,6 +462,9 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 disabled={
                   fileCount <= 0 ||
                   totalSize <= 0 ||
+                  data.some(
+                    (item) => item.size === 0 || item.fileCount === 0
+                  ) ||
                   (fileCountMax !== -1 && fileCount > fileCountMax) ||
                   (totalSizeMax !== -1 && totalSize > totalSizeMax)
                 }

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -249,6 +249,11 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
     return filteredData.sort(sortCartItems);
   }, [data, sort, filters]);
 
+  const emptyItems = React.useMemo(
+    () => data.some((item) => item.size === 0 || item.fileCount === 0),
+    [data]
+  );
+
   return data.length === 0 ? (
     <div
       className="tour-download-results"
@@ -305,8 +310,9 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
           <Paper
             className="tour-download-results"
             style={{
-              height:
-                'calc(100vh - 64px - 48px - 48px - 48px - 3rem - (1.75 * 0.875rem + 12px)',
+              height: `calc(100vh - 64px - 48px - 48px - 48px - 3rem${
+                emptyItems ? ' - 1rem' : ''
+              } - (1.75 * 0.875rem + 12px)`,
               minHeight: 230,
               overflowX: 'auto',
             }}
@@ -417,7 +423,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
               {totalSize !== -1 ? formatBytes(totalSize) : 'Calculating...'}
               {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
             </Typography>
-            {data.some((item) => item.size === 0 || item.fileCount === 0) && (
+            {emptyItems && (
               <Typography>{t('downloadCart.empty_items_warning')}</Typography>
             )}
           </Grid>
@@ -462,9 +468,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 disabled={
                   fileCount <= 0 ||
                   totalSize <= 0 ||
-                  data.some(
-                    (item) => item.size === 0 || item.fileCount === 0
-                  ) ||
+                  emptyItems ||
                   (fileCountMax !== -1 && fileCount > fileCountMax) ||
                   (totalSizeMax !== -1 && totalSize > totalSizeMax)
                 }


### PR DESCRIPTION
## Description

Disable download button if there are empty items in the cart
and also display a message to the user telling them this. Plus add a file count column so that users can see the problematic data

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [x] I will be deploying this change to ISIS prod shortly so can be tested there

## Agile board tracking
Hotfix so not connected to an issue