### PR TITLE
Preventing download of empty files #1195

### DIFF
--- a/packages/datagateway-common/src/views/downloadButton.component.test.tsx
+++ b/packages/datagateway-common/src/views/downloadButton.component.test.tsx
@@ -60,28 +60,30 @@ describe('Generic download button', () => {
   });
 
   it('renders correctly', () => {
-    const textButtonWrapper = createWrapper({
+    const props: DownloadButtonProps = {
       entityType: 'datafile',
       entityName: 'test',
       entityId: 1,
-    });
+      entitySize: 1,
+    };
+    const textButtonWrapper = createWrapper(props);
     expect(textButtonWrapper.find('button').text()).toBe('buttons.download');
 
     const iconButtonWrapper = createWrapper({
-      entityType: 'datafile',
-      entityName: 'test',
-      entityId: 1,
+      ...props,
       variant: 'icon',
     });
     expect(iconButtonWrapper.find('button').text()).toBe('');
   });
 
   it('calls download investigation on button press for both text and icon buttons', () => {
-    let wrapper = createWrapper({
+    const props: DownloadButtonProps = {
       entityType: 'investigation',
       entityName: 'test',
       entityId: 1,
-    });
+      entitySize: 1,
+    };
+    let wrapper = createWrapper(props);
 
     wrapper.find('#download-btn-1').first().simulate('click');
     expect(downloadInvestigation).toHaveBeenCalledWith(
@@ -93,9 +95,7 @@ describe('Generic download button', () => {
     jest.clearAllMocks();
 
     wrapper = createWrapper({
-      entityType: 'investigation',
-      entityName: 'test',
-      entityId: 1,
+      ...props,
       variant: 'icon',
     });
 
@@ -108,11 +108,13 @@ describe('Generic download button', () => {
   });
 
   it('calls download dataset on button press for both text and icon buttons', () => {
-    let wrapper = createWrapper({
+    const props: DownloadButtonProps = {
       entityType: 'dataset',
       entityName: 'test',
       entityId: 1,
-    });
+      entitySize: 1,
+    };
+    let wrapper = createWrapper(props);
 
     wrapper.find('#download-btn-1').first().simulate('click');
     expect(downloadDataset).toHaveBeenCalledWith(
@@ -124,9 +126,7 @@ describe('Generic download button', () => {
     jest.clearAllMocks();
 
     wrapper = createWrapper({
-      entityType: 'dataset',
-      entityName: 'test',
-      entityId: 1,
+      ...props,
       variant: 'icon',
     });
 
@@ -139,11 +139,13 @@ describe('Generic download button', () => {
   });
 
   it('calls download datafile on button press for both text and icon buttons', () => {
-    let wrapper = createWrapper({
+    const props: DownloadButtonProps = {
       entityType: 'datafile',
       entityName: 'test',
       entityId: 1,
-    });
+      entitySize: 1,
+    };
+    let wrapper = createWrapper(props);
 
     wrapper.find('#download-btn-1').first().simulate('click');
     expect(downloadDatafile).toHaveBeenCalledWith(
@@ -155,14 +157,12 @@ describe('Generic download button', () => {
     jest.clearAllMocks();
 
     wrapper = createWrapper({
-      entityType: 'dataset',
-      entityName: 'test',
-      entityId: 1,
+      ...props,
       variant: 'icon',
     });
 
     wrapper.find('#download-btn-1').first().simulate('click');
-    expect(downloadDataset).toHaveBeenCalledWith(
+    expect(downloadDatafile).toHaveBeenCalledWith(
       'https://www.example.com/ids',
       1,
       'test'
@@ -174,8 +174,34 @@ describe('Generic download button', () => {
       entityType: 'datafile',
       entityName: undefined,
       entityId: 1,
+      entitySize: 1,
     });
 
     expect(wrapper.find(DownloadButton).children().length).toBe(0);
+  });
+
+  it('renders a tooltip and disabled button if entity size is zero', () => {
+    const props: DownloadButtonProps = {
+      entityType: 'datafile',
+      entityName: 'test',
+      entityId: 1,
+      entitySize: 0,
+    };
+    let wrapper = createWrapper(props);
+
+    expect(wrapper.exists('#tooltip-1'));
+    wrapper.find('#download-btn-1').first().simulate('click');
+    expect(downloadDatafile).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    wrapper = createWrapper({
+      ...props,
+      variant: 'icon',
+    });
+
+    expect(wrapper.exists('#tooltip-1'));
+    wrapper.find('#download-btn-1').first().simulate('click');
+    expect(downloadDatafile).not.toHaveBeenCalled();
   });
 });

--- a/packages/datagateway-common/src/views/downloadButton.component.tsx
+++ b/packages/datagateway-common/src/views/downloadButton.component.tsx
@@ -61,6 +61,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
             title={
               <Typography>{t('buttons.tooltip.unable_to_download')}</Typography>
             }
+            id={`tooltip-${entityId}`}
             placement="left"
             arrow
             classes={classes}
@@ -103,6 +104,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
             title={
               <Typography>{t('buttons.tooltip.unable_to_download')}</Typography>
             }
+            id={`tooltip-${entityId}`}
             placement="bottom"
             arrow
             classes={classes}

--- a/packages/datagateway-common/src/views/downloadButton.component.tsx
+++ b/packages/datagateway-common/src/views/downloadButton.component.tsx
@@ -1,4 +1,5 @@
-import { Button, IconButton } from '@material-ui/core';
+import { Button, IconButton, Tooltip, Typography } from '@material-ui/core';
+import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import { GetApp } from '@material-ui/icons';
 import { downloadDatafile } from '../api/datafiles';
 import { downloadDataset } from '../api/datasets';
@@ -8,17 +9,32 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+const useStylesTooltip = makeStyles((theme: Theme) =>
+  createStyles({
+    tooltip: {
+      backgroundColor: theme.palette.common.black,
+      fontSize: '0.875rem',
+    },
+    arrow: {
+      color: theme.palette.common.black,
+    },
+  })
+);
+
 export interface DownloadButtonProps {
   entityType: 'investigation' | 'dataset' | 'datafile';
   entityId: number;
   entityName: string | undefined;
+  entitySize: number;
   variant?: 'text' | 'outlined' | 'contained' | 'icon';
 }
 
 const DownloadButton: React.FC<DownloadButtonProps> = (
   props: DownloadButtonProps
 ) => {
-  const { entityType, entityId, entityName, variant } = props;
+  const { entityType, entityId, entityName, variant, entitySize } = props;
+  const { ...classes } = useStylesTooltip();
+
   const [t] = useTranslation();
   const idsUrl = useSelector((state: StateType) => state.dgcommon.urls.idsUrl);
 
@@ -39,32 +55,89 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
   if (!entityName) return null;
   if (variant === 'icon') {
     return (
-      <IconButton
-        id={`download-btn-${entityId}`}
-        aria-label={t('buttons.download')}
-        size={'small'}
-        onClick={() => {
-          downloadData(entityType, entityId, entityName);
-        }}
-        className="tour-dataview-download"
-      >
-        <GetApp />
-      </IconButton>
+      <div>
+        {entitySize <= 0 ? (
+          <Tooltip
+            title={
+              <Typography>{t('buttons.tooltip.unable_to_download')}</Typography>
+            }
+            placement="left"
+            arrow
+            classes={classes}
+          >
+            <span>
+              <IconButton
+                id={`download-btn-${entityId}`}
+                aria-label={t('buttons.download')}
+                size={'small'}
+                onClick={() => {
+                  downloadData(entityType, entityId, entityName);
+                }}
+                className="tour-dataview-download"
+                disabled
+              >
+                <GetApp />
+              </IconButton>
+            </span>
+          </Tooltip>
+        ) : (
+          <IconButton
+            id={`download-btn-${entityId}`}
+            aria-label={t('buttons.download')}
+            size={'small'}
+            onClick={() => {
+              downloadData(entityType, entityId, entityName);
+            }}
+            className="tour-dataview-download"
+          >
+            <GetApp />
+          </IconButton>
+        )}
+      </div>
     );
   } else {
     return (
-      <Button
-        id={`download-btn-${entityId}`}
-        aria-label="Download"
-        variant={variant ?? 'contained'}
-        color="primary"
-        startIcon={<GetApp />}
-        disableElevation
-        onClick={() => downloadData(entityType, entityId, entityName)}
-        className="tour-dataview-download"
-      >
-        {t('buttons.download')}
-      </Button>
+      <div>
+        {entitySize <= 0 ? (
+          <Tooltip
+            title={
+              <Typography>{t('buttons.tooltip.unable_to_download')}</Typography>
+            }
+            placement="bottom"
+            arrow
+            classes={classes}
+          >
+            <span>
+              <Button
+                id={`download-btn-${entityId}`}
+                aria-label="Download"
+                variant={variant ?? 'contained'}
+                color="primary"
+                startIcon={<GetApp />}
+                disableElevation
+                onClick={() => downloadData(entityType, entityId, entityName)}
+                className="tour-dataview-download"
+                disabled
+              >
+                {t('buttons.download')}
+              </Button>
+            </span>
+          </Tooltip>
+        ) : (
+          <Button
+            id={`download-btn-${entityId}`}
+            aria-label="Download"
+            variant={variant ?? 'contained'}
+            color="primary"
+            startIcon={<GetApp />}
+            disableElevation
+            onClick={() => downloadData(entityType, entityId, entityName)}
+            className="tour-dataview-download"
+          >
+            {t('buttons.download')}
+          </Button>
+        )}
+      </div>
     );
   }
 };

--- a/packages/datagateway-common/src/views/downloadButton.component.tsx
+++ b/packages/datagateway-common/src/views/downloadButton.component.tsx
@@ -71,9 +71,6 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
                 id={`download-btn-${entityId}`}
                 aria-label={t('buttons.download')}
                 size={'small'}
-                onClick={() => {
-                  downloadData(entityType, entityId, entityName);
-                }}
                 className="tour-dataview-download"
                 disabled
               >
@@ -117,7 +114,6 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
                 color="primary"
                 startIcon={<GetApp />}
                 disableElevation
-                onClick={() => downloadData(entityType, entityId, entityName)}
                 className="tour-dataview-download"
                 disabled
               >

--- a/packages/datagateway-common/src/views/downloadButton.component.tsx
+++ b/packages/datagateway-common/src/views/downloadButton.component.tsx
@@ -47,7 +47,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
       downloadInvestigation(idsUrl, entityId, entityName);
     } else if (entityType === 'dataset') {
       downloadDataset(idsUrl, entityId, entityName);
-    } else if (entityType === 'datafile') {
+    } else {
       downloadDatafile(idsUrl, entityId, entityName);
     }
   };
@@ -59,7 +59,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
         {entitySize <= 0 ? (
           <Tooltip
             title={
-              <Typography>{t('buttons.tooltip.unable_to_download')}</Typography>
+              <Typography>{t('buttons.unable_to_download_tooltip')}</Typography>
             }
             id={`tooltip-${entityId}`}
             placement="left"
@@ -99,7 +99,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = (
         {entitySize <= 0 ? (
           <Tooltip
             title={
-              <Typography>{t('buttons.tooltip.unable_to_download')}</Typography>
+              <Typography>{t('buttons.unable_to_download_tooltip')}</Typography>
             }
             id={`tooltip-${entityId}`}
             placement="bottom"

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -211,7 +211,10 @@
   "buttons": {
     "add_to_cart": "Add to selection",
     "remove_from_cart": "Remove from selection",
-    "download": "Download"
+    "download": "Download",
+    "tooltip": {
+      "unable_to_download": "Unable to download - this file is empty"
+    }
   },
   "advanced_filters": {
     "show": "Show Advanced Filters",

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -212,9 +212,7 @@
     "add_to_cart": "Add to selection",
     "remove_from_cart": "Remove from selection",
     "download": "Download",
-    "tooltip": {
-      "unable_to_download": "Unable to download - this file is empty"
-    }
+    "unable_to_download_tooltip": "Unable to download - this item is empty"
   },
   "advanced_filters": {
     "show": "Show Advanced Filters",

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
@@ -159,11 +159,14 @@ const ISISDatasetsCardView = (
             entityType="dataset"
             entityId={dataset.id}
             entityName={dataset.name}
+            entitySize={
+              data ? sizeQueries[data.indexOf(dataset)]?.data ?? -1 : -1
+            }
           />
         </div>
       ),
     ],
-    [classes.actionButtons, data]
+    [classes.actionButtons, data, sizeQueries]
   );
 
   const moreInformation = React.useCallback(

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -205,11 +205,14 @@ const ISISInvestigationsCardView = (
             entityType="investigation"
             entityId={investigation.id}
             entityName={investigation.name}
+            entitySize={
+              data ? sizeQueries[data.indexOf(investigation)]?.data ?? -1 : -1
+            }
           />
         </div>
       ),
     ],
-    [classes.actionButtons, data]
+    [classes.actionButtons, data, sizeQueries]
   );
 
   const moreInformation = React.useCallback(

--- a/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisDatasetLanding.component.tsx
@@ -247,11 +247,14 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                 allIds={[parseInt(datasetId)]}
                 entityId={parseInt(datasetId)}
               />
-              <DownloadButton
-                entityType="dataset"
-                entityId={parseInt(datasetId)}
-                entityName={data?.name ?? ''}
-              />
+              <div style={{ margin: 'auto' }}>
+                <DownloadButton
+                  entityType="dataset"
+                  entityId={parseInt(datasetId)}
+                  entityName={data?.name ?? ''}
+                  entitySize={sizeQueries[0]?.data ?? -1}
+                />
+              </div>
             </div>
           </Grid>
         </Grid>

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -520,11 +520,14 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
                     allIds={[dataset.id]}
                     entityId={dataset.id}
                   />
-                  <DownloadButton
-                    entityType="dataset"
-                    entityId={dataset.id}
-                    entityName={dataset.name}
-                  />
+                  <div style={{ margin: 'auto' }}>
+                    <DownloadButton
+                      entityType="dataset"
+                      entityId={dataset.id}
+                      entityName={dataset.name}
+                      entitySize={sizeQueries[0]?.data ?? -1}
+                    />
+                  </div>
                 </div>
               </div>
             ))}

--- a/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datafileTable.component.tsx
@@ -180,6 +180,7 @@ const DatafileTable = (props: DatafileTableProps): React.ReactElement => {
             entityId={rowData.id}
             entityName={(rowData as Datafile).location}
             variant="icon"
+            entitySize={(rowData as Datafile).fileSize ?? -1}
           />
         ),
       ]}

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -184,6 +184,7 @@ const ISISDatafilesTable = (
             entityId={rowData.id}
             entityName={(rowData as Datafile).location}
             variant="icon"
+            entitySize={(rowData as Datafile).fileSize ?? -1}
           />
         ),
       ]}

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -205,6 +205,10 @@ const ISISDatasetsTable = (
             entityId={rowData.id}
             entityName={rowData.name}
             variant="icon"
+            entitySize={
+              sizeQueries[aggregatedData.indexOf(rowData as Dataset)]?.data ??
+              -1
+            }
           />
         ),
       ]}

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -242,6 +242,10 @@ const ISISInvestigationsTable = (
             entityId={rowData.id}
             entityName={rowData.name}
             variant="icon"
+            entitySize={
+              sizeQueries[aggregatedData.indexOf(rowData as Investigation)]
+                ?.data ?? -1
+            }
           />
         ),
       ]}

--- a/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
+++ b/packages/datagateway-search/cypress/integration/searchPageContainer.spec.ts
@@ -214,7 +214,11 @@ describe('SearchPageContainer Component', () => {
 
       cy.get('select[id="select-max-results"]', {
         timeout: 10000,
-      }).select('20');
+      })
+        .select('20')
+        .wait(['@investigations', '@investigations', '@investigationsCount'], {
+          timeout: 10000,
+        });
       cy.get('[aria-label="card-buttons"]', { timeout: 10000 }).should(
         'have.length',
         20
@@ -222,7 +226,11 @@ describe('SearchPageContainer Component', () => {
 
       cy.get('select[id="select-max-results"]', {
         timeout: 10000,
-      }).select('30');
+      })
+        .select('30')
+        .wait(['@investigations', '@investigations', '@investigationsCount'], {
+          timeout: 10000,
+        });
       cy.get('[aria-label="card-buttons"]', { timeout: 10000 }).should(
         'have.length',
         30

--- a/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/datasetSearchCardView.component.tsx
@@ -364,6 +364,9 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
                   entityType="dataset"
                   entityId={dataset.id}
                   entityName={dataset.name}
+                  entitySize={
+                    data ? sizeQueries[data.indexOf(dataset)]?.data ?? -1 : -1
+                  }
                 />
               </div>
             ),
@@ -378,7 +381,7 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
             ),
           ],
 
-    [classes.actionButtons, data, hierarchy]
+    [classes.actionButtons, data, hierarchy, sizeQueries]
   );
 
   return (

--- a/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
+++ b/packages/datagateway-search/src/card/investigationSearchCardView.component.tsx
@@ -365,12 +365,17 @@ const InvestigationCardView = (
                   entityType="investigation"
                   entityId={investigation.id}
                   entityName={investigation.name}
+                  entitySize={
+                    data
+                      ? sizeQueries[data.indexOf(investigation)]?.data ?? -1
+                      : -1
+                  }
                 />
               </div>
             ),
           ]
         : [],
-    [classes.actionButtons, data, hierarchy]
+    [classes.actionButtons, data, hierarchy, sizeQueries]
   );
 
   return (


### PR DESCRIPTION
## Description
This requires passing the size of the relevant entity to the download button. In table and card view, we make use of the `sizeQueries` array for this, disabling the download button until we can confirm the entity size is greater than zero (realistically, this happens quickly enough that the user does not notice). If the button is disabled, the user can move their mouse over the button to show a tooltip explaining the file is empty and thus cannot be downloaded.

## Testing instructions
This should be tested with SciGateway and both Dataview and Search. The download button appears as both a box and an icon in many places so it's important to test it enables and disables properly everywhere. If you're hooked up to the production IDS, you'll get a variety of empty and non-empty sets of data to properly test this. Make sure that every time the button is disabled, a tooltip displays over it. Also check to see how this all looks in light/dark mode and give any thoughts on that too if you have any.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1195