### PR TITLE
fix timestamps for Requested At columns in download tables

### DIFF
--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -165,7 +165,7 @@ describe('Download Status', () => {
       cy.get('[aria-rowcount="0"]').should('exist');
 
       const currDate = new Date();
-      const assertDate = new Date(currDate.toString());
+      const assertDate = currDate;
 
       cy.get('input[id="Requested Date filter from"]').clear();
       cy.get('input[id="Requested Date filter to"]').clear();
@@ -180,10 +180,11 @@ describe('Download Status', () => {
 
       cy.get('[aria-rowcount="4"]').should('exist');
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
-        'have.text',
-        format(assertDate, 'yyyy-MM-dd HH:mm:ss')
-      );
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]')
+        .should(($el) => {
+          const actual = new Date(String($el.text()))
+          expect(actual.getTime()).to.be.closeTo(assertDate.getTime(), 10000);
+        })
     });
 
     it('multiple columns', () => {

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -148,7 +148,7 @@ describe('Download Status', () => {
       );
     });
 
-    it.only('date between', () => {
+    it('date between', () => {
       cy.get('input[id="Requested Date filter from"]').type('2020-01-31 00:00');
 
       const date = new Date();

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -165,14 +165,11 @@ describe('Download Status', () => {
       cy.get('[aria-rowcount="0"]').should('exist');
 
       const currDate = new Date();
-      const assertDate = currDate;
+      currDate.setHours(0, 0, 0, 0)
 
       cy.get('input[id="Requested Date filter from"]').clear();
       cy.get('input[id="Requested Date filter to"]').clear();
       cy.get('[aria-rowcount="4"]').should('exist');
-
-      // Set currDate time to 00:00 before typing into Requested Date From textbox
-      currDate.setHours(0, 0, 0, 0)
 
       cy.get('input[id="Requested Date filter from"]').type(
         format(currDate, 'yyyy-MM-dd HH:mm')
@@ -180,11 +177,10 @@ describe('Download Status', () => {
 
       cy.get('[aria-rowcount="4"]').should('exist');
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]')
-        .should(($el) => {
-          const actual = new Date(String($el.text()))
-          expect(actual.getTime()).to.be.closeTo(assertDate.getTime(), 10000);
-        })
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
+        'contain',
+        format(currDate, 'yyyy-MM-dd HH:mm').slice(0,-6)
+      );
     });
 
     it('multiple columns', () => {

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -148,7 +148,7 @@ describe('Download Status', () => {
       );
     });
 
-    it('date between', () => {
+    it.only('date between', () => {
       cy.get('input[id="Requested Date filter from"]').type('2020-01-31 00:00');
 
       const date = new Date();
@@ -165,7 +165,7 @@ describe('Download Status', () => {
       cy.get('[aria-rowcount="0"]').should('exist');
 
       const currDate = new Date();
-      const assertDate = currDate;
+      const assertDate = new Date(currDate.toString());
 
       cy.get('input[id="Requested Date filter from"]').clear();
       cy.get('input[id="Requested Date filter to"]').clear();

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -179,7 +179,7 @@ describe('Download Status', () => {
 
       cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
         'contain',
-        format(currDate, 'yyyy-MM-dd HH:mm').slice(0,-6)
+        format(currDate, 'yyyy-MM-dd')
       );
     });
 

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -165,21 +165,24 @@ describe('Download Status', () => {
       cy.get('[aria-rowcount="0"]').should('exist');
 
       const currDate = new Date();
+      const assertDate = currDate;
 
       cy.get('input[id="Requested Date filter from"]').clear();
       cy.get('input[id="Requested Date filter to"]').clear();
       cy.get('[aria-rowcount="4"]').should('exist');
 
-      // Set time to 00:00 before typing into Requested Date From textbox
+      // Set currDate time to 00:00 before typing into Requested Date From textbox
+      currDate.setHours(0, 0, 0, 0)
+
       cy.get('input[id="Requested Date filter from"]').type(
-        format(new Date(currDate.setHours(0, 0, 0, 0)), 'yyyy-MM-dd HH:mm')
+        format(currDate, 'yyyy-MM-dd HH:mm')
       );
 
       cy.get('[aria-rowcount="4"]').should('exist');
 
       cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
         'have.text',
-        format(currDate, 'yyyy-MM-dd HH:mm:ss')
+        format(assertDate, 'yyyy-MM-dd HH:mm:ss')
       );
     });
 

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -165,7 +165,6 @@ describe('Download Status', () => {
       cy.get('[aria-rowcount="0"]').should('exist');
 
       const currDate = new Date();
-      currDate.setHours(0, 0, 0, 0);
 
       cy.get('input[id="Requested Date filter from"]').clear();
       cy.get('input[id="Requested Date filter to"]').clear();
@@ -184,7 +183,7 @@ describe('Download Status', () => {
     });
 
     it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Access Method').first().type('globus');
+      cy.get('[aria-label="Filter by Access Method"]').first().type('globus');
 
       cy.get('[aria-label="Filter by Availability"]').first().type('restoring');
 

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -165,7 +165,7 @@ describe('Download Status', () => {
       cy.get('[aria-rowcount="0"]').should('exist');
 
       const currDate = new Date();
-      currDate.setHours(0, 0, 0, 0)
+      currDate.setHours(0, 0, 0, 0);
 
       cy.get('input[id="Requested Date filter from"]').clear();
       cy.get('input[id="Requested Date filter to"]').clear();

--- a/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
+++ b/packages/datagateway-download/cypress/integration/downloadStatus.spec.ts
@@ -170,8 +170,9 @@ describe('Download Status', () => {
       cy.get('input[id="Requested Date filter to"]').clear();
       cy.get('[aria-rowcount="4"]').should('exist');
 
+      // Set time to 00:00 before typing into Requested Date From textbox
       cy.get('input[id="Requested Date filter from"]').type(
-        format(currDate, 'yyyy-MM-dd HH:mm')
+        format(new Date(currDate.setHours(0, 0, 0, 0)), 'yyyy-MM-dd HH:mm')
       );
 
       cy.get('[aria-rowcount="4"]').should('exist');

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -2294,11 +2294,11 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                             class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-188rx6i-MuiTableCell-root"
                           >
                             <p
-                              aria-label="2020-03-01 00:00:00"
+                              aria-label="2020-03-01 15:57:28"
                               class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap css-cvfmw9-MuiTypography-root"
                               data-mui-internal-clone-element="true"
                             >
-                              2020-03-01 00:00:00
+                              2020-03-01 15:57:28
                             </p>
                             <div
                               style="margin-left: 18px; padding-left: 4px; padding-right: 4px; height: 100%;"

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -325,12 +325,12 @@ const AdminDownloadStatusTable: React.FC = () => {
                       dataKey: 'createdAt',
                       cellContentRenderer: (props: TableCellProps) => {
                         if (props.cellData) {
-                          const incomming = String(props.cellData).substring(
-                            0,
-                            props.cellData.length - 5
+                          const date = toDate(
+                            props.cellData.substring(
+                              0,
+                              props.cellData.length - 5
+                            )
                           );
-                          const date = toDate(incomming);
-                          //const date = toDate(props.cellData);
                           return format(date, 'yyyy-MM-dd HH:mm:ss');
                         }
                       },

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -326,10 +326,7 @@ const AdminDownloadStatusTable: React.FC = () => {
                       cellContentRenderer: (props: TableCellProps) => {
                         if (props.cellData) {
                           const date = toDate(
-                            props.cellData.substring(
-                              0,
-                              props.cellData.length - 5
-                            )
+                            props.cellData.replace(/\[.*]/, '')
                           );
                           return format(date, 'yyyy-MM-dd HH:mm:ss');
                         }

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -325,7 +325,12 @@ const AdminDownloadStatusTable: React.FC = () => {
                       dataKey: 'createdAt',
                       cellContentRenderer: (props: TableCellProps) => {
                         if (props.cellData) {
-                          const date = toDate(props.cellData);
+                          const incomming = String(props.cellData).substring(
+                            0,
+                            props.cellData.length - 5
+                          );
+                          const date = toDate(incomming);
+                          //const date = toDate(props.cellData);
                           return format(date, 'yyyy-MM-dd HH:mm:ss');
                         }
                       },

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -249,7 +249,9 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                 dataKey: 'createdAt',
                 cellContentRenderer: (props: TableCellProps) => {
                   if (props.cellData) {
-                    const date = toDate(props.cellData);
+                    const date = toDate(
+                      props.cellData.substring(0, props.cellData.length - 5)
+                    );
                     return format(date, 'yyyy-MM-dd HH:mm:ss');
                   }
                 },

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -249,9 +249,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
                 dataKey: 'createdAt',
                 cellContentRenderer: (props: TableCellProps) => {
                   if (props.cellData) {
-                    const date = toDate(
-                      props.cellData.substring(0, props.cellData.length - 5)
-                    );
+                    const date = toDate(props.cellData.replace(/\[.*]/, ''));
                     return format(date, 'yyyy-MM-dd HH:mm:ss');
                   }
                 },


### PR DESCRIPTION
## Description
Bug #1410 fixed by using the regex replace suggested, `.replace(/\[.*]/, '')`, for both admin and normal download tables. More verbose validation could be done around `props.cellData` where we get the timestamp, however I presume validation is handled by date-fns-tz in the `toDate` method when parsing the date/time string (despite it not working right now :sweat_smile:), so adding more would most likely be redundant.

Additional testing is not required, as multiple date/time strings with the `[UTC]` tag are passed through within the snapshot tests. It seems [adminDownloadStatusTable.component.test.tsx.snap](https://github.com/ral-facilities/datagateway/pull/1414/files#diff-ee01cdf6466b0603ef0131094312ad44d569e5965510cbf1791c49f930d12035) was testing incorrect behaviour, and excepted the times to display as 00:00 given a string with the `[UTC]` tag, so I updated it.

This PR breaks [downloadStatus.spec.ts](https://github.com/ral-facilities/datagateway/pull/1414/files#diff-6ad1b3632d22ae29ffe2fdda72b61f79718f313a0b579dc6e9e04cf72f4eb147) e2e test, as the _should be able to filter download items by date between_ test case makes a check using a date object with the time set to 00:00, which now fails as the correct time is displayed. Current fix uses a `contain` to check the date is as expected, without comparing the time. This is because the test files seem to update somewhat inconsistently, and often it was testing against a timestamp significantly earlier than when the test is being run, making any checks against the time ineffective. I think this test case could be reworked (once filtering by time is working), however I believe this is out of scope for this issue.  

## Testing instructions
Can be seen on /download and /admin/download endpoints

download:
![image](https://user-images.githubusercontent.com/52418954/189709002-6c2b3966-e7ab-4b40-8089-685474039190.png)
## Testing instructions
Can be seen on /download and /admin/download endpoints

download:
![image](https://user-images.githubusercontent.com/52418954/189709002-6c2b3966-e7ab-4b40-8089-685474039190.png)

admin download:
![image](https://user-images.githubusercontent.com/52418954/189709730-965870ad-4ed9-4a57-ab04-734bf779a598.png)

## Agile board tracking
closes #1410 
