### PR TITLE
Docker build workflow should only run on pushes to K8S branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feature/adding-docker-file
+      - k8s-deployment
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
## Description
Modifies the `docker-build.yml` workflow file so that the workflow is only triggered when commits are pushed to the `k8s-deployment` branch. This branch was initially named `feature/k8s-deployment` but was renamed to `k8s-deployment` as part of this issue to keep things consistent with the other repos in the SciGateway/DataGateway stack.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Docker build workflow runs when commits are pushed to the `k8s-deployment` branch (This can only be tested once this PR is merged in the `k8s-deployment` branch)

## Agile board tracking
closes #1236 