### PR TITLE
Set React production variables for plugin build paths in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN yarn set version 1.22
 COPY . .
 ARG HOST_URL
 # Set the React production variables which hold reference to the paths of the plugin builds
-RUN echo "REACT_APP_DATAVIEW_BUILD_DIRECTORY=$HOST_URL:5001/" > packages/datagateway-dataview/.env.production
-RUN echo "REACT_APP_DOWNLOAD_BUILD_DIRECTORY=$HOST_URL:5002/" > packages/datagateway-download/.env.production
-RUN echo "REACT_APP_SEARCH_BUILD_DIRECTORY=$HOST_URL:5003/" > packages/datagateway-search/.env.production
+RUN echo "REACT_APP_DATAVIEW_BUILD_DIRECTORY=$HOST_URL/datagateway-dataview/" > packages/datagateway-dataview/.env.production
+RUN echo "REACT_APP_DOWNLOAD_BUILD_DIRECTORY=$HOST_URL/datagateway-download/" > packages/datagateway-download/.env.production
+RUN echo "REACT_APP_SEARCH_BUILD_DIRECTORY=$HOST_URL/datagateway-search/" > packages/datagateway-search/.env.production
 
 # Install dependancies
 RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,14 @@ ENV PATH /datagateway/node_modules/.bin:$PATH
 # TODO - Use Yarn 2 when project is upgraded
 RUN yarn set version 1.22
 
-# Install dependancies
 COPY . .
+ARG HOST_URL
+# Set the React production variables which hold reference to the paths of the plugin builds
+RUN echo "REACT_APP_DATAVIEW_BUILD_DIRECTORY=$HOST_URL:5001/" > packages/datagateway-dataview/.env.production
+RUN echo "REACT_APP_DOWNLOAD_BUILD_DIRECTORY=$HOST_URL:5002/" > packages/datagateway-download/.env.production
+RUN echo "REACT_APP_SEARCH_BUILD_DIRECTORY=$HOST_URL:5003/" > packages/datagateway-search/.env.production
+
+# Install dependancies
 RUN yarn install
 RUN yarn build
 


### PR DESCRIPTION
## Description
The `main.js` files in each of the plugins are holding a reference to the settings files and by default they are hardcoded to be a local path. The changes in this PR modify the `Dockerfile` so that it sets the `REACT_APP_DATAVIEW_BUILD_DIRECTORY`, `REACT_APP_DOWNLOAD_BUILD_DIRECTORY` and `REACT_APP_SEARCH_BUILD_DIRECTORY` React production build environment variables. These variables allow for the `main.js` plugin files to reference the plugin settings files from:
- `http://<HOST_URL>/datagateway-dataview/datagateway-dataview-settings.json`
- `http://<HOST_URL>/datagateway-download/datagateway-download-settings.json`
- `http://<HOST_URL>/datagateway-search/datagateway-search-settings.json`

where `<HOST_URL>` is the host URL that is specified in the `HOST_URL` `datagateway` service `ARG` build variable in the `docker-compose.yml` file.

## Testing instructions
Checkout the changes from the `implement-reverse-proxy` branch in the `icat-k8s-deployment-config` repo and build and start a datagateway container to be able to carry out the tests.
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] The `main.js` file of the `datagateway-dataview` plugin references its settings file from `http://<HOST_URL>/datagateway-dataview/datagateway-dataview-settings.json` where `<HOST_URL>` is the host URL that you specify in the `HOST_URL` `datagateway` service `ARG` build variable in the `docker-compose.yml` file.
- [ ] The `main.js` file of the `datagateway-download` plugin references its settings file from `http://<HOST_URL>/datagateway-download/datagateway-download-settings.json` where `<HOST_URL>` is the host URL that you specify in the `HOST_URL` `datagateway` service `ARG` build variable in the `docker-compose.yml` file.
 - [ ] The `main.js` file of the `datagateway-search` plugin references its settings file from `http://<HOST_URL>/datagateway-search/datagateway-search-settings.json` where `<HOST_URL>` is the host URL that you specify in the `HOST_URL` `datagateway` service `ARG` build variable in the `docker-compose.yml` file.

## Agile board tracking
closes #1240 