### PR TITLE
Adding alert label if file/size limit exceeded in selections table #1183

### DIFF
--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.17",
     "@types/react": "^17.0.2",

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -85,6 +85,8 @@
     "no_selections": "No data selected. <2>Browse</2> or <6>search</6> for data.",
     "browse_link": "/browse/investigation",
     "search_link": "/search/data",
-    "empty_items_warning": "You have selected some empty items - please remove them to proceed with downloading your selection"
+    "empty_items_error": "You have selected some empty items - please remove them to proceed with downloading your selection",
+    "file_limit_error": "Too many files - you have exceeded limit of {{fileCountMax}} files - please remove some files",
+    "size_limit_error": "Too much data - you have exceeded limit of {{totalSizeMax}} - please remove some files"
   }
 }

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -50,7 +50,7 @@ describe('Download cart table component', () => {
   let cartItems: DownloadCartItem[] = [];
 
   // Create our mocked datagateway-download settings file.
-  const mockedSettings = {
+  let mockedSettings = {
     facilityName: 'LILS',
     apiUrl: 'https://example.com/api',
     downloadApiUrl: 'https://example.com/downloadApi',
@@ -508,5 +508,38 @@ describe('Download cart table component', () => {
         '[aria-label="downloadCart.remove {name:INVESTIGATION 2}"]'
       )
     ).toBe(true);
+  });
+
+  it('displays error alert if file/size limit exceeded', async () => {
+    let wrapper = createWrapper();
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Make sure alerts are not displayed if under the limits
+    expect(wrapper.exists('div#fileLimitAlert')).toBeFalsy();
+    expect(wrapper.exists('div#sizeLimitAlert')).toBeFalsy();
+
+    const oldSettings = mockedSettings;
+    mockedSettings = {
+      ...mockedSettings,
+      fileCountMax: 1,
+      totalSizeMax: 1,
+    };
+
+    wrapper = createWrapper();
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Make sure alerts are displayed if over the limits
+    expect(wrapper.exists('div#fileLimitAlert')).toBeTruthy();
+    expect(wrapper.exists('div#sizeLimitAlert')).toBeTruthy();
+
+    mockedSettings = oldSettings;
   });
 });

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -331,6 +331,7 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
+    expect(wrapper.exists('div#emptyFilesAlert')).toBeTruthy();
     expect(
       wrapper.find('button#downloadCartButton').prop('disabled')
     ).toBeTruthy();
@@ -344,6 +345,7 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
+    expect(wrapper.exists('div#emptyFilesAlert')).toBeTruthy();
     expect(
       wrapper.find('button#downloadCartButton').prop('disabled')
     ).toBeTruthy();
@@ -357,6 +359,7 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
+    expect(wrapper.exists('div#emptyFilesAlert')).toBeFalsy();
     expect(
       wrapper.find('button#downloadCartButton').prop('disabled')
     ).toBeFalsy();
@@ -524,8 +527,7 @@ describe('Download cart table component', () => {
 
     const oldSettings = mockedSettings;
     mockedSettings = {
-      ...mockedSettings,
-      fileCountMax: 1,
+      ...oldSettings,
       totalSizeMax: 1,
     };
 
@@ -536,9 +538,23 @@ describe('Download cart table component', () => {
       wrapper.update();
     });
 
-    // Make sure alerts are displayed if over the limits
-    expect(wrapper.exists('div#fileLimitAlert')).toBeTruthy();
+    // Make sure size limit alert is displayed if over the limit
     expect(wrapper.exists('div#sizeLimitAlert')).toBeTruthy();
+
+    mockedSettings = {
+      ...oldSettings,
+      fileCountMax: 1,
+    };
+
+    wrapper = createWrapper();
+
+    await act(async () => {
+      await flushPromises();
+      wrapper.update();
+    });
+
+    // Make sure file limit alert is displayed if over the limit
+    expect(wrapper.exists('div#fileLimitAlert')).toBeTruthy();
 
     mockedSettings = oldSettings;
   });

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -24,6 +24,7 @@ import {
   CircularProgress,
 } from '@material-ui/core';
 import { RemoveCircle } from '@material-ui/icons';
