### PR TITLE
Adding ability to use DatePicker or DateTimePicker in date filter column #1175

### DIFF
--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -221,9 +221,7 @@ export const getApiParams = (
         if ('endDate' in filter && filter.endDate) {
           searchParams.append(
             'where',
-            JSON.stringify({
-              [column]: { lte: `${filter.endDate} 23:59:59` },
-            })
+            JSON.stringify({ [column]: { lte: `${filter.endDate} 23:59:59` } })
           );
         }
         if ('type' in filter && filter.type) {

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -110,8 +110,8 @@ export const parseSearchToQuery = (queryParams: string): QueryParams => {
   let startDate = null;
   let endDate = null;
 
-  if (startDateString) startDate = new Date(startDateString);
-  if (endDateString) endDate = new Date(endDateString);
+  if (startDateString) startDate = new Date(startDateString + 'T00:00:00Z');
+  if (endDateString) endDate = new Date(endDateString + 'T00:00:00Z');
 
   // Create the query parameters object.
   const params: QueryParams = {
@@ -214,12 +214,7 @@ export const getApiParams = (
           searchParams.append(
             'where',
             JSON.stringify({
-              [column]: {
-                gte: format(
-                  Date.parse(filter.startDate),
-                  'yyyy-MM-dd HH:mm:ss'
-                ),
-              },
+              [column]: { gte: `${filter.startDate} 00:00:00` },
             })
           );
         }
@@ -227,9 +222,7 @@ export const getApiParams = (
           searchParams.append(
             'where',
             JSON.stringify({
-              [column]: {
-                lte: format(Date.parse(filter.endDate), 'yyyy-MM-dd HH:mm:ss'),
-              },
+              [column]: { lte: `${filter.endDate} 23:59:59` },
             })
           );
         }

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -110,8 +110,8 @@ export const parseSearchToQuery = (queryParams: string): QueryParams => {
   let startDate = null;
   let endDate = null;
 
-  if (startDateString) startDate = new Date(startDateString + 'T00:00:00Z');
-  if (endDateString) endDate = new Date(endDateString + 'T00:00:00Z');
+  if (startDateString) startDate = new Date(startDateString);
+  if (endDateString) endDate = new Date(endDateString);
 
   // Create the query parameters object.
   const params: QueryParams = {
@@ -214,14 +214,23 @@ export const getApiParams = (
           searchParams.append(
             'where',
             JSON.stringify({
-              [column]: { gte: `${filter.startDate} 00:00:00` },
+              [column]: {
+                gte: format(
+                  Date.parse(filter.startDate),
+                  'yyyy-MM-dd HH:mm:ss'
+                ),
+              },
             })
           );
         }
         if ('endDate' in filter && filter.endDate) {
           searchParams.append(
             'where',
-            JSON.stringify({ [column]: { lte: `${filter.endDate} 23:59:59` } })
+            JSON.stringify({
+              [column]: {
+                lte: format(Date.parse(filter.endDate), 'yyyy-MM-dd HH:mm:ss'),
+              },
+            })
           );
         }
         if ('type' in filter && filter.type) {

--- a/packages/datagateway-common/src/table/columnFilters/__snapshots__/dateColumnFilter.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/columnFilters/__snapshots__/dateColumnFilter.component.test.tsx.snap
@@ -1,5 +1,315 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Date filter component DatePicker functionality useTextFilter hook returns a function which can generate a working text filter 1`] = `
+<form>
+  <MuiPickersUtilsProvider
+    utils={[Function]}
+  >
+    <PickerWithState
+      KeyboardButtonProps={
+        Object {
+          "aria-label": "Start Date filter from, date picker",
+          "size": "small",
+        }
+      }
+      allowKeyboardControl={true}
+      aria-hidden="true"
+      cancelLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Cancel
+        </span>
+      }
+      clearLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Clear
+        </span>
+      }
+      clearable={true}
+      color="secondary"
+      format="yyyy-MM-dd"
+      id="Start Date filter from"
+      inputProps={
+        Object {
+          "aria-label": "Start Date filter",
+        }
+      }
+      invalidDateMessage="Date format: yyyy-MM-dd."
+      maxDate={2100-01-01T00:00:00.000Z}
+      maxDateMessage="Invalid date range"
+      minDate={1900-01-01T00:00:00.000Z}
+      minDateMessage="Date should not be before minimal date"
+      okLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          OK
+        </span>
+      }
+      onChange={[Function]}
+      openTo="date"
+      placeholder="From..."
+      style={
+        Object {
+          "whiteSpace": "nowrap",
+        }
+      }
+      value={null}
+      views={
+        Array [
+          "year",
+          "month",
+          "date",
+        ]
+      }
+    />
+    <PickerWithState
+      KeyboardButtonProps={
+        Object {
+          "aria-label": "Start Date filter to, date picker",
+          "size": "small",
+        }
+      }
+      allowKeyboardControl={true}
+      aria-hidden="true"
+      cancelLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Cancel
+        </span>
+      }
+      clearLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Clear
+        </span>
+      }
+      clearable={true}
+      color="secondary"
+      format="yyyy-MM-dd"
+      id="Start Date filter to"
+      inputProps={
+        Object {
+          "aria-label": "Start Date filter",
+        }
+      }
+      invalidDateMessage="Date format: yyyy-MM-dd."
+      maxDate={2100-01-01T00:00:00.000Z}
+      maxDateMessage="Date should not be after maximal date"
+      minDate={1984-01-01T00:00:00.000Z}
+      minDateMessage="Invalid date range"
+      okLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          OK
+        </span>
+      }
+      onChange={[Function]}
+      openTo="date"
+      placeholder="To..."
+      style={
+        Object {
+          "whiteSpace": "nowrap",
+        }
+      }
+      value={null}
+      views={
+        Array [
+          "year",
+          "month",
+          "date",
+        ]
+      }
+    />
+  </MuiPickersUtilsProvider>
+</form>
+`;
+
+exports[`Date filter component DateTimePicker functionality useTextFilter hook returns a function which can generate a working text filter 1`] = `
+<form>
+  <MuiPickersUtilsProvider
+    utils={[Function]}
+  >
+    <PickerWithState
+      KeyboardButtonProps={
+        Object {
+          "aria-label": "Start Date filter from, date picker",
+          "size": "small",
+        }
+      }
+      allowKeyboardControl={true}
+      aria-hidden="true"
+      cancelLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Cancel
+        </span>
+      }
+      clearLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Clear
+        </span>
+      }
+      clearable={true}
+      color="secondary"
+      format="yyyy-MM-dd"
+      id="Start Date filter from"
+      inputProps={
+        Object {
+          "aria-label": "Start Date filter",
+        }
+      }
+      invalidDateMessage="Date format: yyyy-MM-dd."
+      maxDate={2100-01-01T00:00:00.000Z}
+      maxDateMessage="Invalid date range"
+      minDate={1900-01-01T00:00:00.000Z}
+      minDateMessage="Date should not be before minimal date"
+      okLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          OK
+        </span>
+      }
+      onChange={[Function]}
+      openTo="date"
+      placeholder="From..."
+      style={
+        Object {
+          "whiteSpace": "nowrap",
+        }
+      }
+      value={null}
+      views={
+        Array [
+          "year",
+          "month",
+          "date",
+        ]
+      }
+    />
+    <PickerWithState
+      KeyboardButtonProps={
+        Object {
+          "aria-label": "Start Date filter to, date picker",
+          "size": "small",
+        }
+      }
+      allowKeyboardControl={true}
+      aria-hidden="true"
+      cancelLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Cancel
+        </span>
+      }
+      clearLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          Clear
+        </span>
+      }
+      clearable={true}
+      color="secondary"
+      format="yyyy-MM-dd"
+      id="Start Date filter to"
+      inputProps={
+        Object {
+          "aria-label": "Start Date filter",
+        }
+      }
+      invalidDateMessage="Date format: yyyy-MM-dd."
+      maxDate={2100-01-01T00:00:00.000Z}
+      maxDateMessage="Date should not be after maximal date"
+      minDate={1984-01-01T00:00:00.000Z}
+      minDateMessage="Invalid date range"
+      okLabel={
+        <span
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+        >
+          OK
+        </span>
+      }
+      onChange={[Function]}
+      openTo="date"
+      placeholder="To..."
+      style={
+        Object {
+          "whiteSpace": "nowrap",
+        }
+      }
+      value={null}
+      views={
+        Array [
+          "year",
+          "month",
+          "date",
+        ]
+      }
+    />
+  </MuiPickersUtilsProvider>
+</form>
+`;
+
 exports[`Date filter component renders correctly 1`] = `
 <form>
   <MuiPickersUtilsProvider
