### PR TITLE
Prevent querying for cart on homepage & fix admin download table queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-**/public/settings.json
-**/public/datagateway-dataview-settings.json
-**/public/datagateway-download-settings.json
-**/public/datagateway-search-settings.json
+**/public/*settings*.json
+!**/public/*settings.example.json
+

--- a/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
@@ -424,4 +424,11 @@ describe('PageContainer - Tests', () => {
       wrapper.find('PageBreadcrumbs').prop('landingPageEntities')
     ).toEqual(['study', 'investigation', 'dataset']);
   });
+
+  it('does not fetch cart when on homepage (cart request errors when user is viewing homepage unauthenticated)', () => {
+    history.replace(paths.homepage);
+    createWrapper();
+
+    expect(useCart).not.toHaveBeenCalled();
+  });
 });

--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -524,7 +524,7 @@ const getToggle = (pathname: string, view: ViewsType): boolean => {
     : false;
 };
 
-const PageContainer: React.FC = () => {
+const DataviewPageContainer: React.FC = () => {
   const location = useLocation();
   const { push } = useHistory();
   const prevLocationRef = React.useRef(location);
@@ -653,103 +653,102 @@ const PageContainer: React.FC = () => {
   };
 
   return (
+    <Paper square elevation={0} style={{ backgroundColor: 'inherit' }}>
+      <NavBar
+        entityCount={totalDataCount ?? 0}
+        cartItems={cartItems ?? []}
+        navigateToSearch={navigateToSearch}
+        navigateToDownload={navigateToDownload}
+        loggedInAnonymously={loggedInAnonymously}
+      />
+
+      <StyledGrid container>
+        <Grid item xs={12} style={{ marginTop: '10px', marginBottom: '10px' }}>
+          <StyledGrid container alignItems="baseline">
+            {/* Toggle between the table and card view */}
+            <Grid item style={{ display: 'flex', alignItems: 'baseline' }}>
+              <Route
+                exact
+                path={Object.values(paths.myData)}
+                render={() => <RoleSelector />}
+              />
+              <Route
+                exact
+                path={togglePaths}
+                render={() => (
+                  <ViewButton
+                    viewCards={view === 'card'}
+                    handleButtonChange={handleButtonChange}
+                  />
+                )}
+              />
+              <Route
+                exact
+                path={Object.values(paths.myData).concat(
+                  Object.values(paths.toggle),
+                  Object.values(paths.standard),
+                  Object.values(paths.studyHierarchy.toggle),
+                  Object.values(paths.studyHierarchy.standard)
+                )}
+                render={() => (
+                  <ClearFiltersButton
+                    handleButtonClearFilters={handleButtonClearFilters}
+                    disabled={disabled}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item xs={true}>
+              <SelectionAlert
+                selectedItems={cartItems ?? []}
+                navigateToSelection={navigateToDownload}
+                marginSide={'8px'}
+                loggedInAnonymously={loggedInAnonymously}
+              />
+            </Grid>
+          </StyledGrid>
+        </Grid>
+
+        {/* Show loading progress if data is still being loaded */}
+        {loading && (
+          <Grid item xs={12}>
+            <LinearProgress
+              color="secondary"
+              style={{ height: linearProgressHeight }}
+            />
+          </Grid>
+        )}
+
+        {/* Hold the view for remainder of the page */}
+        <Grid item xs={12} aria-label="page-view">
+          <ViewRouting
+            view={view}
+            location={location}
+            loadedCount={loadedCount}
+            loggedInAnonymously={loggedInAnonymously}
+            totalDataCount={totalDataCount ?? 0}
+            linearProgressHeight={linearProgressHeight}
+          />
+        </Grid>
+      </StyledGrid>
+    </Paper>
+  );
+};
+
+const PageContainer: React.FC = () => {
+  const location = useLocation();
+
+  return (
     <SwitchRouting location={location}>
       {/* Load the homepage */}
       <Route exact path={paths.homepage} component={TranslatedHomePage} />
       <Route exact path={paths.doiRedirect}>
         <DoiRedirect />
       </Route>
-      <Route
-        render={() => (
-          // Load the standard dataview pageContainer
-          <Paper square elevation={0} style={{ backgroundColor: 'inherit' }}>
-            <NavBar
-              entityCount={totalDataCount ?? 0}
-              cartItems={cartItems ?? []}
-              navigateToSearch={navigateToSearch}
-              navigateToDownload={navigateToDownload}
-              loggedInAnonymously={loggedInAnonymously}
-            />
-
-            <StyledGrid container>
-              <Grid
-                item
-                xs={12}
-                style={{ marginTop: '10px', marginBottom: '10px' }}
-              >
-                <StyledGrid container alignItems="baseline">
-                  {/* Toggle between the table and card view */}
-                  <Grid
-                    item
-                    style={{ display: 'flex', alignItems: 'baseline' }}
-                  >
-                    <Route
-                      exact
-                      path={Object.values(paths.myData)}
-                      render={() => <RoleSelector />}
-                    />
-                    <Route
-                      exact
-                      path={togglePaths}
-                      render={() => (
-                        <ViewButton
-                          viewCards={view === 'card'}
-                          handleButtonChange={handleButtonChange}
-                        />
-                      )}
-                    />
-                    <Route
-                      exact
-                      path={Object.values(paths.myData).concat(
-                        Object.values(paths.toggle),
-                        Object.values(paths.standard),
-                        Object.values(paths.studyHierarchy.toggle),
-                        Object.values(paths.studyHierarchy.standard)
-                      )}
-                      render={() => (
-                        <ClearFiltersButton
-                          handleButtonClearFilters={handleButtonClearFilters}
-                          disabled={disabled}
-                        />
-                      )}
-                    />
-                  </Grid>
-                  <Grid item xs={true}>
-                    <SelectionAlert
-                      selectedItems={cartItems ?? []}
-                      navigateToSelection={navigateToDownload}
-                      marginSide={'8px'}
-                      loggedInAnonymously={loggedInAnonymously}
-                    />
-                  </Grid>
-                </StyledGrid>
-              </Grid>
-
-              {/* Show loading progress if data is still being loaded */}
-              {loading && (
-                <Grid item xs={12}>
-                  <LinearProgress
-                    color="secondary"
-                    style={{ height: linearProgressHeight }}
-                  />
-                </Grid>
-              )}
-
-              {/* Hold the view for remainder of the page */}
-              <Grid item xs={12} aria-label="page-view">
-                <ViewRouting
-                  view={view}
-                  location={location}
-                  loadedCount={loadedCount}
-                  loggedInAnonymously={loggedInAnonymously}
-                  totalDataCount={totalDataCount ?? 0}
-                  linearProgressHeight={linearProgressHeight}
-                />
-              </Grid>
-            </StyledGrid>
-          </Paper>
-        )}
-      />
+      {/* Load the standard dataview pageContainer */}
+      <Route>
+        <DataviewPageContainer />
+      </Route>
     </SwitchRouting>
   );
 };

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -164,7 +164,7 @@ describe('Admin Download Status Table', () => {
     expect(fetchAdminDownloads).toHaveBeenNthCalledWith(
       1,
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.createdAt) desc, UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.createdAt desc, download.id ASC LIMIT 0, 50"
     );
     expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
@@ -194,7 +194,7 @@ describe('Admin Download Status Table', () => {
     expect(fetchAdminDownloads).toHaveBeenCalledTimes(3);
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.createdAt) desc, UPPER(download.id) ASC LIMIT 5, 5"
+      "WHERE download.facilityName = '' ORDER BY download.createdAt desc, download.id ASC LIMIT 5, 5"
     );
     expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
@@ -254,7 +254,7 @@ describe('Admin Download Status Table', () => {
     expect(fetchAdminDownloads).toHaveBeenNthCalledWith(
       3,
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.createdAt) desc, UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.createdAt desc, download.id ASC LIMIT 0, 50"
     );
     expect(wrapper.exists('[aria-rowcount=5]')).toBe(true);
   });
