### PR TITLE
#1397 - make fileCountMax / totalSizeMax optional

### DIFF
--- a/packages/datagateway-download/src/ConfigProvider.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.tsx
@@ -16,8 +16,8 @@ export interface DownloadSettings {
   downloadApiUrl: string;
   idsUrl: string;
 
-  fileCountMax: number;
-  totalSizeMax: number;
+  fileCountMax?: number;
+  totalSizeMax?: number;
 
   accessMethods: DownloadSettingsAccessMethod;
   routes: PluginRoute[];
@@ -30,8 +30,8 @@ const initialConfiguration = {
   apiUrl: '',
   downloadApiUrl: '',
   idsUrl: '',
-  fileCountMax: -1,
-  totalSizeMax: -1,
+  fileCountMax: undefined,
+  totalSizeMax: undefined,
   accessMethods: {},
   routes: [],
   helpSteps: [],

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -328,8 +328,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
             style={{
               height: `calc(100vh - 64px - 48px - 48px - 48px - 3rem${
                 emptyItems ||
-                fileCount > fileCountMax ||
-                totalSize > totalSizeMax
+                (fileCountMax && fileCount > fileCountMax) ||
+                (totalSizeMax && totalSize > totalSizeMax)
                   ? ' - 2rem'
                   : ''
               } - (1.75 * 0.875rem + 12px)`,
@@ -377,11 +377,11 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 {fileCount !== -1
                   ? fileCount
                   : `${t('downloadCart.calculating')}...`}
-                {fileCountMax !== -1 && ` / ${fileCountMax}`}
+                {fileCountMax && ` / ${fileCountMax}`}
               </Typography>
             </Grid>
             <Grid item>
-              {fileCount > fileCountMax && (
+              {fileCountMax && fileCount > fileCountMax && (
                 <Alert
                   id="fileLimitAlert"
                   variant="filled"
@@ -422,11 +422,11 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                 {totalSize !== -1
                   ? formatBytes(totalSize)
                   : `${t('downloadCart.calculating')}...`}
-                {totalSizeMax !== -1 && ` / ${formatBytes(totalSizeMax)}`}
+                {totalSizeMax && ` / ${formatBytes(totalSizeMax)}`}
               </Typography>
             </Grid>
             <Grid item>
-              {totalSize > totalSizeMax && (
+              {totalSizeMax && totalSize > totalSizeMax && (
                 <Alert
                   id="sizeLimitAlert"
                   variant="filled"
@@ -502,8 +502,8 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
                   fileCountsLoading ||
                   sizesLoading ||
                   emptyItems ||
-                  (fileCountMax !== -1 && fileCount > fileCountMax) ||
-                  (totalSizeMax !== -1 && totalSize > totalSizeMax)
+                  (fileCountMax ? fileCount > fileCountMax : false) ||
+                  (totalSizeMax ? totalSize > totalSizeMax : false)
                 }
               >
                 {t('downloadCart.download')}

--- a/packages/datagateway-download/src/index.test.tsx
+++ b/packages/datagateway-download/src/index.test.tsx
@@ -185,8 +185,6 @@ describe('index - fetchSettings', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
-          fileCountMax: 5000,
-          totalSizeMax: 1000000000000,
           accessMethods: {
             https: {
               idsUrl: 'https-ids',
@@ -214,8 +212,6 @@ describe('index - fetchSettings', () => {
       Promise.resolve({
         data: {
           facilityName: 'Generic',
-          fileCountMax: 5000,
-          totalSizeMax: 1000000000000,
           accessMethods: {
             https: {
               idsUrl: 'https-ids',
@@ -246,8 +242,6 @@ describe('index - fetchSettings', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
-          fileCountMax: 5000,
-          totalSizeMax: 1000000000000,
         },
       })
     );
@@ -271,8 +265,6 @@ describe('index - fetchSettings', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
-          fileCountMax: 5000,
-          totalSizeMax: 1000000000000,
           accessMethods: {
             https: {
               idsUrl: 'https-ids',
@@ -307,8 +299,6 @@ describe('index - fetchSettings', () => {
           idsUrl: 'ids',
           apiUrl: 'api',
           downloadApiUrl: 'download-api',
-          fileCountMax: 5000,
-          totalSizeMax: 1000000000000,
           accessMethods: {},
         },
       })
@@ -373,40 +363,6 @@ describe('index - fetchSettings', () => {
     );
   });
 
-  it('logs an error if fileCountMax or totalSizeMax are undefined in the settings', async () => {
-    (axios.get as jest.Mock).mockImplementationOnce(() =>
-      Promise.resolve({
-        data: {
-          facilityName: 'Generic',
-          idsUrl: 'ids',
-          apiUrl: 'api',
-          downloadApiUrl: 'download-api',
-          accessMethods: {
-            https: {
-              idsUrl: 'https-ids',
-              displayName: 'HTTPS',
-              description: 'HTTP description',
-            },
-            globus: {
-              displayName: 'Globus',
-              description: 'Globus description',
-            },
-          },
-        },
-      })
-    );
-
-    const settings = await fetchSettings();
-
-    expect(settings).toBeUndefined();
-    expect(log.error).toHaveBeenCalled();
-
-    const mockLog = (log.error as jest.Mock).mock;
-    expect(mockLog.calls[0][0]).toEqual(
-      'Error loading /datagateway-download-settings.json: fileCountMax or totalSizeMax is undefined in settings'
-    );
-  });
-
   it('logs an error if no routes are defined in the settings', async () => {
     (axios.get as jest.Mock).mockImplementationOnce(() =>
       Promise.resolve({
@@ -427,8 +383,6 @@ describe('index - fetchSettings', () => {
               description: 'Globus description',
             },
           },
-          fileCountMax: 5000,
-          totalSizeMax: 1000000000000,
         },
       })
     );
@@ -464,8 +418,6 @@ describe('index - fetchSettings', () => {
               description: 'Globus description',
             },
           },
-          fileCountMax: 5000,
-          totalSizeMax: 1000000000000,
           routes: [
             {
               section: 'section',

--- a/packages/datagateway-download/src/index.tsx
+++ b/packages/datagateway-download/src/index.tsx
@@ -89,13 +89,6 @@ export const fetchSettings = (): Promise<DownloadSettings | void> => {
         );
       }
 
-      // Ensure all fileCountMax and totalSizeMax are present.
-      if (!('fileCountMax' in settings && 'totalSizeMax' in settings)) {
-        throw new Error(
-          'fileCountMax or totalSizeMax is undefined in settings'
-        );
-      }
-
       // Ensure access methods are present in the configuration.
       if (!('accessMethods' in settings)) {
         throw new Error('accessMethods is undefined in settings');


### PR DESCRIPTION
This means we can more easily remember to check if they're set to a valid number via TS and to disable any features related to them if they're undefined - primilary what's fixed here is the "too many/much" alerts.

Because this is needed to create a patch release, it's needs to merge onto main (and it branched from main). I will then merge main into develop + resolve any merge conflicts.

## Description
Enter a description of the changes here

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Closes #1397