@@ -143,161 +453,6 @@ exports[`Date filter component renders correctly 1`] = `
         }
       }
       value={2000-01-01T00:00:00.000Z}
-      views={
-        Array [
-          "year",
-          "month",
-          "date",
-        ]
-      }
-    />
-  </MuiPickersUtilsProvider>
-</form>
-`;
-
-exports[`Date filter component useTextFilter hook returns a function which can generate a working text filter 1`] = `
-<form>
-  <MuiPickersUtilsProvider
-    utils={[Function]}
-  >
-    <PickerWithState
-      KeyboardButtonProps={
-        Object {
-          "aria-label": "Start Date filter from, date picker",
-          "size": "small",
-        }
-      }
-      allowKeyboardControl={true}
-      aria-hidden="true"
-      cancelLabel={
-        <span
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-        >
-          Cancel
-        </span>
-      }
-      clearLabel={
-        <span
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-        >
-          Clear
-        </span>
-      }
-      clearable={true}
-      color="secondary"
-      format="yyyy-MM-dd"
-      id="Start Date filter from"
-      inputProps={
-        Object {
-          "aria-label": "Start Date filter",
-        }
-      }
-      invalidDateMessage="Date format: yyyy-MM-dd."
-      maxDate={2100-01-01T00:00:00.000Z}
-      maxDateMessage="Invalid date range"
-      minDate={1900-01-01T00:00:00.000Z}
-      minDateMessage="Date should not be before minimal date"
-      okLabel={
-        <span
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-        >
-          OK
-        </span>
-      }
-      onChange={[Function]}
-      openTo="date"
-      placeholder="From..."
-      style={
-        Object {
-          "whiteSpace": "nowrap",
-        }
-      }
-      value={null}
-      views={
-        Array [
-          "year",
-          "month",
-          "date",
-        ]
-      }
-    />
-    <PickerWithState
-      KeyboardButtonProps={
-        Object {
-          "aria-label": "Start Date filter to, date picker",
-          "size": "small",
-        }
-      }
-      allowKeyboardControl={true}
-      aria-hidden="true"
-      cancelLabel={
-        <span
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-        >
-          Cancel
-        </span>
-      }
-      clearLabel={
-        <span
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-        >
-          Clear
-        </span>
-      }
-      clearable={true}
-      color="secondary"
-      format="yyyy-MM-dd"
-      id="Start Date filter to"
-      inputProps={
-        Object {
-          "aria-label": "Start Date filter",
-        }
-      }
-      invalidDateMessage="Date format: yyyy-MM-dd."
-      maxDate={2100-01-01T00:00:00.000Z}
-      maxDateMessage="Date should not be after maximal date"
-      minDate={1984-01-01T00:00:00.000Z}
-      minDateMessage="Invalid date range"
-      okLabel={
-        <span
-          style={
-            Object {
-              "color": undefined,
-            }
-          }
-        >
-          OK
-        </span>
-      }
-      onChange={[Function]}
-      openTo="date"
-      placeholder="To..."
-      style={
-        Object {
-          "whiteSpace": "nowrap",
-        }
-      }
-      value={null}
       views={
         Array [
           "year",

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.test.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.test.tsx
@@ -204,195 +204,419 @@ describe('Date filter component', () => {
     });
   });
 
-  it('calls the onChange method correctly when filling out the date inputs', () => {
-    const onChange = jest.fn();
+  describe('DatePicker functionality', () => {
+    it('calls the onChange method correctly when filling out the date inputs', () => {
+      const onChange = jest.fn();
 
-    const baseProps = {
-      label: 'test',
-      onChange,
-    };
+      const baseProps = {
+        label: 'test',
+        onChange,
+      };
 
-    const wrapper = mount(<DateColumnFilter {...baseProps} />);
+      const wrapper = mount(<DateColumnFilter {...baseProps} />);
 
-    const startDateFilterInput = wrapper.find('input').first();
-    startDateFilterInput.instance().value = '2019-08-06';
-    startDateFilterInput.simulate('change');
+      const startDateFilterInput = wrapper.find('input').first();
+      startDateFilterInput.instance().value = '2019-08-06';
+      startDateFilterInput.simulate('change');
 
-    expect(onChange).toHaveBeenLastCalledWith({
-      startDate: '2019-08-06',
-    });
+      expect(onChange).toHaveBeenLastCalledWith({
+        startDate: '2019-08-06',
+      });
 
-    wrapper.setProps({ ...baseProps, value: { startDate: '2019-08-06' } });
-    const endDateFilterInput = wrapper.find('input').last();
-    endDateFilterInput.instance().value = '2019-08-06';
-    endDateFilterInput.simulate('change');
+      wrapper.setProps({ ...baseProps, value: { startDate: '2019-08-06' } });
+      const endDateFilterInput = wrapper.find('input').last();
+      endDateFilterInput.instance().value = '2019-08-06';
+      endDateFilterInput.simulate('change');
 
-    expect(onChange).toHaveBeenLastCalledWith({
-      startDate: '2019-08-06',
-      endDate: '2019-08-06',
-    });
-
-    wrapper.setProps({
-      ...baseProps,
-      value: {
+      expect(onChange).toHaveBeenLastCalledWith({
         startDate: '2019-08-06',
         endDate: '2019-08-06',
-      },
-    });
-    startDateFilterInput.instance().value = '';
-    startDateFilterInput.simulate('change');
+      });
 
-    expect(onChange).toHaveBeenLastCalledWith({
-      endDate: '2019-08-06',
-    });
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          startDate: '2019-08-06',
+          endDate: '2019-08-06',
+        },
+      });
+      startDateFilterInput.instance().value = '';
+      startDateFilterInput.simulate('change');
 
-    wrapper.setProps({
-      ...baseProps,
-      value: {
+      expect(onChange).toHaveBeenLastCalledWith({
         endDate: '2019-08-06',
-      },
-    });
-    endDateFilterInput.instance().value = '';
-    endDateFilterInput.simulate('change');
+      });
 
-    expect(onChange).toHaveBeenLastCalledWith(null);
-  });
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          endDate: '2019-08-06',
+        },
+      });
+      endDateFilterInput.instance().value = '';
+      endDateFilterInput.simulate('change');
 
-  it('handles invalid date values correctly by not calling onChange, unless there was previously a value there', () => {
-    const onChange = jest.fn();
-
-    const baseProps = {
-      label: 'test',
-      onChange,
-    };
-
-    const wrapper = mount(<DateColumnFilter {...baseProps} />);
-
-    const startDateFilterInput = wrapper.find('input').first();
-    startDateFilterInput.instance().value = '2';
-    startDateFilterInput.simulate('change');
-
-    expect(onChange).not.toHaveBeenCalled();
-
-    const endDateFilterInput = wrapper.find('input').last();
-    endDateFilterInput.instance().value = '201';
-    endDateFilterInput.simulate('change');
-
-    expect(onChange).not.toHaveBeenCalled();
-
-    startDateFilterInput.instance().value = '2019-08-06';
-    startDateFilterInput.simulate('change');
-
-    expect(onChange).toHaveBeenLastCalledWith({
-      startDate: '2019-08-06',
+      expect(onChange).toHaveBeenLastCalledWith(null);
     });
 
-    wrapper.setProps({ ...baseProps, value: { startDate: '2019-08-06' } });
-    endDateFilterInput.instance().value = '2019-08-07';
-    endDateFilterInput.simulate('change');
+    it('handles invalid date values correctly by not calling onChange, unless there was previously a value there', () => {
+      const onChange = jest.fn();
 
-    expect(onChange).toHaveBeenLastCalledWith({
-      startDate: '2019-08-06',
-      endDate: '2019-08-07',
-    });
+      const baseProps = {
+        label: 'test',
+        onChange,
+      };
 
-    wrapper.setProps({
-      ...baseProps,
-      value: {
+      const wrapper = mount(<DateColumnFilter {...baseProps} />);
+
+      const startDateFilterInput = wrapper.find('input').first();
+      startDateFilterInput.instance().value = '2';
+      startDateFilterInput.simulate('change');
+
+      expect(onChange).not.toHaveBeenCalled();
+
+      const endDateFilterInput = wrapper.find('input').last();
+      endDateFilterInput.instance().value = '201';
+      endDateFilterInput.simulate('change');
+
+      expect(onChange).not.toHaveBeenCalled();
+
+      startDateFilterInput.instance().value = '2019-08-06';
+      startDateFilterInput.simulate('change');
+
+      expect(onChange).toHaveBeenLastCalledWith({
+        startDate: '2019-08-06',
+      });
+
+      wrapper.setProps({ ...baseProps, value: { startDate: '2019-08-06' } });
+      endDateFilterInput.instance().value = '2019-08-07';
+      endDateFilterInput.simulate('change');
+
+      expect(onChange).toHaveBeenLastCalledWith({
         startDate: '2019-08-06',
         endDate: '2019-08-07',
-      },
-    });
-    startDateFilterInput.instance().value = '2';
-    startDateFilterInput.simulate('change');
+      });
 
-    expect(onChange).toHaveBeenLastCalledWith({
-      endDate: '2019-08-07',
-    });
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          startDate: '2019-08-06',
+          endDate: '2019-08-07',
+        },
+      });
+      startDateFilterInput.instance().value = '2';
+      startDateFilterInput.simulate('change');
 
-    wrapper.setProps({
-      ...baseProps,
-      value: {
+      expect(onChange).toHaveBeenLastCalledWith({
         endDate: '2019-08-07',
-      },
-    });
-    endDateFilterInput.instance().value = '201';
-    endDateFilterInput.simulate('change');
+      });
 
-    expect(onChange).toHaveBeenLastCalledWith(null);
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          endDate: '2019-08-07',
+        },
+      });
+      endDateFilterInput.instance().value = '201';
+      endDateFilterInput.simulate('change');
+
+      expect(onChange).toHaveBeenLastCalledWith(null);
+    });
+
+    it('displays error for invalid date', () => {
+      const onChange = jest.fn();
+
+      const baseProps = {
+        label: 'test',
+        onChange,
+        value: {
+          startDate: '2019-13-09',
+          endDate: '2019-08-32',
+        },
+      };
+
+      const wrapper = mount(<DateColumnFilter {...baseProps} />);
+
+      expect(wrapper.find('p.Mui-error')).toHaveLength(2);
+      expect(wrapper.find('p.Mui-error').first().text()).toEqual(
+        'Date format: yyyy-MM-dd.'
+      );
+    });
+
+    it('displays error for invalid date range', () => {
+      const onChange = jest.fn();
+
+      const baseProps = {
+        label: 'test',
+        onChange,
+        value: {
+          startDate: '2019-08-09',
+          endDate: '2019-08-08',
+        },
+      };
+
+      const wrapper = mount(<DateColumnFilter {...baseProps} />);
+
+      expect(wrapper.find('p.Mui-error')).toHaveLength(2);
+      expect(wrapper.find('p.Mui-error').first().text()).toEqual(
+        'Invalid date range'
+      );
+    });
+
+    it('useTextFilter hook returns a function which can generate a working text filter', () => {
+      const pushFilter = jest.fn();
+      (usePushFilter as jest.Mock).mockImplementation(() => pushFilter);
+
+      const { result } = renderHook(() => useDateFilter({}));
+      let dateFilter;
+
+      act(() => {
+        dateFilter = result.current('Start Date', 'startDate');
+      });
+
+      const shallowWrapper = shallow(dateFilter);
+      expect(shallowWrapper).toMatchSnapshot();
+
+      const mountWrapper = mount(dateFilter);
+      const startDateFilterInput = mountWrapper.find('input').first();
+      startDateFilterInput.instance().value = '2021-08-09';
+      startDateFilterInput.simulate('change');
+
+      expect(pushFilter).toHaveBeenLastCalledWith('startDate', {
+        startDate: '2021-08-09',
+      });
+
+      mountWrapper.setProps({
+        ...mountWrapper.props(),
+        value: { startDate: '2021-08-09' },
+      });
+      startDateFilterInput.instance().value = '';
+      startDateFilterInput.simulate('change');
+
+      expect(pushFilter).toHaveBeenCalledTimes(2);
+      expect(pushFilter).toHaveBeenLastCalledWith('startDate', null);
+    });
   });
 
-  it('displays error for invalid date', () => {
-    const onChange = jest.fn();
+  describe('DateTimePicker functionality', () => {
+    it('calls the onChange method correctly when filling out the date/time inputs', () => {
+      const onChange = jest.fn();
 
-    const baseProps = {
-      label: 'test',
-      onChange,
-      value: {
-        startDate: '2019-13-09',
-        endDate: '2019-08-32',
-      },
-    };
+      const baseProps = {
+        label: 'test',
+        onChange,
+      };
 
-    const wrapper = mount(<DateColumnFilter {...baseProps} />);
+      const wrapper = mount(<DateColumnFilter filterByTime {...baseProps} />);
 
-    expect(wrapper.find('p.Mui-error')).toHaveLength(2);
-    expect(wrapper.find('p.Mui-error').first().text()).toEqual(
-      'Date format: yyyy-MM-dd.'
-    );
-  });
+      const startDateFilterInput = wrapper.find('input').first();
+      startDateFilterInput.instance().value = '2019-08-06 00:00';
+      startDateFilterInput.simulate('change');
 
-  it('displays error for invalid date range', () => {
-    const onChange = jest.fn();
+      expect(onChange).toHaveBeenLastCalledWith({
+        startDate: '2019-08-06 00:00',
+      });
 
-    const baseProps = {
-      label: 'test',
-      onChange,
-      value: {
-        startDate: '2019-08-09',
-        endDate: '2019-08-08',
-      },
-    };
+      wrapper.setProps({
+        ...baseProps,
+        value: { startDate: '2019-08-06 00:00' },
+      });
+      const endDateFilterInput = wrapper.find('input').last();
+      endDateFilterInput.instance().value = '2019-08-06 23:59';
+      endDateFilterInput.simulate('change');
 
-    const wrapper = mount(<DateColumnFilter {...baseProps} />);
+      expect(onChange).toHaveBeenLastCalledWith({
+        startDate: '2019-08-06 00:00',
+        endDate: '2019-08-06 23:59',
+      });
 
-    expect(wrapper.find('p.Mui-error')).toHaveLength(2);
-    expect(wrapper.find('p.Mui-error').first().text()).toEqual(
-      'Invalid date range'
-    );
-  });
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          startDate: '2019-08-06 00:00',
+          endDate: '2019-08-06 23:59',
+        },
+      });
+      startDateFilterInput.instance().value = '';
+      startDateFilterInput.simulate('change');
 
-  it('useTextFilter hook returns a function which can generate a working text filter', () => {
-    const pushFilter = jest.fn();
-    (usePushFilter as jest.Mock).mockImplementation(() => pushFilter);
+      expect(onChange).toHaveBeenLastCalledWith({
+        endDate: '2019-08-06 23:59',
+      });
 
-    const { result } = renderHook(() => useDateFilter({}));
-    let dateFilter;
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          endDate: '2019-08-06 23:59',
+        },
+      });
+      endDateFilterInput.instance().value = '';
+      endDateFilterInput.simulate('change');
 
-    act(() => {
-      dateFilter = result.current('Start Date', 'startDate');
+      expect(onChange).toHaveBeenLastCalledWith(null);
     });
 
-    const shallowWrapper = shallow(dateFilter);
-    expect(shallowWrapper).toMatchSnapshot();
+    it('handles invalid date values correctly by not calling onChange, unless there was previously a value there', () => {
+      const onChange = jest.fn();
 
-    const mountWrapper = mount(dateFilter);
-    const startDateFilterInput = mountWrapper.find('input').first();
-    startDateFilterInput.instance().value = '2021-08-09';
-    startDateFilterInput.simulate('change');
+      const baseProps = {
+        label: 'test',
+        onChange,
+      };
 
-    expect(pushFilter).toHaveBeenLastCalledWith('startDate', {
-      startDate: '2021-08-09',
+      const wrapper = mount(<DateColumnFilter filterByTime {...baseProps} />);
+
+      const startDateFilterInput = wrapper.find('input').first();
+      startDateFilterInput.instance().value = '2';
+      startDateFilterInput.simulate('change');
+
+      expect(onChange).not.toHaveBeenCalled();
+
+      const endDateFilterInput = wrapper.find('input').last();
+      endDateFilterInput.instance().value = '201';
+      endDateFilterInput.simulate('change');
+
+      expect(onChange).not.toHaveBeenCalled();
+
+      startDateFilterInput.instance().value = '2019-08-06 00:00';
+      startDateFilterInput.simulate('change');
+
+      expect(onChange).toHaveBeenLastCalledWith({
+        startDate: '2019-08-06 00:00',
+      });
+
+      wrapper.setProps({
+        ...baseProps,
+        value: { startDate: '2019-08-06 00:00' },
+      });
+      endDateFilterInput.instance().value = '2019-08-07 00:00';
+      endDateFilterInput.simulate('change');
+
+      expect(onChange).toHaveBeenLastCalledWith({
+        startDate: '2019-08-06 00:00',
+        endDate: '2019-08-07 00:00',
+      });
+
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          startDate: '2019-08-06 00:00',
+          endDate: '2019-08-07 00:00',
+        },
+      });
+      startDateFilterInput.instance().value = '2';
+      startDateFilterInput.simulate('change');
+
+      expect(onChange).toHaveBeenLastCalledWith({
+        endDate: '2019-08-07 00:00',
+      });
+
+      wrapper.setProps({
+        ...baseProps,
+        value: {
+          endDate: '2019-08-07 00:00',
+        },
+      });
+      endDateFilterInput.instance().value = '201';
+      endDateFilterInput.simulate('change');
+
+      expect(onChange).toHaveBeenLastCalledWith(null);
     });
 
-    mountWrapper.setProps({
-      ...mountWrapper.props(),
-      value: { startDate: '2021-08-09' },
-    });
-    startDateFilterInput.instance().value = '';
-    startDateFilterInput.simulate('change');
+    it('displays error for invalid date', () => {
+      const onChange = jest.fn();
 
-    expect(pushFilter).toHaveBeenCalledTimes(2);
-    expect(pushFilter).toHaveBeenLastCalledWith('startDate', null);
+      const baseProps = {
+        label: 'test',
+        onChange,
+        value: {
+          startDate: '2019-13-09 00:00',
+          endDate: '2019-08-32 00:00',
+        },
+      };
+
+      const wrapper = mount(<DateColumnFilter filterByTime {...baseProps} />);
+
+      expect(wrapper.find('p.Mui-error')).toHaveLength(2);
+      expect(wrapper.find('p.Mui-error').first().text()).toEqual(
+        'Date format: yyyy-MM-dd HH:mm.'
+      );
+    });
+
+    it('displays error for invalid time', () => {
+      const onChange = jest.fn();
+
+      const baseProps = {
+        label: 'test',
+        onChange,
+        value: {
+          startDate: '2019-13-09 00:60',
+          endDate: '2019-08-32 24:00',
+        },
+      };
+
+      const wrapper = mount(<DateColumnFilter filterByTime {...baseProps} />);
+
+      expect(wrapper.find('p.Mui-error')).toHaveLength(2);
+      expect(wrapper.find('p.Mui-error').first().text()).toEqual(
+        'Date format: yyyy-MM-dd HH:mm.'
+      );
+    });
+
+    it('displays error for invalid date/time range', () => {
+      const onChange = jest.fn();
+
+      const baseProps = {
+        label: 'test',
+        onChange,
+        value: {
+          startDate: '2019-08-08 12:00',
+          endDate: '2019-08-08 11:00',
+        },
+      };
+
+      const wrapper = mount(<DateColumnFilter filterByTime {...baseProps} />);
+
+      expect(wrapper.find('p.Mui-error')).toHaveLength(2);
+      expect(wrapper.find('p.Mui-error').first().text()).toEqual(
+        'Invalid date/time range'
+      );
+    });
+
+    // I don't believe this works with date+time due to time values not appearing in URL params
+    // TODO remove this?
+    it.skip('useTextFilter hook returns a function which can generate a working text filter', () => {
+      const pushFilter = jest.fn();
+      (usePushFilter as jest.Mock).mockImplementation(() => pushFilter);
+
+      const { result } = renderHook(() => useDateFilter({}));
+      let dateFilter;
+
+      act(() => {
+        dateFilter = result.current('Start Date', 'startDate');
+      });
+
+      const shallowWrapper = shallow(dateFilter);
+      expect(shallowWrapper).toMatchSnapshot();
+
+      const mountWrapper = mount(dateFilter);
+      const startDateFilterInput = mountWrapper.find('input').first();
+      startDateFilterInput.instance().value = '2021-08-09 00:00';
+      startDateFilterInput.simulate('change');
+
+      expect(pushFilter).toHaveBeenLastCalledWith('startDate', {
+        startDate: '2021-08-09 00:00',
+      });
+
+      mountWrapper.setProps({
+        ...mountWrapper.props(),
+        value: { startDate: '2021-08-09 00:00' },
+      });
+      startDateFilterInput.instance().value = '';
+      startDateFilterInput.simulate('change');
+
+      expect(pushFilter).toHaveBeenCalledTimes(2);
+      expect(pushFilter).toHaveBeenLastCalledWith('startDate', null);
+    });
   });
 });

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { format, isValid, isEqual } from 'date-fns';
 import {
@@ -74,6 +74,19 @@ interface DateColumnFilterProps {
   filterByTime?: boolean;
 }
 
+interface DatePickerCommonProps {
+  clearable: boolean;
+  allowKeyboardControl: boolean;
+  invalidDateMessage: string;
+  ariaHidden: boolean;
+  format: string;
+  color: 'secondary' | 'primary' | undefined;
+  strictCompareDates?: boolean;
+  okLabel: ReactElement;
+  cancelLabel: ReactElement;
+  clearLabel: ReactElement;
+}
+
 const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
   //Need state to change otherwise wont update error messages for an invalid date
   const [startDate, setStartDate] = useState(
@@ -88,29 +101,43 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const buttonColour = (theme as any).colours?.blue;
 
+  const datePickerProps: DatePickerCommonProps = {
+    clearable: true,
+    allowKeyboardControl: true,
+    invalidDateMessage: 'Date format: yyyy-MM-dd.',
+    ariaHidden: true,
+    format: 'yyyy-MM-dd',
+    color: 'secondary',
+    okLabel: <span style={{ color: buttonColour }}>OK</span>,
+    cancelLabel: <span style={{ color: buttonColour }}>Cancel</span>,
+    clearLabel: <span style={{ color: buttonColour }}>Clear</span>,
+  };
+
+  const dateTimePickerProps: DatePickerCommonProps = {
+    ...datePickerProps,
+    invalidDateMessage: 'Date format: yyyy-MM-dd HH:mm.',
+    format: 'yyyy-MM-dd HH:mm',
+    strictCompareDates: true,
+  };
+
   return (
     <form>
       {props.filterByTime ? (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
           <KeyboardDateTimePicker
-            clearable
-            allowKeyboardControl
+            {...dateTimePickerProps}
             style={{ whiteSpace: 'nowrap' }}
             inputProps={{ 'aria-label': `${props.label} filter` }}
-            invalidDateMessage="Date format: yyyy-MM-dd HH:mm."
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter from, date/time picker`,
             }}
             id={props.label + ' filter from'}
