### PR TITLE
#1196 - Use MUI theme background colour for breadcrumb gaps

### DIFF
--- a/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
+++ b/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
@@ -81,7 +81,7 @@ const breadcrumbsStyles = (theme: Theme): StyleRules =>
             // change skew to alter how shallow the arrow is
             transform: 'scale(0.707) rotate(45deg) skew(15deg,15deg)',
             zIndex: 1,
-            boxShadow: '2px -2px 0 2px white',
+            boxShadow: `2px -2px 0 2px ${theme.palette.background.default}`,
             borderRadius: ' 0 5px 0 50px',
             backgroundColor: theme.palette.primary.light,
           },


### PR DESCRIPTION
## Description
I did an oopsie and forgot to change from `white` to the MUI theme background colour for the breadcrumb gaps

Note - I already fixed this in the MUIv5 upgrade branch (as I noticed it when looking at the code in there)

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Part of #1196 