+import { Alert } from '@material-ui/lab';
 import {
   useCart,
   useRemoveEntityFromCart,
@@ -351,51 +352,83 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
         >
           <Grid
             container
-            item
+            spacing={1}
             justify="flex-end"
             alignItems="center"
             direction="row"
             style={{ marginRight: '1.2em' }}
           >
-            {fileCountsLoading && (
-              <CircularProgress
-                size={15}
-                thickness={7}
-                disableShrink={true}
-                aria-label={t('downloadCart.calculating')}
-              />
-            )}
-            <Typography id="fileCountDisplay" style={{ marginLeft: '4px' }}>
-              {t('downloadCart.number_of_files')}:{' '}
-              {fileCount !== -1
-                ? fileCount
-                : `${t('downloadCart.calculating')}...`}
-              {fileCountMax !== -1 && ` / ${fileCountMax}`}
-            </Typography>
+            <Grid item>
+              {fileCountsLoading && (
+                <CircularProgress
+                  size={15}
+                  thickness={7}
+                  disableShrink={true}
+                  aria-label={t('downloadCart.calculating')}
+                />
+              )}
+              <Typography id="fileCountDisplay" style={{ marginLeft: '4px' }}>
+                {t('downloadCart.number_of_files')}:{' '}
+                {fileCount !== -1
+                  ? fileCount
+                  : `${t('downloadCart.calculating')}...`}
+                {fileCountMax !== -1 && ` / ${fileCountMax}`}
+              </Typography>
+            </Grid>
+            <Grid item>
+              {fileCount > fileCountMax && (
+                <Alert
+                  id="fileLimitAlert"
+                  variant="filled"
+                  severity="error"
+                  icon={false}
+                  style={{ padding: '0px 8px', lineHeight: 0.6 }}
+                >
+                  Too many files - you have exceeded limit of {fileCountMax}{' '}
+                  files - please remove some files
+                </Alert>
+              )}
+            </Grid>
           </Grid>
           <Grid
             container
-            item
+            spacing={1}
             justify="flex-end"
             alignItems="center"
             direction="row"
             style={{ marginRight: '1.2em' }}
           >
-            {sizesLoading && (
-              <CircularProgress
-                size={15}
-                thickness={7}
-                disableShrink={true}
-                aria-label={t('downloadCart.calculating')}
-              />
-            )}
-            <Typography id="totalSizeDisplay" style={{ marginLeft: '4px' }}>
-              {t('downloadCart.total_size')}:{' '}
-              {totalSize !== -1
-                ? formatBytes(totalSize)
-                : `${t('downloadCart.calculating')}...`}
-              {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
-            </Typography>
+            <Grid item>
+              {sizesLoading && (
+                <CircularProgress
+                  size={15}
+                  thickness={7}
+                  disableShrink={true}
+                  aria-label={t('downloadCart.calculating')}
+                />
+              )}
+              <Typography id="totalSizeDisplay" style={{ marginLeft: '4px' }}>
+                {t('downloadCart.total_size')}:{' '}
+                {totalSize !== -1
+                  ? formatBytes(totalSize)
+                  : `${t('downloadCart.calculating')}...`}
+                {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
+              </Typography>
+            </Grid>
+            <Grid item>
+              {totalSize > totalSizeMax && (
+                <Alert
+                  id="sizeLimitAlert"
+                  variant="filled"
+                  severity="error"
+                  icon={false}
+                  style={{ padding: '0px 8px', lineHeight: 0.6 }}
+                >
+                  Too much data - you have exceeded limit of{' '}
+                  {formatBytes(totalSizeMax)} - please remove some files
+                </Alert>
+              )}
+            </Grid>
           </Grid>
           <Grid
             container

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -327,7 +327,11 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             className="tour-download-results"
             style={{
               height: `calc(100vh - 64px - 48px - 48px - 48px - 3rem${
-                emptyItems ? ' - 1rem' : ''
+                emptyItems ||
+                fileCount > fileCountMax ||
+                totalSize > totalSizeMax
+                  ? ' - 2rem'
+                  : ''
               } - (1.75 * 0.875rem + 12px)`,
               minHeight: 230,
               overflowX: 'auto',
@@ -352,83 +356,27 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
         >
           <Grid
             container
-            spacing={1}
+            item
             justify="flex-end"
             alignItems="center"
             direction="row"
             style={{ marginRight: '1.2em' }}
           >
-            <Grid item>
-              {fileCountsLoading && (
-                <CircularProgress
-                  size={15}
-                  thickness={7}
-                  disableShrink={true}
-                  aria-label={t('downloadCart.calculating')}
-                />
-              )}
-              <Typography id="fileCountDisplay" style={{ marginLeft: '4px' }}>
-                {t('downloadCart.number_of_files')}:{' '}
-                {fileCount !== -1
-                  ? fileCount
-                  : `${t('downloadCart.calculating')}...`}
-                {fileCountMax !== -1 && ` / ${fileCountMax}`}
-              </Typography>
-            </Grid>
-            {fileCount > fileCountMax && (
-              <Grid item>
-                <Alert
-                  id="fileLimitAlert"
-                  variant="filled"
-                  severity="error"
-                  icon={false}
-                  style={{ padding: '0px 8px', lineHeight: 0.6 }}
-                >
-                  Too many files - you have exceeded limit of {fileCountMax}{' '}
-                  files - please remove some files
-                </Alert>
-              </Grid>
+            {fileCountsLoading && (
+              <CircularProgress
+                size={15}
+                thickness={7}
+                disableShrink={true}
+                aria-label={t('downloadCart.calculating')}
+              />
             )}
-          </Grid>
-          <Grid
-            container
-            spacing={1}
-            justify="flex-end"
-            alignItems="center"
-            direction="row"
-            style={{ marginRight: '1.2em' }}
-          >
-            <Grid item>
-              {sizesLoading && (
-                <CircularProgress
-                  size={15}
-                  thickness={7}
-                  disableShrink={true}
-                  aria-label={t('downloadCart.calculating')}
-                />
-              )}
-              <Typography id="totalSizeDisplay" style={{ marginLeft: '4px' }}>
-                {t('downloadCart.total_size')}:{' '}
-                {totalSize !== -1
-                  ? formatBytes(totalSize)
-                  : `${t('downloadCart.calculating')}...`}
-                {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
-              </Typography>
-            </Grid>
-            {totalSize > totalSizeMax && (
-              <Grid item>
-                <Alert
-                  id="sizeLimitAlert"
-                  variant="filled"
-                  severity="error"
-                  icon={false}
-                  style={{ padding: '0px 8px', lineHeight: 0.6 }}
-                >
-                  Too much data - you have exceeded limit of{' '}
-                  {formatBytes(totalSizeMax)} - please remove some files
-                </Alert>
-              </Grid>
-            )}
+            <Typography id="fileCountDisplay" style={{ marginLeft: '4px' }}>
+              {t('downloadCart.number_of_files')}:{' '}
+              {fileCount !== -1
+                ? fileCount
+                : `${t('downloadCart.calculating')}...`}
+              {fileCountMax !== -1 && ` / ${fileCountMax}`}
+            </Typography>
           </Grid>
           <Grid
             container
@@ -438,8 +386,79 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             direction="row"
             style={{ marginRight: '1.2em' }}
           >
-            {emptyItems && (
-              <Typography>{t('downloadCart.empty_items_warning')}</Typography>
+            {sizesLoading && (
+              <CircularProgress
+                size={15}
+                thickness={7}
+                disableShrink={true}
+                aria-label={t('downloadCart.calculating')}
+              />
+            )}
+            <Typography id="totalSizeDisplay" style={{ marginLeft: '4px' }}>
+              {t('downloadCart.total_size')}:{' '}
+              {totalSize !== -1
+                ? formatBytes(totalSize)
+                : `${t('downloadCart.calculating')}...`}
+              {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
+            </Typography>
+          </Grid>
+          <Grid
+            container
+            item
+            justify="flex-end"
+            alignItems="center"
+            direction="row"
+            style={{ marginRight: '1.2em' }}
+          >
+            {emptyItems ? (
+              <Alert
+                id="emptyFilesAlert"
+                variant="filled"
+                severity="error"
+                style={{
+                  padding: '0px 8px',
+                  lineHeight: 0.6,
+                  alignItems: 'center',
+                }}
+              >
+                <Typography>{t('downloadCart.empty_items_error')}</Typography>
+              </Alert>
+            ) : totalSize > totalSizeMax ? (
+              <Alert
+                id="sizeLimitAlert"
+                variant="filled"
+                severity="error"
+                style={{
+                  padding: '0px 8px',
+                  lineHeight: 0.6,
+                  alignItems: 'center',
+                }}
+              >
+                <Typography>
+                  {t('downloadCart.size_limit_error', {
+                    totalSizeMax: formatBytes(totalSizeMax),
+                  })}
+                </Typography>
+              </Alert>
+            ) : (
+              fileCount > fileCountMax && (
+                <Alert
+                  id="fileLimitAlert"
+                  variant="filled"
+                  severity="error"
+                  style={{
+                    padding: '0px 8px',
+                    lineHeight: 0.6,
+                    alignItems: 'center',
+                  }}
+                >
+                  <Typography>
+                    {t('downloadCart.file_limit_error', {
+                      fileCountMax: fileCountMax,
+                    })}
+                  </Typography>
+                </Alert>
+              )
             )}
           </Grid>
           <Grid

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -375,8 +375,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 {fileCountMax !== -1 && ` / ${fileCountMax}`}
               </Typography>
             </Grid>
-            <Grid item>
-              {fileCount > fileCountMax && (
+            {fileCount > fileCountMax && (
+              <Grid item>
                 <Alert
                   id="fileLimitAlert"
                   variant="filled"
@@ -387,8 +387,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                   Too many files - you have exceeded limit of {fileCountMax}{' '}
                   files - please remove some files
                 </Alert>
-              )}
-            </Grid>
+              </Grid>
+            )}
           </Grid>
           <Grid
             container
@@ -415,8 +415,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
               </Typography>
             </Grid>
-            <Grid item>
-              {totalSize > totalSizeMax && (
+            {totalSize > totalSizeMax && (
+              <Grid item>
                 <Alert
                   id="sizeLimitAlert"
                   variant="filled"
@@ -427,8 +427,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                   Too much data - you have exceeded limit of{' '}
                   {formatBytes(totalSizeMax)} - please remove some files
                 </Alert>
-              )}
-            </Grid>
+              </Grid>
+            )}
           </Grid>
           <Grid
             container

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -357,108 +357,114 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
           <Grid
             container
             item
+            spacing={1}
             justify="flex-end"
             alignItems="center"
             direction="row"
             style={{ marginRight: '1.2em' }}
           >
-            {fileCountsLoading && (
-              <CircularProgress
-                size={15}
-                thickness={7}
-                disableShrink={true}
-                aria-label={t('downloadCart.calculating')}
-              />
-            )}
-            <Typography id="fileCountDisplay" style={{ marginLeft: '4px' }}>
-              {t('downloadCart.number_of_files')}:{' '}
-              {fileCount !== -1
-                ? fileCount
-                : `${t('downloadCart.calculating')}...`}
-              {fileCountMax !== -1 && ` / ${fileCountMax}`}
-            </Typography>
-          </Grid>
-          <Grid
-            container
-            item
-            justify="flex-end"
-            alignItems="center"
-            direction="row"
-            style={{ marginRight: '1.2em' }}
-          >
-            {sizesLoading && (
-              <CircularProgress
-                size={15}
-                thickness={7}
-                disableShrink={true}
-                aria-label={t('downloadCart.calculating')}
-              />
-            )}
-            <Typography id="totalSizeDisplay" style={{ marginLeft: '4px' }}>
-              {t('downloadCart.total_size')}:{' '}
-              {totalSize !== -1
-                ? formatBytes(totalSize)
-                : `${t('downloadCart.calculating')}...`}
-              {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
-            </Typography>
-          </Grid>
-          <Grid
-            container
-            item
-            justify="flex-end"
-            alignItems="center"
-            direction="row"
-            style={{ marginRight: '1.2em' }}
-          >
-            {emptyItems ? (
-              <Alert
-                id="emptyFilesAlert"
-                variant="filled"
-                severity="error"
-                style={{
-                  padding: '0px 8px',
-                  lineHeight: 0.6,
-                  alignItems: 'center',
-                }}
-              >
-                <Typography>{t('downloadCart.empty_items_error')}</Typography>
-              </Alert>
-            ) : totalSize > totalSizeMax ? (
-              <Alert
-                id="sizeLimitAlert"
-                variant="filled"
-                severity="error"
-                style={{
-                  padding: '0px 8px',
-                  lineHeight: 0.6,
-                  alignItems: 'center',
-                }}
-              >
-                <Typography>
-                  {t('downloadCart.size_limit_error', {
-                    totalSizeMax: formatBytes(totalSizeMax),
-                  })}
-                </Typography>
-              </Alert>
-            ) : (
-              fileCount > fileCountMax && (
+            <Grid item>
+              {fileCountsLoading && (
+                <CircularProgress
+                  size={15}
+                  thickness={7}
+                  disableShrink={true}
+                  aria-label={t('downloadCart.calculating')}
+                />
+              )}
+              <Typography id="fileCountDisplay" style={{ marginLeft: '4px' }}>
+                {t('downloadCart.number_of_files')}:{' '}
+                {fileCount !== -1
+                  ? fileCount
+                  : `${t('downloadCart.calculating')}...`}
+                {fileCountMax !== -1 && ` / ${fileCountMax}`}
+              </Typography>
+            </Grid>
+            <Grid item>
+              {fileCount > fileCountMax && (
                 <Alert
                   id="fileLimitAlert"
                   variant="filled"
                   severity="error"
+                  icon={false}
                   style={{
                     padding: '0px 8px',
                     lineHeight: 0.6,
-                    alignItems: 'center',
                   }}
                 >
-                  <Typography>
-                    {t('downloadCart.file_limit_error', {
-                      fileCountMax: fileCountMax,
-                    })}
-                  </Typography>
+                  {t('downloadCart.file_limit_error', {
+                    fileCountMax: fileCountMax,
+                  })}
                 </Alert>
-              )
+              )}
+            </Grid>
+          </Grid>
+          <Grid
+            container
+            item
+            spacing={1}
+            justify="flex-end"
+            alignItems="center"
+            direction="row"
+            style={{ marginRight: '1.2em' }}
+          >
+            <Grid item>
+              {sizesLoading && (
+                <CircularProgress
+                  size={15}
+                  thickness={7}
+                  disableShrink={true}
+                  aria-label={t('downloadCart.calculating')}
+                />
+              )}
+              <Typography id="totalSizeDisplay" style={{ marginLeft: '4px' }}>
+                {t('downloadCart.total_size')}:{' '}
+                {totalSize !== -1
+                  ? formatBytes(totalSize)
+                  : `${t('downloadCart.calculating')}...`}
+                {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
+              </Typography>
+            </Grid>
+            <Grid item>
+              {totalSize > totalSizeMax && (
+                <Alert
+                  id="sizeLimitAlert"
+                  variant="filled"
+                  severity="error"
+                  icon={false}
+                  style={{
+                    padding: '0px 8px',
+                    lineHeight: 0.6,
+                  }}
+                >
+                  {t('downloadCart.size_limit_error', {
+                    totalSizeMax: formatBytes(totalSizeMax),
+                  })}
+                </Alert>
+              )}
+            </Grid>
+          </Grid>
+          <Grid
+            container
+            item
+            justify="flex-end"
+            alignItems="center"
+            direction="row"
+            style={{ marginRight: '1.2em' }}
+          >
+            {emptyItems && (
+              <Alert
+                id="emptyFilesAlert"
+                variant="filled"
+                severity="error"
+                icon={false}
+                style={{
+                  padding: '0px 8px',
+                  lineHeight: 0.6,
+                }}
+              >
+                {t('downloadCart.empty_items_error')}
+              </Alert>
             )}
           </Grid>
           <Grid


### PR DESCRIPTION
## Description
This implementation is designed to mimic Topcat as much as possible.

Here is Topcat:
![160371182-998c26c0-8e54-410b-923e-3589b8358880](https://user-images.githubusercontent.com/71134574/164243162-be8993f0-91aa-4395-8de3-c0f8553896cb.png)

~~And here is DataGateway with this feature:~~
![Capture](https://user-images.githubusercontent.com/71134574/164243085-41db1616-188b-4f0b-9f01-74a78e8875a8.PNG)

Later amendment - this is the updated screenshot
![image](https://user-images.githubusercontent.com/71134574/164465491-6aa542c3-cad7-4e3b-956a-15e02475172b.png)

Both the text and the label are open to change if we feel its too wordy, etc. Alternatively, if we don't like the design at all, we can have an error notification appear instead. I wasn't too keen on this idea as it may cause notifications to appear too frequently if the user is excessively amending the selections table. I was also more of a fan of the error message appearing next to the offending item so the user can more easily tell what's wrong.

## Testing instructions
Best run through SciGateway so the selections can be customised. To make things easier, change the `fileCountMax` and `totalSizeMax` values in download settings to much smaller values so that the labels can be displayed more easily. Try adding and removing things from the selections - the labels should appear and disappear as necessary.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1183