-            aria-hidden="true"
-            format="yyyy-MM-dd HH:mm"
             placeholder="From..."
             value={startDate}
             views={['year', 'month', 'date', 'hours', 'minutes']}
             maxDate={endDate || new Date('2100-01-01 00:00')}
             maxDateMessage="Invalid date/time range"
-            color="secondary"
             onChange={(date) => {
               setStartDate(date);
               updateFilter({
@@ -122,30 +149,21 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
                 filterByTime: true,
               });
             }}
-            okLabel={<span style={{ color: buttonColour }}>OK</span>}
-            cancelLabel={<span style={{ color: buttonColour }}>Cancel</span>}
-            clearLabel={<span style={{ color: buttonColour }}>Clear</span>}
-            strictCompareDates
           />
           <KeyboardDateTimePicker
-            clearable
-            allowKeyboardControl
+            {...dateTimePickerProps}
             style={{ whiteSpace: 'nowrap' }}
             inputProps={{ 'aria-label': `${props.label} filter` }}
-            invalidDateMessage="Date format: yyyy-MM-dd HH:mm."
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter to, date/time picker`,
             }}
             id={props.label + ' filter to'}
-            aria-hidden="true"
-            format="yyyy-MM-dd HH:mm"
             placeholder="To..."
             value={endDate}
             views={['year', 'month', 'date', 'hours', 'minutes']}
             minDate={startDate || new Date('1984-01-01 00:00')}
             minDateMessage="Invalid date/time range"
-            color="secondary"
             onChange={(date) => {
               setEndDate(date);
               updateFilter({
@@ -157,33 +175,24 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
                 filterByTime: true,
               });
             }}
-            okLabel={<span style={{ color: buttonColour }}>OK</span>}
-            cancelLabel={<span style={{ color: buttonColour }}>Cancel</span>}
-            clearLabel={<span style={{ color: buttonColour }}>Clear</span>}
-            strictCompareDates
           />
         </MuiPickersUtilsProvider>
       ) : (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
           <KeyboardDatePicker
-            clearable
-            allowKeyboardControl
+            {...datePickerProps}
             style={{ whiteSpace: 'nowrap' }}
             inputProps={{ 'aria-label': `${props.label} filter` }}
-            invalidDateMessage="Date format: yyyy-MM-dd."
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter from, date picker`,
             }}
             id={props.label + ' filter from'}
