### PR TITLE
Adjust height calculations in various components

### DIFF
--- a/packages/datagateway-dataview/src/page/pageContainer.component.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.tsx
@@ -369,7 +369,7 @@ const StyledRouting = (props: {
   // Chrome's display is 1px shorter than Firefox's, so we subtract 1px extra to account for this
   // We also don't want the <LinearProgress> bar to push the page down so subtract the height of this (4px if on-screen)
   // Additional rows of breadcrumbs also push the page down so subtract the height of the breadcrumb div
-  const tablePaperHeight = `calc(100vh - 180px - 36px - 1px - ${linearProgressHeight} - ${breadcrumbHeight})`;
+  const tablePaperHeight = `calc(100vh - 152px - 36px - 1px - ${linearProgressHeight} - ${breadcrumbHeight})`;
 
   const [t] = useTranslation();
   const tableClassStyle = getTablePaperStyle(

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Admin Download Status Table renders correctly 1`] = `
           <ForwardRef(Paper)
             style={
               Object {
-                "height": "calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px)) - 4px",
+                "height": "calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px) - 4px)",
                 "minHeight": 230,
                 "overflowX": "auto",
               }

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Admin Download Status Table renders correctly 1`] = `
           <ForwardRef(Paper)
             style={
               Object {
-                "height": "calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px))",
+                "height": "calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px)) - 4px",
                 "minHeight": 230,
                 "overflowX": "auto",
               }

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -313,9 +313,9 @@ const AdminDownloadStatusTable: React.FC = () => {
             tabs, admin header, table padding, text above table, and the LinearProgress above (respectively). */}
               <Paper
                 style={{
-                  height: `calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px))${
+                  height: `calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px)${
                     dataLoaded ? '' : ' - 4px'
-                  }`,
+                  })`,
                   minHeight: 230,
                   overflowX: 'auto',
                 }}

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -310,11 +310,12 @@ const AdminDownloadStatusTable: React.FC = () => {
             )}
             <Grid item>
               {/* Table should take up page but leave room for: SG appbar, SG footer,
-            tabs, admin header, table padding, and text above table (respectively). */}
+            tabs, admin header, table padding, text above table, and the LinearProgress above (respectively). */}
               <Paper
                 style={{
-                  height:
-                    'calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px))',
+                  height: `calc(100vh - 64px - 36px - 48px - (3rem * 1.167) - 32px - (1.75rem + 40px))${
+                    dataLoaded ? '' : ' - 4px'
+                  }`,
                   minHeight: 230,
                   overflowX: 'auto',
                 }}


### PR DESCRIPTION
## Description
This PR includes fixes for some height miscalculations:
- admin download status table in `datagateway-download`: content overflows slightly when the progress bar appears
- `PageContainer` in `datagateway-dataview`: slightly too short causing a white bar appear underneath tables

Related: https://github.com/ral-facilities/scigateway/pull/1121

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to https://github.com/ral-facilities/scigateway/pull/1121
