### PR TITLE
Couple of references to 'studies' removed as per updated vocabulary #1194

### DIFF
--- a/packages/datagateway-dataview/public/datagateway-dataview-settings.example.json
+++ b/packages/datagateway-dataview/public/datagateway-dataview-settings.example.json
@@ -21,7 +21,7 @@
     },
     {
       "target": "#plugin-link--browseStudyHierarchy-instrument",
-      "content": "Browse the data via instruments and studies"
+      "content": "Browse the data via instruments and experiments"
     },
     {
       "target": "#plugin-link--my-data-ISIS",

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -10,7 +10,7 @@
     "open_data_warning": {
       "message": "Open data",
       "tooltip": "Only open data is displayed when browsing anonymously. Please login to see embargoed data.",
-      "studies_tooltip": "Only open data is currently supported by the experiment view. Please browse via facility cycle to view closed data",
+      "experiments_tooltip": "Only open data is currently supported by the experiment view. Please browse via facility cycle to view closed data",
       "tooltip_link": "Click here to learn more about our data policy.",
       "aria_label": "More information about open data"
     }

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -241,7 +241,7 @@ const NavBar = React.memo(
                       title={
                         <h4>
                           {isStudyHierarchy
-                            ? t('app.open_data_warning.studies_tooltip')
+                            ? t('app.open_data_warning.experiments_tooltip')
                             : t('app.open_data_warning.tooltip')}
                           <br />
                           <br />


### PR DESCRIPTION
## Description
Updated vocabulary on ISIS DataGateway makes reference to experiments over studies. This PR updates a couple of tooltips that make reference to studies, either in name or content.

## Testing instructions
Should be run with SciGateway to be able to view the tooltip. Navigate through the tooltip messages until the one for Experiments is reached. It should no longer references studies.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1194