-            aria-hidden="true"
-            format="yyyy-MM-dd"
             placeholder="From..."
             value={startDate}
             views={['year', 'month', 'date']}
             maxDate={endDate || new Date('2100-01-01T00:00:00Z')}
             maxDateMessage="Invalid date range"
-            color="secondary"
             onChange={(date) => {
               setStartDate(date);
               updateFilter({
@@ -194,9 +203,6 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
                 onChange: props.onChange,
               });
             }}
-            okLabel={<span style={{ color: buttonColour }}>OK</span>}
-            cancelLabel={<span style={{ color: buttonColour }}>Cancel</span>}
-            clearLabel={<span style={{ color: buttonColour }}>Clear</span>}
           />
           <KeyboardDatePicker
             clearable

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -1,10 +1,12 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { format, isValid, isEqual } from 'date-fns';
 import {
   KeyboardDatePicker,
   KeyboardDateTimePicker,
   MuiPickersUtilsProvider,
+  KeyboardDatePickerProps,
+  KeyboardDateTimePickerProps,
 } from '@material-ui/pickers';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import { FiltersType, DateFilter } from '../../app.types';
@@ -74,18 +76,6 @@ interface DateColumnFilterProps {
   filterByTime?: boolean;
 }
 
-interface DatePickerCommonProps {
-  clearable: boolean;
-  allowKeyboardControl: boolean;
-  invalidDateMessage: string;
-  format: string;
-  color: 'secondary' | 'primary' | undefined;
-  strictCompareDates?: boolean;
-  okLabel: ReactElement;
-  cancelLabel: ReactElement;
-  clearLabel: ReactElement;
-}
-
 const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
   //Need state to change otherwise wont update error messages for an invalid date
   const [startDate, setStartDate] = useState(
@@ -100,7 +90,7 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const buttonColour = (theme as any).colours?.blue;
 
-  const datePickerProps: DatePickerCommonProps = {
+  const datePickerProps: Partial<KeyboardDatePickerProps> = {
     clearable: true,
     allowKeyboardControl: true,
     invalidDateMessage: 'Date format: yyyy-MM-dd.',
@@ -109,13 +99,18 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
     okLabel: <span style={{ color: buttonColour }}>OK</span>,
     cancelLabel: <span style={{ color: buttonColour }}>Cancel</span>,
     clearLabel: <span style={{ color: buttonColour }}>Clear</span>,
+    style: { whiteSpace: 'nowrap' },
+    'aria-hidden': 'true',
+    inputProps: { 'aria-label': `${props.label} filter` },
+    views: ['year', 'month', 'date'],
   };
 
-  const dateTimePickerProps: DatePickerCommonProps = {
+  const dateTimePickerProps: Partial<KeyboardDateTimePickerProps> = {
     ...datePickerProps,
     invalidDateMessage: 'Date format: yyyy-MM-dd HH:mm.',
     format: 'yyyy-MM-dd HH:mm',
     strictCompareDates: true,
+    views: ['year', 'month', 'date', 'hours', 'minutes'],
   };
 
   return (
@@ -124,17 +119,13 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
           <KeyboardDateTimePicker
             {...dateTimePickerProps}
-            style={{ whiteSpace: 'nowrap' }}
-            inputProps={{ 'aria-label': `${props.label} filter` }}
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter from, date/time picker`,
             }}
             id={props.label + ' filter from'}
-            aria-hidden="true"
             placeholder="From..."
             value={startDate}
-            views={['year', 'month', 'date', 'hours', 'minutes']}
             maxDate={endDate || new Date('2100-01-01 00:00')}
             maxDateMessage="Invalid date/time range"
             onChange={(date) => {
@@ -151,17 +142,13 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
           />
           <KeyboardDateTimePicker
             {...dateTimePickerProps}
-            style={{ whiteSpace: 'nowrap' }}
-            inputProps={{ 'aria-label': `${props.label} filter` }}
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter to, date/time picker`,
             }}
             id={props.label + ' filter to'}
-            aria-hidden="true"
             placeholder="To..."
             value={endDate}
-            views={['year', 'month', 'date', 'hours', 'minutes']}
             minDate={startDate || new Date('1984-01-01 00:00')}
             minDateMessage="Invalid date/time range"
             onChange={(date) => {
@@ -181,17 +168,13 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
           <KeyboardDatePicker
             {...datePickerProps}
-            style={{ whiteSpace: 'nowrap' }}
-            inputProps={{ 'aria-label': `${props.label} filter` }}
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter from, date picker`,
             }}
             id={props.label + ' filter from'}
-            aria-hidden="true"
             placeholder="From..."
             value={startDate}
-            views={['year', 'month', 'date']}
             maxDate={endDate || new Date('2100-01-01T00:00:00Z')}
             maxDateMessage="Invalid date range"
             onChange={(date) => {
@@ -207,17 +190,13 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
           />
           <KeyboardDatePicker
             {...datePickerProps}
-            style={{ whiteSpace: 'nowrap' }}
-            inputProps={{ 'aria-label': `${props.label} filter` }}
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter to, date picker`,
             }}
             id={props.label + ' filter to'}
-            aria-hidden="true"
             placeholder="To..."
             value={endDate}
-            views={['year', 'month', 'date']}
             minDate={startDate || new Date('1984-01-01T00:00:00Z')}
             minDateMessage="Invalid date range"
             onChange={(date) => {

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -53,13 +53,13 @@ export function updateFilter({
       onChange({
         [startDateOrEndDateChanged]:
           date && isValid(date)
-            ? format(date, filterByTime ? 'yyyy-MM-dd HH:mm:ss' : 'yyyy-MM-dd')
+            ? format(date, filterByTime ? 'yyyy-MM-dd HH:mm' : 'yyyy-MM-dd')
             : undefined,
         [startDateOrEndDateChanged === 'startDate' ? 'endDate' : 'startDate']:
           otherDate && isValid(otherDate)
             ? format(
                 otherDate,
-                filterByTime ? 'yyyy-MM-dd HH:mm:ss' : 'yyyy-MM-dd'
+                filterByTime ? 'yyyy-MM-dd HH:mm' : 'yyyy-MM-dd'
               )
             : undefined,
       });
@@ -97,18 +97,18 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
             allowKeyboardControl
             style={{ whiteSpace: 'nowrap' }}
             inputProps={{ 'aria-label': `${props.label} filter` }}
-            invalidDateMessage="Date format: yyyy-MM-dd HH:mm:ss."
+            invalidDateMessage="Date format: yyyy-MM-dd HH:mm."
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter from, date/time picker`,
             }}
             id={props.label + ' filter from'}
             aria-hidden="true"
-            format="yyyy-MM-dd HH:mm:ss"
+            format="yyyy-MM-dd HH:mm"
             placeholder="From..."
             value={startDate}
             views={['year', 'month', 'date', 'hours', 'minutes']}
-            maxDate={endDate || new Date('2100-01-01T00:00:00Z')}
+            maxDate={endDate || new Date('2100-01-01 00:00')}
             maxDateMessage="Invalid date/time range"
             color="secondary"
             onChange={(date) => {
@@ -132,18 +132,18 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
             allowKeyboardControl
             style={{ whiteSpace: 'nowrap' }}
             inputProps={{ 'aria-label': `${props.label} filter` }}
-            invalidDateMessage="Date format: yyyy-MM-dd HH:mm:ss."
+            invalidDateMessage="Date format: yyyy-MM-dd HH:mm."
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter to, date/time picker`,
             }}
             id={props.label + ' filter to'}
             aria-hidden="true"
-            format="yyyy-MM-dd HH:mm:ss"
+            format="yyyy-MM-dd HH:mm"
             placeholder="To..."
             value={endDate}
             views={['year', 'month', 'date', 'hours', 'minutes']}
-            minDate={startDate || new Date('1984-01-01T00:00:00Z')}
+            minDate={startDate || new Date('1984-01-01 00:00')}
             minDateMessage="Invalid date/time range"
             color="secondary"
             onChange={(date) => {

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -78,7 +78,6 @@ interface DatePickerCommonProps {
   clearable: boolean;
   allowKeyboardControl: boolean;
   invalidDateMessage: string;
-  ariaHidden: boolean;
   format: string;
   color: 'secondary' | 'primary' | undefined;
   strictCompareDates?: boolean;
@@ -105,7 +104,6 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
     clearable: true,
     allowKeyboardControl: true,
     invalidDateMessage: 'Date format: yyyy-MM-dd.',
-    ariaHidden: true,
     format: 'yyyy-MM-dd',
     color: 'secondary',
     okLabel: <span style={{ color: buttonColour }}>OK</span>,
@@ -133,6 +131,7 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
               'aria-label': `${props.label} filter from, date/time picker`,
             }}
             id={props.label + ' filter from'}
+            aria-hidden="true"
             placeholder="From..."
             value={startDate}
             views={['year', 'month', 'date', 'hours', 'minutes']}
@@ -159,6 +158,7 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
               'aria-label': `${props.label} filter to, date/time picker`,
             }}
             id={props.label + ' filter to'}
+            aria-hidden="true"
             placeholder="To..."
             value={endDate}
             views={['year', 'month', 'date', 'hours', 'minutes']}
@@ -188,6 +188,7 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
               'aria-label': `${props.label} filter from, date picker`,
             }}
             id={props.label + ' filter from'}
+            aria-hidden="true"
             placeholder="From..."
             value={startDate}
             views={['year', 'month', 'date']}
@@ -205,24 +206,20 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
             }}
           />
           <KeyboardDatePicker
