### PR TITLE
Selections tab is now loaded on every navigation to /download #1193

### DIFF
--- a/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
@@ -22,12 +22,6 @@ describe('Admin Download Status', () => {
     });
   });
 
-  afterEach(() => {
-    // Ensure to clear sessionStorage to prevent the app
-    // storing tab data.
-    sessionStorage.clear();
-  });
-
   it('should load correctly and display admin download status table', () => {
     cy.title().should('equal', 'DataGateway Download');
     cy.get('#datagateway-download').should('be.visible');

--- a/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadCart.spec.ts
@@ -12,10 +12,6 @@ describe('Download Cart', () => {
 
   afterEach(() => {
     cy.clearDownloadCart();
-
-    // Ensure to clear sessionStorage to prevent the app
-    // storing tab data.
-    sessionStorage.clear();
   });
 
   it('should load correctly and display cart items', () => {

--- a/packages/datagateway-download/cypress/integration/downloadConfirmation.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadConfirmation.spec.ts
@@ -27,11 +27,6 @@ describe('Download Confirmation', () => {
     cy.get('[aria-label="Download confirmation dialog"]').should('exist');
   });
 
-  afterEach(() => {
-    // Clear the session storage to avoid storing the current tab information.
-    sessionStorage.clear();
-  });
-
   it('should load correctly and display the confirmation dialog for the cart items', () => {
     // Show the correct download size of the cart items.
     cy.contains('Download Size: 11.01 GB').should('exist');

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -26,12 +26,6 @@ describe('Download Status', () => {
     });
   });
 
-  afterEach(() => {
-    // Ensure to clear sessionStorage to prevent the app
-    // storing tab data.
-    sessionStorage.clear();
-  });
-
   it('should load correctly and display download status table', () => {
     cy.title().should('equal', 'DataGateway Download');
     cy.get('#datagateway-download').should('be.visible');

--- a/packages/datagateway-download/cypress/integration/downloadTab.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadTab.spec.ts
@@ -1,0 +1,37 @@
+describe('Download Cart', () => {
+  beforeEach(() => {
+    //cy.intercept('GET', '**/topcat/user/cart/**').as('fetchCart');
+    //cy.intercept('GET', '**/topcat/user/downloads**').as('fetchDownloads');
+    cy.login();
+    cy.clearDownloadCart();
+
+    cy.seedDownloadCart().then(() => {
+      cy.visit('/download');
+      //cy.visit('/download').wait('@fetchCart');
+    });
+  });
+
+  afterEach(() => {
+    cy.clearDownloadCart();
+  });
+
+  it('should load correctly and display selection panel', () => {
+    cy.title().should('equal', 'DataGateway Download');
+    cy.get('#datagateway-download').should('be.visible');
+    cy.get('[aria-label="Selection"]').should('exist');
+    cy.get('[aria-label="Downloads"]').should('exist');
+    cy.get('[aria-label="Download selection panel"]').should('be.visible');
+    cy.get('[aria-label="Download status panel"]').should('not.be.visible');
+  });
+
+  it('should display the selection tab on every page reload', () => {
+    cy.get('[aria-label="Downloads"]').should('exist').click();
+    cy.get('[aria-label="Download status panel"]').should('be.visible');
+    cy.get('[aria-label="Download selection panel"]').should('not.be.visible');
+
+    cy.reload();
+
+    cy.get('[aria-label="Download selection panel"]').should('be.visible');
+    cy.get('[aria-label="Download status panel"]').should('not.be.visible');
+  });
+});

--- a/packages/datagateway-download/cypress/integration/downloadTab.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadTab.spec.ts
@@ -1,13 +1,10 @@
 describe('Download Cart', () => {
   beforeEach(() => {
-    //cy.intercept('GET', '**/topcat/user/cart/**').as('fetchCart');
-    //cy.intercept('GET', '**/topcat/user/downloads**').as('fetchDownloads');
     cy.login();
     cy.clearDownloadCart();
 
     cy.seedDownloadCart().then(() => {
       cy.visit('/download');
-      //cy.visit('/download').wait('@fetchCart');
     });
   });
 

--- a/packages/datagateway-download/src/downloadTab/downloadTab.component.test.tsx
+++ b/packages/datagateway-download/src/downloadTab/downloadTab.component.test.tsx
@@ -40,83 +40,11 @@ describe('DownloadTab', () => {
 
   afterEach(() => {
     mount.cleanUp();
-
-    // Clear the session storage.
-    sessionStorage.clear();
   });
 
   it('renders correctly', () => {
     const wrapper = shallow(<DownloadTabs />);
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('renders the previously used tab based on sessionStorage', async () => {
-    let wrapper = mount(
-      <Router history={history}>
-        <DownloadSettingsContext.Provider value={mockedSettings}>
-          <DownloadTabs />
-        </DownloadSettingsContext.Provider>
-      </Router>
-    );
-
-    await act(async () => {
-      await flushPromises();
-      wrapper.update();
-    });
-
-    expect(
-      wrapper.exists('[aria-label="downloadTab.download_cart_panel_arialabel"]')
-    ).toBe(true);
-    expect(
-      wrapper
-        .find('div[aria-label="downloadTab.download_cart_panel_arialabel"]')
-        .props().hidden
-    ).toBe(false);
-
-    // The tab index should be 0 for the cart tab.
-    expect(sessionStorage.getItem('downloadStatusTab')).toEqual('0');
-
-    await act(async () => {
-      wrapper
-        .find('button[aria-label="downloadTab.downloads_tab_arialabel"]')
-        .simulate('click');
-
-      await flushPromises();
-      wrapper.update();
-
-      expect(
-        wrapper
-          .find('div[aria-label="downloadTab.download_status_panel_arialabel"]')
-          .props().hidden
-      ).toBe(false);
-    });
-
-    // The tab index should be 1 for the download tab.
-    expect(sessionStorage.getItem('downloadStatusTab')).toEqual('1');
-
-    // Recreate the wrapper and expect it to show the download tab.
-    wrapper = mount(
-      <DownloadSettingsContext.Provider value={mockedSettings}>
-        <DownloadTabs />
-      </DownloadSettingsContext.Provider>
-    );
-
-    await act(async () => {
-      await flushPromises();
-      wrapper.update();
-    });
-
-    expect(sessionStorage.getItem('downloadStatusTab')).toEqual('1');
-    expect(
-      wrapper.exists(
-        '[aria-label="downloadTab.download_status_panel_arialabel"]'
-      )
-    ).toBe(true);
-    expect(
-      wrapper
-        .find('div[aria-label="downloadTab.download_status_panel_arialabel"]')
-        .props().hidden
-    ).toBe(false);
   });
 
   it('shows the appropriate table when clicking between tabs', async () => {
@@ -198,5 +126,53 @@ describe('DownloadTab', () => {
           .props().hidden
       ).toBe(true);
     });
+  });
+
+  it('renders the selections tab on each mount', async () => {
+    let wrapper = mount(
+      <Router history={history}>
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadTabs />
+        </DownloadSettingsContext.Provider>
+      </Router>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Navigate to downloads tab
+    await act(async () => {
+      wrapper
+        .find('button[aria-label="downloadTab.downloads_tab_arialabel"]')
+        .simulate('click');
+
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Recreate the wrapper and expect it to show the selections tab.
+    wrapper = mount(
+      <Router history={history}>
+        <DownloadSettingsContext.Provider value={mockedSettings}>
+          <DownloadTabs />
+        </DownloadSettingsContext.Provider>
+      </Router>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    expect(
+      wrapper.exists('[aria-label="downloadTab.download_cart_panel_arialabel"]')
+    ).toBe(true);
+    expect(
+      wrapper
+        .find('div[aria-label="downloadTab.download_cart_panel_arialabel"]')
+        .props().hidden
+    ).toBe(false);
   });
 });

--- a/packages/datagateway-download/src/downloadTab/downloadTab.component.tsx
+++ b/packages/datagateway-download/src/downloadTab/downloadTab.component.tsx
@@ -62,21 +62,8 @@ function a11yProps(
 }
 
 const DownloadTabs: React.FC = () => {
-  // Setting the selected tab in session storage is required
-  // as the selected tab information is lost with each re-render
-  // (e.g. opening/closing the navigation drawer).
-  const getTab = (): number => {
-    const savedTab = sessionStorage.getItem('downloadStatusTab');
-
-    // If the tab has not been saved, then set it to the initial cart view (0).
-    if (!savedTab) sessionStorage.setItem('downloadStatusTab', '0');
-    else return parseInt(savedTab);
-
-    return 0;
-  };
-
   // Set the initial tab.
-  const [selectedTab, setSelectedTab] = React.useState(getTab());
+  const [selectedTab, setSelectedTab] = React.useState(0);
   const [refreshDownloads, setRefreshDownloads] = React.useState(false);
   const [lastChecked, setLastChecked] = React.useState('');
   const [t] = useTranslation();
@@ -85,8 +72,6 @@ const DownloadTabs: React.FC = () => {
     event: React.ChangeEvent<unknown>,
     setTab: number
   ): void => {
-    // Set the tab in the session storage.
-    sessionStorage.setItem('downloadStatusTab', setTab.toString());
     setSelectedTab(setTab);
   };
 


### PR DESCRIPTION
## Description
Previously, the last tab the user had open was displayed whenever /download was visited. The last tab number was persisted in session storage to facilitate this. However, because we have links pointing to "selections", it can be confusing if the user arrives at the downloads tab instead and has to then navigate to the selections tab themselves. This commit remedies this by making the selections tab the goto every time. From now on, the user can only reach the downloads tab by manually clicking on the tab in /download.

## Testing instructions
Best tested alongside dataview. Try navigating to the download page through a variety of methods (nav bar, "go to selections", click on cart icon, page refresh, etc.) The selections tab should be loaded every time, not the downloads tab. Also check nothing is stored in session storage relating to the download tab anymore.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1193