### PR TITLE
Implement best practices in Docker image 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+/.github
+/.husky
+/packages/datagateway-*/cypress
+/packages/datagateway-*/cypress.json
+/packages/datagateway-*/server
+/packages/datagateway-*/README.md
+.gitignore
+.prettierrc
+codecov.yml
+CODEOWNERS
+LICENSE.md
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Multipart build dockerfile to build and serve datagateway
 
 FROM node:16.14-alpine3.15 as build
+
 WORKDIR /datagateway
-ENV PATH /datagateway/node_modules/.bin:$PATH
 
 # TODO: use yarn install --production:
 # https://github.com/ral-facilities/datagateway/issues/1155

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,19 @@ FROM node:16.14-alpine3.15 as build
 
 WORKDIR /datagateway
 
-# TODO: use yarn install --production:
-# https://github.com/ral-facilities/datagateway/issues/1155
-
-# Set Yarn version
-# TODO - Use Yarn 2 when project is upgraded
-RUN yarn set version 1.22
+ARG HOST_URL
 
 COPY . .
-ARG HOST_URL
-# Set the React production variables which hold reference to the paths of the plugin builds
-RUN echo "REACT_APP_DATAVIEW_BUILD_DIRECTORY=$HOST_URL/datagateway-dataview/" > packages/datagateway-dataview/.env.production
-RUN echo "REACT_APP_DOWNLOAD_BUILD_DIRECTORY=$HOST_URL/datagateway-download/" > packages/datagateway-download/.env.production
-RUN echo "REACT_APP_SEARCH_BUILD_DIRECTORY=$HOST_URL/datagateway-search/" > packages/datagateway-search/.env.production
 
-# Install dependancies
-RUN yarn install
-RUN yarn build
+# TODO - Use Yarn 2 when project is upgraded
+RUN yarn set version 1.22 \
+  # Set the React production variables which hold reference to the paths of the plugin builds
+  && echo "REACT_APP_DATAVIEW_BUILD_DIRECTORY=$HOST_URL/datagateway-dataview/" > packages/datagateway-dataview/.env.production \
+  && echo "REACT_APP_DOWNLOAD_BUILD_DIRECTORY=$HOST_URL/datagateway-download/" > packages/datagateway-download/.env.production \
+  && echo "REACT_APP_SEARCH_BUILD_DIRECTORY=$HOST_URL/datagateway-search/" > packages/datagateway-search/.env.production \
+  # TODO: use yarn install --production - https://github.com/ral-facilities/datagateway/issues/1155
+  && yarn install \
+  && yarn build
 
 # Put the output of the build into an apache server
 FROM httpd:2.4-alpine3.15

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,10 @@ RUN sed -i '/Listen 80$/a\
 \    DocumentRoot "/usr/local/apache2/htdocs/datagateway-search"\n\
 \</VirtualHost>' httpd.conf
 
+RUN apk --no-cache add libcap \
+  # Privileged ports are permitted to root only by default.
+  # setcap to bind to privileged ports (80) as non-root.
+  && setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd
+
 # Switch to non-root user defined in httpd image
 USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,9 @@ RUN sed -i '/Listen 80$/a\
 RUN apk --no-cache add libcap \
   # Privileged ports are permitted to root only by default.
   # setcap to bind to privileged ports (80) as non-root.
-  && setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd
+  && setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd \
+  # Change access righs for logs from root to www-data
+  && chown www-data:www-data /usr/local/apache2/logs
 
 # Switch to non-root user defined in httpd image
 USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,5 @@ RUN sed -i '/Listen 80$/a\
 \    DocumentRoot "/usr/local/apache2/htdocs/datagateway-search"\n\
 \</VirtualHost>' httpd.conf
 
-
+# Switch to non-root user defined in httpd image
+USER www-data


### PR DESCRIPTION
## Description
This PR implements best practices in the Docker image.

In summary, the changes do the following:
- Removes the lines that sets the `PATH` because the image builds and the container works fine without it.
- Combines the `RUN` commands so that there are less layers.
- Configures the image so that containers run using the non-root `www-data` user account that the `httpd` image defines.
- Uses `setcap` to allow non-root user accounts to bind to privileged ports (port 80 in this case) as these ports are only permitted to `root` by default. I found this solution in [this](https://takac.dev/docker-run-apache-as-non-root-user-based-on-the-official-image/) article.
- Changes the access rights for the Apache's `logs` directory from `root` to `www-data` user account.

I also tried to leverage build cache in the building stage to reduce the build time but I could not achieve this. I faced some `lerna` issues which I could not resolve.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Image builds successfully
- [ ] Container starts successfully