### PR TITLE
Fix breadcrumbs visual glitch

### DIFF
--- a/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
+++ b/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
@@ -65,7 +65,7 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
 
           /* Positions breadcrumb */
           lineHeight: '28px',
-          padding: ' 0 10px 0 20px',
+          padding: ' 0 4px 0 14px',
           textAlign: 'center',
 
           /* Add the arrow between breadcrumbs */
@@ -110,17 +110,14 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
       },
       '& li:first-child': {
         '& a, p': {
-          paddingLeft: '16px',
-          '&:before': {
-            left: '14px',
-          },
+          paddingLeft: '14px',
         },
       },
       '& li:last-child': {
         '& a, p': {
           /* Curve the last breadcrumb border */
           borderRadius: '0 5px 5px 0',
-          paddingLeft: '20px',
+          paddingLeft: '14px',
           '&:after': {
             content: 'none',
           },

--- a/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
+++ b/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
@@ -64,52 +64,37 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
           position: 'relative',
 
           /* Positions breadcrumb */
-          height: '28px',
           lineHeight: '28px',
-          padding: '0 5px 0 2px',
+          padding: ' 0 10px 0 20px',
           textAlign: 'center',
 
-          /* Adds between breadcrumbs */
-          marginRight: '-1px',
-          '&:before, &:after': {
+          /* Add the arrow between breadcrumbs */
+          '&:after': {
             content: '""',
             position: 'absolute',
-            top: 0,
-            border: `0 solid ${theme.palette.primary.light}`,
-            // these need to be even numbers to avoid sub-pixel issue (#1196)
-            borderWidth: '14px 6px',
-            width: 0,
-            height: 0,
-          },
-          '&:before': {
-            left: '-12px',
-            borderLeftColor: 'transparent',
-          },
-          '&:after': {
-            left: '100%',
-
-            /* Gap in between chevrons */
-            borderColor: 'transparent',
-            borderLeftColor: theme.palette.primary.light,
+            top: '3px',
+            // half the width/height
+            right: '-11px',
+            // width/height same as lineHeight - 2* top height
+            height: '22px',
+            width: '22px',
+            // change skew to alter how shallow the arrow is
+            transform: 'scale(0.707) rotate(45deg) skew(15deg,15deg)',
+            zIndex: 1,
+            boxShadow: '2px -2px 0 2px white',
+            borderRadius: ' 0 5px 0 50px',
+            backgroundColor: theme.palette.primary.light,
           },
           '&:hover': {
             backgroundColor: theme.palette.primary.light,
-            '&:before': {
-              borderColor: theme.palette.primary.light,
-              borderLeftColor: 'transparent',
-            },
             '&:after': {
-              borderLeftColor: theme.palette.primary.light,
+              backgroundColor: theme.palette.primary.light,
             },
           },
           '&:active': {
             backgroundColor: theme.palette.grey[600],
-            '&:before': {
-              borderColor: `${theme.palette.grey[600]} !important`,
-              borderLeftColor: 'transparent !important',
-            },
             '&:after': {
-              borderLeftColor: `${theme.palette.grey[600]} !important`,
+              backgroundColor: `${theme.palette.grey[600]} !important`,
             },
           },
         },
@@ -118,31 +103,26 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
       '& li:nth-child(4n + 3)': {
         '& a, p': {
           backgroundColor: theme.palette.primary.main,
-          '&:before': {
-            borderColor: theme.palette.primary.main,
-            borderLeftColor: 'transparent',
-          },
           '&:after': {
-            borderLeftColor: theme.palette.primary.main,
+            backgroundColor: theme.palette.primary.main,
           },
         },
       },
       '& li:first-child': {
         '& a, p': {
-          paddingLeft: '4px',
+          paddingLeft: '16px',
           '&:before': {
-            border: 'none',
+            left: '14px',
           },
         },
       },
       '& li:last-child': {
         '& a, p': {
-          paddingRight: '8px',
-
           /* Curve the last breadcrumb border */
-          borderRadius: '0 4px 4px 0',
+          borderRadius: '0 5px 5px 0',
+          paddingLeft: '20px',
           '&:after': {
-            border: 'none',
+            content: 'none',
           },
         },
       },
@@ -156,6 +136,10 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
         overflow: 'hidden',
         textOverflow: 'ellipsis',
       },
+    },
+    separator: {
+      marginLeft: 0,
+      marginRight: 0,
     },
   });
 

--- a/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
+++ b/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
@@ -64,24 +64,25 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
           position: 'relative',
 
           /* Positions breadcrumb */
-          height: '30px',
-          lineHeight: '30px',
+          height: '28px',
+          lineHeight: '28px',
           padding: '0 5px 0 2px',
           textAlign: 'center',
 
           /* Adds between breadcrumbs */
-          marginRight: '1px',
+          marginRight: '-1px',
           '&:before, &:after': {
             content: '""',
             position: 'absolute',
             top: 0,
             border: `0 solid ${theme.palette.primary.light}`,
-            borderWidth: '15px 7px',
+            // these need to be even numbers to avoid sub-pixel issue (#1196)
+            borderWidth: '14px 6px',
             width: 0,
             height: 0,
           },
           '&:before': {
-            left: '-14px',
+            left: '-12px',
             borderLeftColor: 'transparent',
           },
           '&:after': {
@@ -136,7 +137,7 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
       },
       '& li:last-child': {
         '& a, p': {
-          paddingRight: '7px',
+          paddingRight: '8px',
 
           /* Curve the last breadcrumb border */
           borderRadius: '0 4px 4px 0',

--- a/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
+++ b/packages/datagateway-search/cypress/integration/search/datafileSearch.spec.ts
@@ -81,15 +81,14 @@ describe('Datafile search tab', () => {
     cy.get('[aria-label="Start date input"]').type('2012-02-02');
     cy.get('[aria-label="End date input"]').type('2012-02-03');
 
-    cy.get('[aria-label="Submit search"]').click();
+    cy.get('[aria-label="Submit search"]').click().wait('@datafilesCount', {
+      timeout: 10000,
+    });
 
     cy.get('[aria-label="Search table"]')
       .contains('Datafile')
       .contains('9')
-      .click()
-      .wait(['@datafiles', '@datafiles', '@datafilesCount'], {
-        timeout: 10000,
-      });
+      .click();
 
     cy.get('[aria-rowcount="9"]').should('exist');
 


### PR DESCRIPTION
## Description
I believe I fixed the error I was seeing - which was specifically in Firefox on my second monitor (it wasn't specifically due to the size of the window, just the size of the monitor weirdly). I found through trail and error that having the `borderWidth` property in the `:before` and `:after` bits of the CSS as odd was causing the subpixel issue (presumably because of some division by two not rounding right?). I've set it to use even numbers, adjusted the rest of the numbers to make everything align right and added a comment so we don't make the same mistake further down the line.

@agbeltran does this fix the issue you saw? As your visual glitch looked slightly different to mine.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] I think Sam was able to see the issue in FF? if you run it then it shouldn't occur anymore - compare to one of the dev machines.
- [ ] TODO: test if this fixes the display error Alejandra had (could be Mac specific...)

## Agile board tracking
Closes #1196