### PR TITLE
Download tables sort by requested time descending by default #1176

### DIFF
--- a/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
@@ -57,7 +57,7 @@ describe('Admin Download Status', () => {
       cy.get('.react-draggable')
         .eq(7)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 600 })
+        .trigger('mousemove', { clientX: 800 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Requested Date').click();
 
@@ -81,7 +81,7 @@ describe('Admin Download Status', () => {
       cy.get('.react-draggable')
         .eq(7)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 600 })
+        .trigger('mousemove', { clientX: 800 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Requested Date').click();
 
@@ -110,7 +110,7 @@ describe('Admin Download Status', () => {
       cy.get('.react-draggable')
         .eq(7)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 600 })
+        .trigger('mousemove', { clientX: 800 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Requested Date').click();
 
@@ -144,7 +144,7 @@ describe('Admin Download Status', () => {
       cy.get('.react-draggable')
         .eq(7)
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: 600 })
+        .trigger('mousemove', { clientX: 800 })
         .trigger('mouseup');
       cy.contains('[role="button"]', 'Requested Date').click();
 

--- a/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/adminDownloadStatus.spec.ts
@@ -53,6 +53,14 @@ describe('Admin Download Status', () => {
 
   describe('should be able to sort download items by', () => {
     it('ascending order', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.get('.react-draggable')
+        .eq(7)
+        .trigger('mousedown')
+        .trigger('mousemove', { clientX: 600 })
+        .trigger('mouseup');
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.get('.react-draggable')
         .eq(4)
         .trigger('mousedown')
@@ -69,6 +77,14 @@ describe('Admin Download Status', () => {
     });
 
     it('descending order', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.get('.react-draggable')
+        .eq(7)
+        .trigger('mousedown')
+        .trigger('mousemove', { clientX: 600 })
+        .trigger('mouseup');
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.get('.react-draggable')
         .eq(4)
         .trigger('mousedown')
@@ -90,6 +106,14 @@ describe('Admin Download Status', () => {
     });
 
     it('no order', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.get('.react-draggable')
+        .eq(7)
+        .trigger('mousedown')
+        .trigger('mousemove', { clientX: 600 })
+        .trigger('mouseup');
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.get('.react-draggable')
         .eq(3)
         .trigger('mousedown')
@@ -116,6 +140,14 @@ describe('Admin Download Status', () => {
     });
 
     it('multiple columns', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.get('.react-draggable')
+        .eq(7)
+        .trigger('mousedown')
+        .trigger('mousemove', { clientX: 600 })
+        .trigger('mouseup');
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.get('.react-draggable')
         .eq(4)
         .trigger('mousedown')

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -44,6 +44,9 @@ describe('Download Status', () => {
 
   describe('should be able to sort download items by', () => {
     it('ascending order', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.contains('[role="button"]', 'Download Name').click();
 
       cy.get('[aria-sort="ascending"]').should('exist');
@@ -56,6 +59,9 @@ describe('Download Status', () => {
     });
 
     it('descending order', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.contains('[role="button"]', 'Download Name').click();
       cy.contains('[role="button"]', 'Download Name').click();
 
@@ -77,6 +83,9 @@ describe('Download Status', () => {
     });
 
     it('no order', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.contains('[role="button"]', 'Download Name').click();
       cy.contains('[role="button"]', 'Download Name').click();
       cy.contains('[role="button"]', 'Download Name').click();
@@ -100,6 +109,9 @@ describe('Download Status', () => {
     });
 
     it('multiple columns', () => {
+      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
+      cy.contains('[role="button"]', 'Requested Date').click();
+
       cy.contains('[role="button"]', 'Access Method').click();
       cy.contains('[role="button"]', 'Availability').click();
 

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -144,7 +144,11 @@ exports[`Admin Download Status Table renders correctly 1`] = `
               loadMoreRows={[Function]}
               loading={true}
               onSort={[Function]}
-              sort={Object {}}
+              sort={
+                Object {
+                  "createdAt": "desc",
+                }
+              }
               totalRowCount={9007199254740991}
             />
           </WithStyles(ForwardRef(Paper))>

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
@@ -60,7 +60,11 @@ exports[`Download Status Table renders correctly 1`] = `
         data={Array []}
         loading={true}
         onSort={[Function]}
-        sort={Object {}}
+        sort={
+          Object {
+            "createdAt": "desc",
+          }
+        }
       />
     </WithStyles(ForwardRef(Paper))>
   </WithStyles(ForwardRef(Grid))>

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -148,7 +148,7 @@ describe('Admin Download Status Table', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('fetches the download items on load', async () => {
+  it('fetches the download items and sorts by download requested time desc on load ', async () => {
     const wrapper = mount(
       <div id="datagateway-download">
         <AdminDownloadStatusTable />
@@ -164,7 +164,7 @@ describe('Admin Download Status Table', () => {
     expect(fetchAdminDownloads).toHaveBeenNthCalledWith(
       1,
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.createdAt) desc, UPPER(download.id) ASC LIMIT 0, 50"
     );
     expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
@@ -194,7 +194,7 @@ describe('Admin Download Status Table', () => {
     expect(fetchAdminDownloads).toHaveBeenCalledTimes(3);
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.id) ASC LIMIT 5, 5"
+      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.createdAt) desc, UPPER(download.id) ASC LIMIT 5, 5"
     );
     expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
@@ -254,7 +254,7 @@ describe('Admin Download Status Table', () => {
     expect(fetchAdminDownloads).toHaveBeenNthCalledWith(
       3,
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.createdAt) desc, UPPER(download.id) ASC LIMIT 0, 50"
     );
     expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
@@ -267,6 +267,17 @@ describe('Admin Download Status Table', () => {
     );
 
     await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Table is sorted by createdAt desc by default
+    // To keep working test, we will remove all sorts on the table beforehand
+    const createdAtSortLabel = wrapper
+      .find('[role="columnheader"] span[role="button"]')
+      .at(6);
+    await act(async () => {
+      createdAtSortLabel.simulate('click');
       await flushPromises();
       wrapper.update();
     });
@@ -332,6 +343,17 @@ describe('Admin Download Status Table', () => {
     );
 
     await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Table is sorted by createdAt desc by default
+    // To keep working test, we will remove all sorts on the table beforehand
+    const createdAtSortLabel = wrapper
+      .find('[role="columnheader"] span[role="button"]')
+      .at(6);
+    await act(async () => {
+      createdAtSortLabel.simulate('click');
       await flushPromises();
       wrapper.update();
     });
@@ -406,6 +428,17 @@ describe('Admin Download Status Table', () => {
     );
 
     await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Table is sorted by createdAt desc by default
+    // To keep working test, we will remove all sorts on the table beforehand
+    const createdAtSortLabel = wrapper
+      .find('[role="columnheader"] span[role="button"]')
+      .at(6);
+    await act(async () => {
+      createdAtSortLabel.simulate('click');
       await flushPromises();
       wrapper.update();
     });

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -59,7 +59,9 @@ const AdminDownloadStatusTable: React.FC = () => {
   // Load the settings for use
   const settings = React.useContext(DownloadSettingsContext);
   // Sorting columns
-  const [sort, setSort] = React.useState<{ [column: string]: Order }>({});
+  const [sort, setSort] = React.useState<{ [column: string]: Order }>({
+    createdAt: 'desc',
+  });
   const [filters, setFilters] = React.useState<{
     [column: string]:
       | { value?: string | number; type: string }

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -334,6 +334,13 @@ describe('Download Status Table', () => {
       wrapper.update();
     });
 
+    // Table is sorted by createdAt desc by default
+    // To keep working test, we will remove all sorts on the table beforehand
+    const createdAtSortLabel = wrapper
+      .find('[role="columnheader"] span[role="button"]')
+      .at(3);
+    createdAtSortLabel.simulate('click');
+
     const firstNameCell = wrapper.find('[aria-colindex=1]').find('p').first();
 
     // Get the access method sort header.

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -33,7 +33,9 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
   const settings = React.useContext(DownloadSettingsContext);
 
   // Sorting columns
-  const [sort, setSort] = React.useState<{ [column: string]: Order }>({});
+  const [sort, setSort] = React.useState<{ [column: string]: Order }>({
+    createdAt: 'desc',
+  });
   const [filters, setFilters] = React.useState<{
     [column: string]:
       | { value?: string | number; type: string }


### PR DESCRIPTION
## Description
Whenever the user navigates to the download status tables, they are now sorted by download requested time descending. This change affects both user download status table and admin download status tables.

## Testing instructions
Check unit and e2e tests carefully to make sure changes are correct. When trying the changes yourself, navigate back and forth from the download tables with multiple sorts applied to make sure that every navigation back shows the default sort as requested time descending.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #1176