### PR TITLE
Fix 'Date To' Filter in user download table  

### DIFF
--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -363,16 +363,20 @@ describe('Download Status Table', () => {
       name: 'downloadStatus.createdAt filter to',
     });
 
+    // Type into date from filter textbox
     await user.type(dateFromFilterInput, '2020-01-01 00:00');
 
+    // Should show all files
     expect(await screen.findByText('test-file-1')).toBeInTheDocument();
     expect(await screen.findByText('test-file-2')).toBeInTheDocument();
     expect(await screen.findByText('test-file-3')).toBeInTheDocument();
     expect(await screen.findByText('test-file-4')).toBeInTheDocument();
     expect(await screen.findByText('test-file-5')).toBeInTheDocument();
 
+    // Type into date to filter textbox
     await user.type(dateToFilterInput, '2020-01-02 23:59');
 
+    // Should show no files
     await waitFor(() => {
       expect(screen.queryByText('test-file-1')).toBeNull();
       expect(screen.queryByText('test-file-2')).toBeNull();
@@ -381,14 +385,42 @@ describe('Download Status Table', () => {
       expect(screen.queryByText('test-file-5')).toBeNull();
     });
 
+    // Clear both date filter textboxes
     await user.clear(dateFromFilterInput);
     await user.clear(dateToFilterInput);
+    // Type into both date filters
     await user.type(dateFromFilterInput, '2020-02-26 00:00');
     await user.type(dateToFilterInput, '2020-02-27 23:59');
 
+    // Should show only test-file-2 and test-file-3
     expect(await screen.findByText('test-file-2')).toBeInTheDocument();
     expect(await screen.findByText('test-file-3')).toBeInTheDocument();
     expect(screen.queryByText('test-file-1')).toBeNull();
+    expect(screen.queryByText('test-file-4')).toBeNull();
+    expect(screen.queryByText('test-file-5')).toBeNull();
+
+    // Clear both date filter textboxes
+    await user.clear(dateFromFilterInput);
+    await user.clear(dateToFilterInput);
+    // Type into only date from filter
+    await user.type(dateFromFilterInput, '2020-02-27 00:00');
+
+    // Should show test-file-3, test-file-4 and test-file-5
+    expect(await screen.findByText('test-file-3')).toBeInTheDocument();
+    expect(await screen.findByText('test-file-4')).toBeInTheDocument();
+    expect(await screen.findByText('test-file-5')).toBeInTheDocument();
+    expect(screen.queryByText('test-file-1')).toBeNull();
+    expect(screen.queryByText('test-file-2')).toBeNull();
+
+    // Clear date from filter textbox
+    await user.clear(dateFromFilterInput);
+    // Type into only date to filter
+    await user.type(dateToFilterInput, '2020-02-27 00:00');
+
+    // Should show only test-file-1 and test-file-2
+    expect(await screen.findByText('test-file-1')).toBeInTheDocument();
+    expect(await screen.findByText('test-file-2')).toBeInTheDocument();
+    expect(screen.queryByText('test-file-3')).toBeNull();
     expect(screen.queryByText('test-file-4')).toBeNull();
     expect(screen.queryByText('test-file-5')).toBeNull();
 

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -152,12 +152,13 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
           } else if (
             typeof value === 'object' &&
             'startDate' in value &&
-            'endDate' in value &&
-            value.startDate
+            'endDate' in value
           ) {
             // Check that the given date is in the range specified by the filter.
             const tableTimestamp = toDate(tableValue).getTime();
-            const startTimestamp = toDate(value.startDate).getTime();
+            const startTimestamp = value.startDate
+              ? new Date(value.startDate).getTime()
+              : 0;
             const endTimestamp = value.endDate
               ? new Date(value.endDate).getTime()
               : Date.now();


### PR DESCRIPTION
### Description
Old logic would not get to filter range checking if startDate was null (lines 152/156). Changes remove this check and add a conditional where startTimestamp is set, so that if startDate is null, assign the timestamp to 0.

Unit test updated to test each filter (from/to) independently, as well as general comments added to test file.

### Testing instructions
Can be tested by updating 'Date To' filter text box whilst keeping the 'Date From' box empty:

![chrome_V4AFWiDSer](https://user-images.githubusercontent.com/52418954/189115668-c3b6843d-4ae3-41ed-b550-6add37ba809c.gif)

### Agile board tracking
connect to #1399 
closes #1399 
