### PR TITLE
Customising notification message if it concerns session expiry #1209

### DIFF
--- a/packages/datagateway-common/src/handleICATError.test.ts
+++ b/packages/datagateway-common/src/handleICATError.test.ts
@@ -134,4 +134,33 @@ describe('handleICATError', () => {
       type: InvalidateTokenType,
     });
   });
+
+  it('customises notification message to SciGateway on TopCAT authentication error', () => {
+    error.response.status = 403;
+    handleICATError(error);
+
+    expect(events.length).toBe(2);
+    expect(events[0].detail).toEqual({
+      type: NotificationType,
+      payload: {
+        severity: 'error',
+        message: 'Your session has expired, please reload the page',
+      },
+    });
+
+    events = [];
+    error.response.data = {
+      message: 'Unable to find user by sessionid: null',
+    };
+    handleICATError(error);
+
+    expect(events.length).toBe(2);
+    expect(events[0].detail).toEqual({
+      type: NotificationType,
+      payload: {
+        severity: 'error',
+        message: 'Your session has expired, please reload the page',
+      },
+    });
+  });
 });

--- a/packages/datagateway-common/src/handleICATError.ts
+++ b/packages/datagateway-common/src/handleICATError.ts
@@ -7,33 +7,35 @@ import {
 import { MicroFrontendId } from './app.types';
 
 const handleICATError = (error: AxiosError, broadcast = true): void => {
-  let message;
-  if (error.response && error.response.data.message) {
-    message = error.response.data.message;
-  } else {
-    message = error.message;
-  }
+  const message = error.response?.data.message ?? error.message;
   log.error(message);
   if (broadcast) {
+    let broadcastMessage = message;
+    if (
+      error.response?.status &&
+      (error.response.status === 403 ||
+        // TopCAT doesn't set 403 for session ID failure, so detect by looking at the message
+        message.toUpperCase().includes('SESSION'))
+    ) {
+      broadcastMessage = 'Your session has expired, please reload the page';
+    }
     document.dispatchEvent(
       new CustomEvent(MicroFrontendId, {
         detail: {
           type: NotificationType,
           payload: {
             severity: 'error',
-            message: message,
+            message: broadcastMessage,
           },
         },
       })
     );
   }
   if (
-    error.response &&
-    error.response.status &&
+    error.response?.status &&
     (error.response.status === 403 ||
       // TopCAT doesn't set 403 for session ID failure, so detect by looking at the message
-      (error.response.data.message &&
-        error.response.data.message.toUpperCase().includes('SESSION')))
+      message.toUpperCase().includes('SESSION'))
   ) {
     document.dispatchEvent(
       new CustomEvent(MicroFrontendId, {

--- a/packages/datagateway-common/src/handleICATError.ts
+++ b/packages/datagateway-common/src/handleICATError.ts
@@ -17,7 +17,10 @@ const handleICATError = (error: AxiosError, broadcast = true): void => {
         // TopCAT doesn't set 403 for session ID failure, so detect by looking at the message
         message.toUpperCase().includes('SESSION'))
     ) {
-      broadcastMessage = 'Your session has expired, please reload the page';
+      broadcastMessage =
+        localStorage.getItem('autoLogin') === 'true'
+          ? 'Your session has expired, please reload the page'
+          : 'Your session has expired, please login again';
     }
     document.dispatchEvent(
       new CustomEvent(MicroFrontendId, {


### PR DESCRIPTION
## Description
To enable a more helpful notification message for the user, we want to amend the notification the user will receive when their session expires. Instead of displaying the returned error message from TopCAT which references a null or expired session ID which the user doesn't need to know or care about, the user is now informed that their session has expired and is instructed to reload the page to refresh their session.

## Testing instructions
Run through SciGateway. I believe the most reliable way of getting this notification to appear is to use an invalid URL for the DG API. Alternatively, see the below screenshot:

<img width="530" alt="session expired" src="https://user-images.githubusercontent.com/71134574/167388672-153a3134-fc42-4aa1-80d7-36c4b7b407d1.PNG">

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1209