### PR TITLE
#1199 Fix instrument view default sorts when switching between study hierarchy and not

### DIFF
--- a/packages/datagateway-dataview/public/datagateway-dataview-settings.example.json
+++ b/packages/datagateway-dataview/public/datagateway-dataview-settings.example.json
@@ -117,31 +117,31 @@
     },
     {
       "section": "Browse",
-      "link": "/browse/proposal",
+      "link": "/browse/proposal?sort={\"title\":\"asc\"}",
       "displayName": "DLS View",
       "order": 2
     },
     {
       "section": "Browse",
-      "link": "/browse/instrument",
+      "link": "/browse/instrument?sort={\"fullName\":\"asc\"}",
       "displayName": "ISIS View",
       "order": 3
     },
     {
       "section": "Browse",
-      "link": "/browseStudyHierarchy/instrument",
+      "link": "/browseStudyHierarchy/instrument?sort={\"fullName\":\"asc\"}",
       "displayName": "Experiments",
       "order": 4
     },
     {
       "section": "Browse",
-      "link": "/my-data/DLS",
+      "link": "/my-data/DLS?filters={\"startDate\":{\"endDate\":\"2022-04-01\"}}&sort={\"startDate\":\"desc\"}",
       "displayName": "My Data DLS",
       "order": 5
     },
     {
       "section": "Browse",
-      "link": "/my-data/ISIS",
+      "link": "/my-data/ISIS?sort={\"startDate\":\"desc\"}",
       "displayName": "My Data ISIS",
       "order": 6
     }

--- a/packages/datagateway-dataview/src/page/pageRouting.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageRouting.component.tsx
@@ -436,9 +436,9 @@ class PageRouting extends React.PureComponent<PageRoutingProps> {
           path={paths.studyHierarchy.toggle.isisInstrument}
           render={() =>
             this.props.view === 'card' ? (
-              <ISISInstrumentsCardView studyHierarchy={true} />
+              <ISISInstrumentsCardView studyHierarchy={true} key="true" />
             ) : (
-              <ISISInstrumentsTable studyHierarchy={true} />
+              <ISISInstrumentsTable studyHierarchy={true} key="true" />
             )
           }
         />
@@ -552,9 +552,9 @@ class PageRouting extends React.PureComponent<PageRoutingProps> {
           path={paths.toggle.isisInstrument}
           render={() =>
             this.props.view === 'card' ? (
-              <ISISInstrumentsCardView studyHierarchy={false} />
+              <ISISInstrumentsCardView studyHierarchy={false} key="false" />
             ) : (
-              <ISISInstrumentsTable studyHierarchy={false} />
+              <ISISInstrumentsTable studyHierarchy={false} key="false" />
             )
           }
         />


### PR DESCRIPTION
## Description
Fix Instrument views not remounting when switching between studyHierarchy true & false by adding a key - this forces React to remount and thus applies the initial mount logic. We need to force remount as the default sort logic only applies on mount.

![instrument-switch-fix](https://user-images.githubusercontent.com/22525471/161266596-d0368b4f-dfd8-4dcf-b965-60f7d23461bc.gif)

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] See gif where I added links to switch between /browse/instrument and /browseStudyHierarchy/instrument without reloaded page. Or mount in SG

## Agile board tracking
Fixes #1199