@@ -294,7 +294,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.userName) asc, UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.userName asc, download.id ASC LIMIT 0, 50"
     );
 
     // Get the Access Method sort header.
@@ -309,7 +309,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.userName) asc, UPPER(download.transport) asc, UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.userName asc, download.transport asc, download.id ASC LIMIT 0, 50"
     );
 
     await act(async () => {
@@ -320,7 +320,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.userName) asc, UPPER(download.transport) desc, UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.userName asc, download.transport desc, download.id ASC LIMIT 0, 50"
     );
 
     await act(async () => {
@@ -331,7 +331,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.userName) asc, UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.userName asc, download.id ASC LIMIT 0, 50"
     );
   }, 10000);
 
@@ -371,7 +371,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.userName) LIKE CONCAT('%', 'TEST USER', '%') ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' AND UPPER(download.userName) LIKE CONCAT('%', 'TEST USER', '%') ORDER BY download.id ASC LIMIT 0, 50"
     );
     usernameFilterInput.instance().value = '';
     usernameFilterInput.simulate('change');
@@ -389,7 +389,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.status) LIKE CONCAT('%', 'COMPLETE', '%') ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' AND UPPER(download.status) LIKE CONCAT('%', 'COMPLETE', '%') ORDER BY download.id ASC LIMIT 0, 50"
     );
 
     // We simulate a change in the select from 'include' to 'exclude'.