-            clearable
-            allowKeyboardControl
+            {...datePickerProps}
             style={{ whiteSpace: 'nowrap' }}
             inputProps={{ 'aria-label': `${props.label} filter` }}
-            invalidDateMessage="Date format: yyyy-MM-dd."
             KeyboardButtonProps={{
               size: 'small',
               'aria-label': `${props.label} filter to, date picker`,
             }}
             id={props.label + ' filter to'}
             aria-hidden="true"
-            format="yyyy-MM-dd"
             placeholder="To..."
             value={endDate}
             views={['year', 'month', 'date']}
             minDate={startDate || new Date('1984-01-01T00:00:00Z')}
             minDateMessage="Invalid date range"
-            color="secondary"
             onChange={(date) => {
               setEndDate(date);
               updateFilter({
@@ -233,9 +230,6 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
                 onChange: props.onChange,
               });
             }}
-            okLabel={<span style={{ color: buttonColour }}>OK</span>}
-            cancelLabel={<span style={{ color: buttonColour }}>Cancel</span>}
-            clearLabel={<span style={{ color: buttonColour }}>Clear</span>}
           />
         </MuiPickersUtilsProvider>
       )}

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns-tz';
+
 describe('Download Status', () => {
   before(() => {
     // Ensure the downloads are cleared before running tests.
@@ -129,7 +131,7 @@ describe('Download Status', () => {
     });
 
     it('date between', () => {
-      cy.get('input[id="Requested Date filter from"]').type('2020-01-31');
+      cy.get('input[id="Requested Date filter from"]').type('2020-01-31 00:00');
 
       const date = new Date();
       const month = date.toLocaleString('default', { month: 'long' });
@@ -156,7 +158,7 @@ describe('Download Status', () => {
 
       cy.get('input[id="Requested Date filter to"]').should(
         'have.value',
-        date.toISOString().slice(0, 10)
+        format(date, 'yyyy-MM-dd HH:mm')
       );
 
       // There should not be results for this time period.
@@ -169,7 +171,7 @@ describe('Download Status', () => {
       cy.get('[aria-rowcount="4"]').should('exist');
 
       cy.get('input[id="Requested Date filter from"]').type(
-        currDate.toISOString().slice(0, 10)
+        format(currDate, 'yyyy-MM-dd HH:mm')
       );
 
       cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -415,7 +415,7 @@ describe('Admin Download Status Table', () => {
       'input[id="downloadStatus.createdAt filter from"]'
     );
     await act(async () => {
-      dateFromFilterInput.instance().value = '2020-01-01';
+      dateFromFilterInput.instance().value = '2020-01-01 00:00';
       dateFromFilterInput.simulate('change');
       await flushPromises();
       wrapper.update();
@@ -423,7 +423,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.createdAt) BETWEEN {ts '2020-01-01 00:00:00'} AND {ts '9999-12-31 23:59:59'} ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.createdAt) BETWEEN {ts '2020-01-01 00:00'} AND {ts '9999-12-31 23:59'} ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
     );
 
     // Get the Requested Data To filter input
@@ -431,7 +431,7 @@ describe('Admin Download Status Table', () => {
       'input[id="downloadStatus.createdAt filter to"]'
     );
     await act(async () => {
-      dateToFilterInput.instance().value = '2020-01-02';
+      dateToFilterInput.instance().value = '2020-01-02 23:59';
       dateToFilterInput.simulate('change');
       await flushPromises();
       wrapper.update();
@@ -439,7 +439,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.createdAt) BETWEEN {ts '2020-01-01 00:00:00'} AND {ts '2020-01-02 23:59:59'} ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.createdAt) BETWEEN {ts '2020-01-01 00:00'} AND {ts '2020-01-02 23:59'} ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
     );
 
     dateFromFilterInput.instance().value = '';

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -90,10 +90,10 @@ const AdminDownloadStatusTable: React.FC = () => {
         if (!Array.isArray(filter)) {
           if ('startDate' in filter || 'endDate' in filter) {
             const startDate = filter.startDate
-              ? `${filter.startDate} 00:00:00`
+              ? filter.startDate
               : '0000-01-01 00:00:00';
             const endDate = filter.endDate
-              ? `${filter.endDate} 23:59:59`
+              ? filter.endDate
               : '9999-12-31 23:59:59';
 
             queryOffset += ` AND UPPER(download.${column}) BETWEEN {ts '${startDate}'} AND {ts '${endDate}'}`;
@@ -259,6 +259,7 @@ const AdminDownloadStatusTable: React.FC = () => {
         }
       }}
       value={filters[dataKey] as DateFilter}
+      filterByTime
     />
   );
 

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -89,12 +89,8 @@ const AdminDownloadStatusTable: React.FC = () => {
       if (typeof filter === 'object') {
         if (!Array.isArray(filter)) {
           if ('startDate' in filter || 'endDate' in filter) {
-            const startDate = filter.startDate
-              ? filter.startDate
-              : '0000-01-01 00:00';
-            const endDate = filter.endDate
-              ? filter.endDate
-              : '9999-12-31 23:59';
+            const startDate = filter.startDate ?? '0000-01-01 00:00';
+            const endDate = filter.endDate ?? '9999-12-31 23:59';
 
             queryOffset += ` AND UPPER(download.${column}) BETWEEN {ts '${startDate}'} AND {ts '${endDate}'}`;
           }

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -91,10 +91,10 @@ const AdminDownloadStatusTable: React.FC = () => {
           if ('startDate' in filter || 'endDate' in filter) {
             const startDate = filter.startDate
               ? filter.startDate
-              : '0000-01-01 00:00:00';
+              : '0000-01-01 00:00';
             const endDate = filter.endDate
               ? filter.endDate
-              : '9999-12-31 23:59:59';
+              : '9999-12-31 23:59';
 
             queryOffset += ` AND UPPER(download.${column}) BETWEEN {ts '${startDate}'} AND {ts '${endDate}'}`;
           }

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -461,7 +461,7 @@ describe('Download Status Table', () => {
       'input[id="downloadStatus.createdAt filter from"]'
     );
 
-    dateFromFilterInput.instance().value = '2020-01-01';
+    dateFromFilterInput.instance().value = '2020-01-01 00:00';
     dateFromFilterInput.simulate('change');
 
     expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
@@ -470,14 +470,14 @@ describe('Download Status Table', () => {
       'input[id="downloadStatus.createdAt filter to"]'
     );
 
-    dateToFilterInput.instance().value = '2020-01-02';
+    dateToFilterInput.instance().value = '2020-01-02 23:59';
     dateToFilterInput.simulate('change');
 
     expect(wrapper.exists('[aria-rowcount=0]')).toBe(true);
 
-    dateFromFilterInput.instance().value = '2020-02-26';
+    dateFromFilterInput.instance().value = '2020-02-26 00:00';
     dateFromFilterInput.simulate('change');
-    dateToFilterInput.instance().value = '2020-02-27';
+    dateToFilterInput.instance().value = '2020-02-27 23:59';
     dateToFilterInput.simulate('change');
 
     expect(wrapper.exists('[aria-rowcount=2]')).toBe(true);

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -158,6 +158,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
         }
       }}
       value={filters[dataKey] as DateFilter}
+      filterByTime
     />
   );
 
@@ -186,7 +187,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
             const tableTimestamp = toDate(tableValue).getTime();
             const startTimestamp = toDate(value.startDate).getTime();
             const endTimestamp = value.endDate
-              ? new Date(`${value.endDate} 23:59:59`).getTime()
+              ? new Date(value.endDate).getTime()
               : Date.now();
 
             if (


### PR DESCRIPTION
## Description
Depending on if a `filterByTime` prop is passed, the date filter component will return either a `KeyboardDatePicker` or a `KeyboardDateTimePicker`. Thus, the admin download table now contains a `KeyboardDateTimePicker` for more accurate filtering of results, as per user request.

This required some amendments to how time is passed to the backend date query. Previously, if a date was passed, it was assumed the time value would be 00:00:00 or 23:59:59, depending on `startDate` or `endDate` being changed. Now we must provide a time value if the user specifies one.

Fortunately, the formatting for this is done in the `dateColumnFilter` component. However, the GUI for `KeyboardDateTimePicker` can only be accurate to hours and minutes - we can't enter a value for seconds. 

This causes a slight amendment to queries - if we enter an end date of `2022-04-06 23:59`, we won't get any results for `2022-04-06 23:59:00` < x < `2022-04-06 23:59:59`. We'd need to update the query to an end date of `2022-04-07 00:00`. If anyone has any thoughts on this, how this might impact users, other unintended side-effects, solutions for including a value for seconds, etc. please comment!

## Testing instructions
Because this is a change to the globally-used date filter, it is important to test date filtering in a variety of pages, including dataview, search, download and admin download. Currently, only the admin download table wants date and time filtering so make sure that other filters are date filter only and continue to work as expected. Finally, check to make sure that date and time values can be filtered on the admin download table correctly.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1175