### PR TITLE
Improving download e2e test to account for random ordering of downloads

### DIFF
--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -175,17 +175,12 @@ describe('Download Status', () => {
         format(currDate, 'yyyy-MM-dd HH:mm')
       );
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
-        'have.text',
-        'test-file-1'
-      );
-
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').should(
-        'have.text',
-        'https'
-      );
-
       cy.get('[aria-rowcount="4"]').should('exist');
+
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
+        'have.text',
+        format(currDate, 'yyyy-MM-dd HH:mm:ss')
+      );
     });
 
     it('multiple columns', () => {


### PR DESCRIPTION
## Description
I've noticed a small bug that can cause a failing e2e test on DG download.

When fetching the list of downloads to display in the downloadStatusTable, all 4 test files have the same date and time. This essentially does nothing when the default sort of the table is applied, which is requested date descending. So what generally happens is that the test data appears in ascending order of filename, since that's the other main distinction. 

But _occasionally_, when fetching the list of downloads, the files may appear in a random order and there is one test where this ordering is important in its current implementation. This test is to check that we can filter by date between two values. What happens is:

1. Test data is displayed in a random order
2. Test filters data from today's date
3. The correct data is displayed in the table
4. The test checks for this by verifying the filename of the top file. This is no good when the files are sometimes displayed in a random order

So since the files all have the same date, I've changed the implementation to check the timestamps on the displayed files matches what the user is filtering by.

You should be able to see this error in action (as well as in the failing CI run on develop right now). If you run the DG download e2e tests locally, you should sometimes see the `beforeEach()` causing test data to appear in a random order. Otherwise, here's a couple of screenshots of what I'm talking about.

What is normally displayed in the table following the `beforeEach()`:
![image](https://user-images.githubusercontent.com/71134574/183425410-c9e7a1d6-7394-462b-94ee-a8ddd563bd4c.png)

What is occasionally displayed otherwise:
![image](https://user-images.githubusercontent.com/71134574/183425570-a0dee555-0f35-4fb9-b661-c94d7b1cf520.png)

## Testing instructions
You may be happy with just the code review but feel free to double check by verifying this test for yourself locally.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Hotfix (no issue connected)