### PR TITLE
Use different settings.json file for running e2e in CI vs locally

### DIFF
--- a/packages/datagateway-dataview/cypress/support/commands.js
+++ b/packages/datagateway-dataview/cypress/support/commands.js
@@ -55,7 +55,8 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', (credentials) => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.request('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     let body = {
       username: '',
       password: '',
@@ -82,7 +83,8 @@ Cypress.Commands.add('login', (credentials) => {
 });
 
 Cypress.Commands.add('clearDownloadCart', () => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.request('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     cy.request({
       method: 'DELETE',
       url: `${settings.downloadApiUrl}/user/cart/${settings.facilityName}/cartItems`,

--- a/packages/datagateway-dataview/server/e2e-test-server.js
+++ b/packages/datagateway-dataview/server/e2e-test-server.js
@@ -1,11 +1,21 @@
-var express = require('express');
-var path = require('path');
-var serveStatic = require('serve-static');
+const express = require('express');
+const path = require('path');
+const serveStatic = require('serve-static');
 
-var app = express();
+const app = express();
 
-app.get('/datagateway-dataview-settings.json', function(req, res) {
-  res.sendFile(path.resolve('./server/e2e-settings.json'));
+app.get('/datagateway-dataview-settings.json', function (req, res) {
+  // detect if the E2E test is running inside CI
+  // If so, use the settings file specific to E2E
+  // Otherwise, use the same settings file that is also for running the app normally (yarn start etc).
+  const isCiEnv = process.env.CI;
+  res.sendFile(
+    path.resolve(
+      isCiEnv
+        ? './server/e2e-settings.json'
+        : './public/datagateway-dataview-settings.json'
+    )
+  );
 });
 
 app.use(
@@ -13,7 +23,7 @@ app.use(
   serveStatic(path.resolve('./build'), { index: ['index.html', 'index.htm'] })
 );
 
-app.get('/*', function(req, res) {
+app.get('/*', function (req, res) {
   res.sendFile(path.resolve('./build/index.html'));
 });
 

--- a/packages/datagateway-download/cypress/support/commands.js
+++ b/packages/datagateway-download/cypress/support/commands.js
@@ -90,7 +90,7 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', (credentials) => {
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-download-settings.json').then((response) => {
     const settings = response.body;
     let body = {
       username: '',
@@ -118,7 +118,7 @@ Cypress.Commands.add('login', (credentials) => {
 });
 
 Cypress.Commands.add('clearDownloadCart', () => {
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-download-settings.json').then((response) => {
     const settings = response.body;
     cy.request({
       method: 'DELETE',
@@ -138,7 +138,7 @@ Cypress.Commands.add('seedDownloadCart', () => {
     .map((value, index) => `${entities[index % 2]} ${index}`)
     .join(', ');
 
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-download-settings.json').then((response) => {
     const settings = response.body;
     cy.request({
       method: 'POST',
@@ -153,7 +153,7 @@ Cypress.Commands.add('seedDownloadCart', () => {
 });
 
 Cypress.Commands.add('addCartItem', (cartItem) => {
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-download-settings.json').then((response) => {
     const settings = response.body;
     cy.request({
       method: 'POST',
@@ -168,7 +168,7 @@ Cypress.Commands.add('addCartItem', (cartItem) => {
 });
 
 Cypress.Commands.add('seedDownloads', () => {
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-download-settings.json').then((response) => {
     const settings = response.body;
     let i = 1;
     for (var info of downloadsInfo) {
@@ -225,7 +225,7 @@ Cypress.Commands.add('seedDownloads', () => {
 });
 
 Cypress.Commands.add('clearDownloads', () => {
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-download-settings.json').then((response) => {
     const settings = response.body;
     cy.request({
       method: 'GET',

--- a/packages/datagateway-download/cypress/support/commands.js
+++ b/packages/datagateway-download/cypress/support/commands.js
@@ -90,7 +90,8 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', (credentials) => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     let body = {
       username: '',
       password: '',
@@ -117,7 +118,8 @@ Cypress.Commands.add('login', (credentials) => {
 });
 
 Cypress.Commands.add('clearDownloadCart', () => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     cy.request({
       method: 'DELETE',
       url: `${settings.downloadApiUrl}/user/cart/${settings.facilityName}/cartItems`,
@@ -136,7 +138,8 @@ Cypress.Commands.add('seedDownloadCart', () => {
     .map((value, index) => `${entities[index % 2]} ${index}`)
     .join(', ');
 
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     cy.request({
       method: 'POST',
       url: `${settings.downloadApiUrl}/user/cart/${settings.facilityName}/cartItems`,
@@ -150,7 +153,8 @@ Cypress.Commands.add('seedDownloadCart', () => {
 });
 
 Cypress.Commands.add('addCartItem', (cartItem) => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     cy.request({
       method: 'POST',
       url: `${settings.downloadApiUrl}/user/cart/${settings.facilityName}/cartItems`,
@@ -164,7 +168,8 @@ Cypress.Commands.add('addCartItem', (cartItem) => {
 });
 
 Cypress.Commands.add('seedDownloads', () => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     let i = 1;
     for (var info of downloadsInfo) {
       // Seed a single cart item as items are cleared after each download.
@@ -220,7 +225,8 @@ Cypress.Commands.add('seedDownloads', () => {
 });
 
 Cypress.Commands.add('clearDownloads', () => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     cy.request({
       method: 'GET',
       url: `${settings.downloadApiUrl}/user/downloads`,

--- a/packages/datagateway-download/server/e2e-test-server.js
+++ b/packages/datagateway-download/server/e2e-test-server.js
@@ -1,11 +1,21 @@
-var express = require('express');
-var path = require('path');
-var serveStatic = require('serve-static');
+const express = require('express');
+const path = require('path');
+const serveStatic = require('serve-static');
 
-var app = express();
+const app = express();
 
 app.get('/datagateway-download-settings.json', function (req, res) {
-  res.sendFile(path.resolve('./server/e2e-settings.json'));
+  // detect if the E2E test is running inside CI
+  // If so, use the settings file specific to E2E
+  // Otherwise, use the same settings file that is also for running the app normally (yarn start etc).
+  const isCiEnv = process.env.CI;
+  res.sendFile(
+    path.resolve(
+      isCiEnv
+        ? './server/e2e-settings.json'
+        : './public/datagateway-download-settings.json'
+    )
+  );
 });
 
 app.use(

--- a/packages/datagateway-search/cypress/support/commands.js
+++ b/packages/datagateway-search/cypress/support/commands.js
@@ -55,7 +55,7 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', () => {
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-search-settings.json').then((response) => {
     const settings = response.body;
     cy.request('POST', `${settings.apiUrl}/sessions`, {
       username: '',
@@ -79,7 +79,7 @@ Cypress.Commands.add('login', () => {
 });
 
 Cypress.Commands.add('clearDownloadCart', () => {
-  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+  return cy.request('datagateway-search-settings.json').then((response) => {
     const settings = response.body;
     cy.request({
       method: 'DELETE',

--- a/packages/datagateway-search/cypress/support/commands.js
+++ b/packages/datagateway-search/cypress/support/commands.js
@@ -55,7 +55,8 @@ export const readSciGatewayToken = () => {
 };
 
 Cypress.Commands.add('login', () => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     cy.request('POST', `${settings.apiUrl}/sessions`, {
       username: '',
       password: '',
@@ -78,7 +79,8 @@ Cypress.Commands.add('login', () => {
 });
 
 Cypress.Commands.add('clearDownloadCart', () => {
-  return cy.readFile('server/e2e-settings.json').then((settings) => {
+  return cy.readFile('datagateway-dataview-settings.json').then((response) => {
+    const settings = response.body;
     cy.request({
       method: 'DELETE',
       url: `${settings.downloadApiUrl}/user/cart/${settings.facilityName}/cartItems`,

--- a/packages/datagateway-search/server/e2e-test-server.js
+++ b/packages/datagateway-search/server/e2e-test-server.js
@@ -1,51 +1,61 @@
-var express = require('express');
-var path = require('path');
-var serveStatic = require('serve-static');
-var axios = require('axios');
-var fs = require('fs')
+const express = require('express');
+const path = require('path');
+const serveStatic = require('serve-static');
+const axios = require('axios');
+const fs = require('fs');
 
-var app = express();
+const app = express();
 
 app.use(
   express.json(),
   serveStatic(path.resolve('./build'), { index: ['index.html', 'index.htm'] })
 );
 
-app.get('/datagateway-search-settings.json', function(req, res) {
-  res.sendFile(path.resolve('./server/e2e-settings.json'));
+app.get('/datagateway-search-settings.json', function (req, res) {
+  // detect if the E2E test is runnFing inside CI
+  // If so, use the settings file specific to E2E
+  // Otherwise, use the same settings file that is also for running the app normally (yarn start etc).
+  const isCiEnv = process.env.CI;
+  res.sendFile(
+    path.resolve(
+      isCiEnv
+        ? './server/e2e-settings.json'
+        : './public/datagateway-search-settings.json'
+    )
+  );
 });
 
-app.get(/\/sessions|investigations|datasets|datafiles/, function(req, res) {
+app.get(/\/sessions|investigations|datasets|datafiles/, function (req, res) {
   fs.readFile('server/e2e-settings.json').then((settings) => {
     axios
-    .get(settings.apiUrl + req.url, {
-      headers: req.headers,
-    })
-    .then(apiRes => {
-      res.json(apiRes.data);
-    })
-    .catch(error => {
-      res.status(error.response.status).end();
-    });
-  });
-});
-
-app.post(/\/sessions|investigations|datasets|datafiles/, function(req, res) {
-  fs.readFile('server/e2e-settings.json').then((settings) => {
-    axios
-      .post(settings.apiUrl + req.url, req.body, {
+      .get(settings.apiUrl + req.url, {
         headers: req.headers,
       })
-      .then(apiRes => {
+      .then((apiRes) => {
         res.json(apiRes.data);
       })
-      .catch(error => {
+      .catch((error) => {
         res.status(error.response.status).end();
       });
   });
 });
 
-app.get('/*', function(req, res) {
+app.post(/\/sessions|investigations|datasets|datafiles/, function (req, res) {
+  fs.readFile('server/e2e-settings.json').then((settings) => {
+    axios
+      .post(settings.apiUrl + req.url, req.body, {
+        headers: req.headers,
+      })
+      .then((apiRes) => {
+        res.json(apiRes.data);
+      })
+      .catch((error) => {
+        res.status(error.response.status).end();
+      });
+  });
+});
+
+app.get('/*', function (req, res) {
   res.sendFile(path.resolve('./build/index.html'));
 });
 


### PR DESCRIPTION
## Description
This PR adds the ability for e2e test servers to select the corresponding `*-settings.json` file depending on whether the e2e tests are running in CI or not. If the tests are running in CI, then the `*-settings.json` in `server/` is used. Otherwise, the one in `public/` is used.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1370 

Closes #1370 