@@ -404,7 +404,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.status) NOT LIKE CONCAT('%', 'COMPLETE', '%') ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' AND UPPER(download.status) NOT LIKE CONCAT('%', 'COMPLETE', '%') ORDER BY download.id ASC LIMIT 0, 50"
     );
 
     await act(async () => {
@@ -416,7 +416,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.id ASC LIMIT 0, 50"
     );
   }, 10000);
 
@@ -456,7 +456,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.createdAt) BETWEEN {ts '2020-01-01 00:00'} AND {ts '9999-12-31 23:59'} ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' AND download.createdAt BETWEEN {ts '2020-01-01 00:00'} AND {ts '9999-12-31 23:59'} ORDER BY download.id ASC LIMIT 0, 50"
     );
 
     // Get the Requested Data To filter input
@@ -472,7 +472,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' AND UPPER(download.createdAt) BETWEEN {ts '2020-01-01 00:00'} AND {ts '2020-01-02 23:59'} ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' AND download.createdAt BETWEEN {ts '2020-01-01 00:00'} AND {ts '2020-01-02 23:59'} ORDER BY download.id ASC LIMIT 0, 50"
     );
 
     dateFromFilterInput.instance().value = '';
@@ -486,7 +486,7 @@ describe('Admin Download Status Table', () => {
 
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      "WHERE UPPER(download.facilityName) = '' ORDER BY UPPER(download.id) ASC LIMIT 0, 50"
+      "WHERE download.facilityName = '' ORDER BY download.id ASC LIMIT 0, 50"
     );
   }, 10000);
 
@@ -524,7 +524,7 @@ describe('Admin Download Status Table', () => {
     });
     expect(fetchAdminDownloads).toHaveBeenLastCalledWith(
       { downloadApiUrl: '', facilityName: '' },
-      'WHERE UPPER(download.id) = 4'
+      'WHERE download.id = 4'
     );
     expect(
       wrapper.exists(

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -86,15 +86,15 @@ const AdminDownloadStatusTable: React.FC = () => {
   }, [t]);
 
   const buildQueryOffset = useCallback(() => {
-    let queryOffset = `WHERE UPPER(download.facilityName) = '${settings.facilityName}'`;
+    let queryOffset = `WHERE download.facilityName = '${settings.facilityName}'`;
     for (const [column, filter] of Object.entries(filters)) {
       if (typeof filter === 'object') {
         if (!Array.isArray(filter)) {
           if ('startDate' in filter || 'endDate' in filter) {
-            const startDate = filter.startDate ?? '0000-01-01 00:00';
+            const startDate = filter.startDate ?? '0001-01-01 00:00';
             const endDate = filter.endDate ?? '9999-12-31 23:59';
 
-            queryOffset += ` AND UPPER(download.${column}) BETWEEN {ts '${startDate}'} AND {ts '${endDate}'}`;
+            queryOffset += ` AND download.${column} BETWEEN {ts '${startDate}'} AND {ts '${endDate}'}`;
           }
 
           if ('type' in filter && filter.type) {
@@ -116,9 +116,9 @@ const AdminDownloadStatusTable: React.FC = () => {
 
     queryOffset += ' ORDER BY';
     for (const [column, order] of Object.entries(sort)) {
-      queryOffset += ` UPPER(download.${column}) ${order},`;
+      queryOffset += ` download.${column} ${order},`;
     }
-    queryOffset += ' UPPER(download.id) ASC';
+    queryOffset += ' download.id ASC';
 
     return queryOffset;
   }, [filters, settings.facilityName, sort]);
@@ -427,7 +427,7 @@ const AdminDownloadStatusTable: React.FC = () => {
                                   facilityName: settings.facilityName,
                                   downloadApiUrl: settings.downloadApiUrl,
                                 },
-                                `WHERE UPPER(download.id) = ${downloadItem.id}`
+                                `WHERE download.id = ${downloadItem.id}`
                               ).then((downloads) => {
                                 const formattedDownload = formatDownloads(
                                   downloads


### PR DESCRIPTION
## Description
With the new SciGateway change to allow unauthenticated access to the homepage, it meant the user was seeing errors as the cart was requested on  the homepage. I justed jiggled the code around to create an extra component so that the cart is only requested on "actual" dataview pages.

The second change is to fix some of the querying in the admin download table - there were `UPPER`s being applied too liberally and breaking things (e.g. the sorting) so I only kept the `UPPER`s where necessary - for text filters. Also, I noticed that only setting the to field in a date filter threw an error when done against an Oracle DB due to Oracle not accepting the year being 0 (this issue is also present on TopCAT). So I set it to 1 instead which avoids the error.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Run dataview in scigateway and verify that no requests are sent when you're on the DG homepage
- [ ] test out the sorting and filtering in the admin download table

## Agile board tracking
No issue as these are things I found whilst doing the DLS demo so I made hotfixes for them.