### PR TITLE
Fix incorrect study dates shown in ISIS study views with date filters

### DIFF
--- a/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.test.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.test.tsx
@@ -280,7 +280,7 @@ describe('Cell content renderers', () => {
 
     it('should return a list of study investigations that match the given end date filter with no start date', () => {
       const endDateFilter: DateFilter = {
-        endDate: '2010-03-01',
+        endDate: '2022-03-01',
       };
 
       const filters: FiltersType = {

--- a/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.test.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.test.tsx
@@ -9,7 +9,14 @@ import {
   tableLink,
   formatCountOrSize,
   getStudyInfoInvestigation,
+  filterStudyInfoInvestigations,
 } from './cellContentRenderers';
+import type {
+  DateFilter,
+  FiltersType,
+  Study,
+  TextFilter,
+} from '../../app.types';
 
 describe('Cell content renderers', () => {
   describe('formatBytes', () => {
@@ -125,6 +132,214 @@ describe('Cell content renderers', () => {
           ],
         })
       ).toBeUndefined();
+    });
+  });
+
+  describe('filterStudyInfoInvestigations', () => {
+    const study: Study = {
+      id: 1,
+      pid: '3Pd4AO',
+      name: 'lip',
+      modTime: '1977-01-01',
+      createTime: '1977-01-01',
+      studyInvestigations: [
+        {
+          id: 183,
+          investigation: {
+            id: 2,
+            title: 'react js',
+            name: 'rod of ages',
+            visitId: 'kxinp',
+            startDate: '2010-03-01',
+            endDate: '2021-01-09',
+          },
+        },
+        {
+          id: 248,
+          investigation: {
+            id: 3,
+            title: 'whenever maybe spill second',
+            name: 'divine sunderer',
+            visitId: 'B8YxAMU',
+            startDate: '2010-03-01',
+            endDate: '2025-01-09',
+          },
+        },
+        {
+          id: 374,
+          investigation: {
+            id: 3,
+            title: 'whenever maybe spill third',
+            name: 'boots of lucidity',
+            visitId: 'FNv0',
+            startDate: '2009-03-01',
+            endDate: '2021-12-23',
+          },
+        },
+      ],
+    };
+
+    it('should return a list of StudyInvestigations that only matches the given filters', () => {
+      const includeTitleFilter: TextFilter = {
+        type: 'include',
+        value: 'react',
+      };
+      const excludeTitleFilter: TextFilter = {
+        type: 'exclude',
+        value: 'react',
+      };
+      const startDateFilter: DateFilter = {
+        startDate: '2010-01-01',
+        endDate: '2011-01-01',
+      };
+      const endDateFilter: DateFilter = {
+        startDate: '2020-01-01',
+        endDate: '2022-01-01',
+      };
+      const filters: FiltersType = {
+        'studyInvestigations.investigation.title': includeTitleFilter,
+        'studyInvestigations.investigation.startDate': startDateFilter,
+        'studyInvestigations.investigation.endDate': endDateFilter,
+      };
+
+      expect(filterStudyInfoInvestigations(study, filters)).toEqual([
+        {
+          id: 183,
+          investigation: {
+            id: 2,
+            title: 'react js',
+            name: 'rod of ages',
+            visitId: 'kxinp',
+            startDate: '2010-03-01',
+            endDate: '2021-01-09',
+          },
+        },
+      ]);
+
+      // verify that the function works with exclude text filter
+      filters['studyInvestigations.investigation.title'] = excludeTitleFilter;
+      expect(filterStudyInfoInvestigations(study, filters)).toHaveLength(0);
+    });
+
+    it('should return a list of study investigations that match the given start date filter with no start date', () => {
+      const startDateFilter: DateFilter = {
+        endDate: '2009-04-01',
+      };
+      const filters: FiltersType = {
+        'studyInvestigations.investigation.startDate': startDateFilter,
+      };
+
+      expect(filterStudyInfoInvestigations(study, filters)).toEqual([
+        {
+          id: 374,
+          investigation: {
+            id: 3,
+            title: 'whenever maybe spill third',
+            name: 'boots of lucidity',
+            visitId: 'FNv0',
+            startDate: '2009-03-01',
+            endDate: '2021-12-23',
+          },
+        },
+      ]);
+    });
+
+    it('should return a list of study investigations that match the given start date filter with no end date', () => {
+      const startDateFilter: DateFilter = {
+        startDate: '2009-04-01',
+      };
+      const filters: FiltersType = {
+        'studyInvestigations.investigation.startDate': startDateFilter,
+      };
+
+      expect(filterStudyInfoInvestigations(study, filters)).toEqual([
+        {
+          id: 183,
+          investigation: {
+            id: 2,
+            title: 'react js',
+            name: 'rod of ages',
+            visitId: 'kxinp',
+            startDate: '2010-03-01',
+            endDate: '2021-01-09',
+          },
+        },
+        {
+          id: 248,
+          investigation: {
+            id: 3,
+            title: 'whenever maybe spill second',
+            name: 'divine sunderer',
+            visitId: 'B8YxAMU',
+            startDate: '2010-03-01',
+            endDate: '2025-01-09',
+          },
+        },
+      ]);
+    });
+
+    it('should return a list of study investigations that match the given end date filter with no start date', () => {
+      const endDateFilter: DateFilter = {
+        endDate: '2010-03-01',
+      };
+
+      const filters: FiltersType = {
+        'studyInvestigations.investigation.endDate': endDateFilter,
+      };
+
+      expect(filterStudyInfoInvestigations(study, filters)).toEqual([
+        {
+          id: 183,
+          investigation: {
+            id: 2,
+            title: 'react js',
+            name: 'rod of ages',
+            visitId: 'kxinp',
+            startDate: '2010-03-01',
+            endDate: '2021-01-09',
+          },
+        },
+        {
+          id: 374,
+          investigation: {
+            id: 3,
+            title: 'whenever maybe spill third',
+            name: 'boots of lucidity',
+            visitId: 'FNv0',
+            startDate: '2009-03-01',
+            endDate: '2021-12-23',
+          },
+        },
+      ]);
+    });
+
+    it('should return a list of study investigations that match the given end date filter with no end date', () => {
+      const endDateFilter: DateFilter = {
+        startDate: '2025-01-01',
+      };
+
+      const filters: FiltersType = {
+        'studyInvestigations.investigation.endDate': endDateFilter,
+      };
+
+      expect(filterStudyInfoInvestigations(study, filters)).toEqual([
+        {
+          id: 248,
+          investigation: {
+            id: 3,
+            title: 'whenever maybe spill second',
+            name: 'divine sunderer',
+            visitId: 'B8YxAMU',
+            startDate: '2010-03-01',
+            endDate: '2025-01-09',
+          },
+        },
+      ]);
+    });
+
+    it('should return undefined if the given study object does not have study investigations', () => {
+      const { studyInvestigations, ...rest } = study;
+      expect(filterStudyInfoInvestigations(rest, {})).toBeUndefined();
     });
   });
 

--- a/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
@@ -83,12 +83,30 @@ export const filterStudyInfoInvestigations = (
 
   if (titleFilter && titleFilter.value) {
     // check if the underlying Investigation has a matching title
-    filterFns.push(
-      (studyInvestigation) =>
-        studyInvestigation?.investigation?.title?.includes(
-          String(titleFilter.value)
-        ) === true
-    );
+    switch (titleFilter.type) {
+      case 'include':
+        // the filter requires the text to contain the value
+        filterFns.push(
+          (studyInvestigation) =>
+            studyInvestigation?.investigation?.title?.includes(
+              String(titleFilter.value)
+            ) === true
+        );
+        break;
+
+      case 'exclude':
+        // the filter requires the text to NOT contain the value
+        filterFns.push(
+          (studyInvestigation) =>
+            studyInvestigation?.investigation?.title?.includes(
+              String(titleFilter.value)
+            ) === false
+        );
+        break;
+
+      default:
+        break;
+    }
   }
   if (startDateFilter) {
     // check if the start date of the underlying Investigation falls

--- a/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
+++ b/packages/datagateway-common/src/table/cellRenderers/cellContentRenderers.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { Link } from '@mui/material';
-import { Investigation, Study, ViewsType } from '../../app.types';
+import type {
+  DateFilter,
+  FiltersType,
+  Investigation,
+  Study,
+  StudyInvestigation,
+  TextFilter,
+  ViewsType,
+} from '../../app.types';
 import { UseQueryResult } from 'react-query';
+import { isWithinInterval } from 'date-fns';
 
 export function formatBytes(bytes: number | undefined): string {
   if (bytes === -1) return 'Loading...';
@@ -40,6 +49,88 @@ export const getStudyInfoInvestigation = (
 ): Investigation | undefined => {
   return study.studyInvestigations?.filter((si) => si?.investigation)?.[0]
     ?.investigation;
+};
+
+/**
+ * Given a Study object and a list of query param filters, return a list of {@link StudyInvestigation}
+ * that passes the filters.
+ *
+ * @param study   The Study object that the returned list of StudyInvestigations belong to.
+ * @param filters The query param filters that should be applied to the filter operation.
+ *
+ * @return A list of {@link StudyInvestigation} belonging to the given {@link Study} object
+ *         that passes the given list of filters, or `undefined` if the {@link Study} object
+ *         doesn't have any {@link StudyInvestigation}s.
+ */
+export const filterStudyInfoInvestigations = (
+  study: Study,
+  filters: FiltersType
+): StudyInvestigation[] | undefined => {
+  const titleFilter = filters[
+    'studyInvestigations.investigation.title'
+  ] as TextFilter;
+  const startDateFilter = filters[
+    'studyInvestigations.investigation.startDate'
+  ] as DateFilter;
+  const endDateFilter = filters[
+    'studyInvestigations.investigation.endDate'
+  ] as DateFilter;
+
+  // a list of filters that a StudyInvestigation needs to pass
+  // in order to make it to the final list.
+  // Each function returns true or false indicating whether the given StudyInvestigation passes the filter.
+  const filterFns: ((s: StudyInvestigation) => boolean)[] = [];
+
+  if (titleFilter && titleFilter.value) {
+    // check if the underlying Investigation has a matching title
+    filterFns.push(
+      (studyInvestigation) =>
+        studyInvestigation?.investigation?.title?.includes(
+          String(titleFilter.value)
+        ) === true
+    );
+  }
+  if (startDateFilter) {
+    // check if the start date of the underlying Investigation falls
+    // within the range specified by the start date filter.
+
+    // if the start of the filter range is not specified, defaults to the beginning of time
+    // which is January 1st, 1970
+    const filterStart = new Date(startDateFilter.startDate ?? 0);
+    // if the end of the filter range is not specified, defaults to the end of the universe
+    // which is Sep 13, 275760
+    const filterEnd = new Date(startDateFilter.endDate ?? 8640000000000000);
+    filterFns.push((studyInvestigation) => {
+      const startDate = studyInvestigation?.investigation?.startDate;
+      if (!startDate) return false;
+      return isWithinInterval(new Date(startDate), {
+        start: filterStart,
+        end: filterEnd,
+      });
+    });
+  }
+  if (endDateFilter) {
+    // check if the e end date of the underlying Investigation falls
+    // within the range specified by the end date filter.
+
+    // if the start of the filter range is not specified, defaults to the beginning of time
+    // which is January 1st, 1970
+    const filterStart = new Date(endDateFilter.startDate ?? 0);
+    // if the end of the filter range is not specified, defaults to the end of the universe
+    // which is Sep 13, 275760
+    const filterEnd = new Date(endDateFilter.endDate ?? 8640000000000000);
+    filterFns.push((studyInvestigation) => {
+      const endDate = studyInvestigation?.investigation?.endDate;
+      if (!endDate) return false;
+      return isWithinInterval(new Date(endDate), {
+        start: filterStart,
+        end: filterEnd,
+      });
+    });
+  }
+
+  // return only the StudyInvestigations that passes every filter specified.
+  return study.studyInvestigations?.filter((s) => filterFns.every((f) => f(s)));
 };
 
 // NOTE: Allow the link to specify the view to keep the same view when navigating.

--- a/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisStudiesCardView.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/card/isis/__snapshots__/isisStudiesCardView.component.test.tsx.snap
@@ -9,6 +9,17 @@ Object {
       "modTime": "2000-01-01",
       "name": "Test 1",
       "pid": "doi",
+      "studyInvestigations": Array [
+        Object {
+          "id": 151,
+          "investigation": Object {
+            "id": 711,
+            "name": "investigation name",
+            "title": "investigation title",
+            "visitId": "IPim0",
+          },
+        },
+      ],
     },
   ],
   "description": Object {

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.test.tsx
@@ -65,6 +65,17 @@ describe('ISIS Studies - Card View', () => {
         name: 'Test 1',
         modTime: '2000-01-01',
         createTime: '2000-01-01',
+        studyInvestigations: [
+          {
+            id: 151,
+            investigation: {
+              id: 711,
+              title: 'investigation title',
+              name: 'investigation name',
+              visitId: 'IPim0',
+            },
+          },
+        ],
       },
     ];
     history = createMemoryHistory();

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   CardView,
   CardViewDetails,
+  filterStudyInfoInvestigations,
   getStudyInfoInvestigation,
   parseSearchToQuery,
   Study,
@@ -166,9 +167,25 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
     [dateFilter, t, textFilter]
   );
 
+  const aggregatedData = React.useMemo(
+    () =>
+      data?.reduce<Study[]>((studies, study) => {
+        studies.push(
+          ...(filterStudyInfoInvestigations(study, filters)?.map<Study>(
+            (studyInvestigation) => ({
+              ...study,
+              studyInvestigations: [studyInvestigation],
+            })
+          ) ?? [])
+        );
+        return studies;
+      }, []),
+    [data, filters]
+  );
+
   return (
     <CardView
-      data={data ?? []}
+      data={aggregatedData ?? []}
       totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilter}

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
@@ -192,7 +192,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
   return (
     <CardView
       data={aggregatedData ?? []}
-      totalDataCount={totalDataCount}
+      totalDataCount={totalDataCount ?? 0}
       onPageChange={pushPage}
       onFilter={pushFilter}
       onSort={handleSort}

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
@@ -169,6 +169,10 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
 
   const aggregatedData = React.useMemo(
     () =>
+      // for each Investigation in studyInvestigations that matches the current filter
+      // create a new Study object with the studyInvestigations array
+      // having only one StudyInvestigation (& Investigation) object in it
+      // so that each matched Investigation appears as a separate card
       data?.reduce<Study[]>((studies, study) => {
         studies.push(
           ...(filterStudyInfoInvestigations(study, filters)?.map<Study>(

--- a/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisStudiesCardView.component.tsx
@@ -174,14 +174,16 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
       // having only one StudyInvestigation (& Investigation) object in it
       // so that each matched Investigation appears as a separate card
       data?.reduce<Study[]>((studies, study) => {
-        studies.push(
-          ...(filterStudyInfoInvestigations(study, filters)?.map<Study>(
-            (studyInvestigation) => ({
-              ...study,
-              studyInvestigations: [studyInvestigation],
-            })
-          ) ?? [])
-        );
+        const firstInvestigationMatched = filterStudyInfoInvestigations(
+          study,
+          filters
+        )?.[0];
+        studies.push({
+          ...study,
+          studyInvestigations: firstInvestigationMatched
+            ? [firstInvestigationMatched]
+            : study.studyInvestigations,
+        });
         return studies;
       }, []),
     [data, filters]
@@ -190,7 +192,7 @@ const ISISStudiesCardView = (props: ISISStudiesCVProps): React.ReactElement => {
   return (
     <CardView
       data={aggregatedData ?? []}
-      totalDataCount={totalDataCount ?? 0}
+      totalDataCount={totalDataCount}
       onPageChange={pushPage}
       onFilter={pushFilter}
       onSort={handleSort}

--- a/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/table/isis/__snapshots__/isisStudiesTable.component.test.tsx.snap
@@ -82,6 +82,17 @@ Object {
       "modTime": "2000-01-01",
       "name": "Test 1",
       "pid": "doi",
+      "studyInvestigations": Array [
+        Object {
+          "id": 636,
+          "investigation": Object {
+            "id": 357,
+            "name": "peculiar crowd",
+            "title": "all might urgent",
+            "visitId": "Y2D8y7v",
+          },
+        },
+      ],
     },
   ],
   "loadMoreRows": [Function],

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.test.tsx
@@ -78,6 +78,17 @@ describe('ISIS Studies table component', () => {
         name: 'Test 1',
         modTime: '2000-01-01',
         createTime: '2000-01-01',
+        studyInvestigations: [
+          {
+            id: 636,
+            investigation: {
+              id: 357,
+              title: 'all might urgent',
+              name: 'peculiar crowd',
+              visitId: 'Y2D8y7v',
+            },
+          },
+        ],
       },
     ];
     history = createMemoryHistory();

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -95,20 +95,25 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
   ]);
 
   /* istanbul ignore next */
-  const aggregatedData: Study[] = React.useMemo(() => {
-    if (!data) return [];
-    return data.pages.flat().reduce<Study[]>((studies, study) => {
-      studies.push(
-        ...(filterStudyInfoInvestigations(study, filters)?.map<Study>(
-          (studyInvestigation) => ({
-            ...study,
-            studyInvestigations: [studyInvestigation],
-          })
-        ) ?? [])
-      );
-      return studies;
-    }, []);
-  }, [data, filters]);
+  const aggregatedData: Study[] = React.useMemo(
+    () =>
+      // for each Investigation in studyInvestigations that matches the current filter
+      // create a new Study object with the studyInvestigations array
+      // having only one StudyInvestigation (& Investigation) object in it
+      // so that each matched Investigation appears as a separate row in the table
+      data?.pages.flat().reduce<Study[]>((studies, study) => {
+        studies.push(
+          ...(filterStudyInfoInvestigations(study, filters)?.map<Study>(
+            (studyInvestigation) => ({
+              ...study,
+              studyInvestigations: [studyInvestigation],
+            })
+          ) ?? [])
+        );
+        return studies;
+      }, []) ?? [],
+    [data, filters]
+  );
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -1,26 +1,27 @@
 import {
+  ColumnType,
+  externalSiteLink,
+  filterStudyInfoInvestigations,
+  getStudyInfoInvestigation,
+  parseSearchToQuery,
+  Study,
   Table,
   tableLink,
-  parseSearchToQuery,
-  useStudiesInfinite,
-  useStudyCount,
-  ColumnType,
-  getStudyInfoInvestigation,
-  Study,
   useDateFilter,
   useSort,
+  useStudiesInfinite,
+  useStudyCount,
   useTextFilter,
-  externalSiteLink,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { IndexRange, TableCellProps } from 'react-virtualized';
 
 import {
-  Public,
-  Fingerprint,
-  Subject,
   CalendarToday,
+  Fingerprint,
+  Public,
+  Subject,
 } from '@mui/icons-material';
 import { useLocation } from 'react-router-dom';
 import { format, set } from 'date-fns';
@@ -95,16 +96,19 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
 
   /* istanbul ignore next */
   const aggregatedData: Study[] = React.useMemo(() => {
-    if (data) {
-      if ('pages' in data) {
-        return data.pages.flat();
-      } else if (data instanceof Array) {
-        return data;
-      }
-    }
-
-    return [];
-  }, [data]);
+    if (!data) return [];
+    return data.pages.flat().reduce<Study[]>((studies, study) => {
+      studies.push(
+        ...(filterStudyInfoInvestigations(study, filters)?.map<Study>(
+          (studyInvestigation) => ({
+            ...study,
+            studyInvestigations: [studyInvestigation],
+          })
+        ) ?? [])
+      );
+      return studies;
+    }, []);
+  }, [data, filters]);
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -97,19 +97,17 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
   /* istanbul ignore next */
   const aggregatedData: Study[] = React.useMemo(
     () =>
-      // for each Investigation in studyInvestigations that matches the current filter
-      // create a new Study object with the studyInvestigations array
-      // having only one StudyInvestigation (& Investigation) object in it
-      // so that each matched Investigation appears as a separate row in the table
       data?.pages.flat().reduce<Study[]>((studies, study) => {
-        studies.push(
-          ...(filterStudyInfoInvestigations(study, filters)?.map<Study>(
-            (studyInvestigation) => ({
-              ...study,
-              studyInvestigations: [studyInvestigation],
-            })
-          ) ?? [])
-        );
+        const firstInvestigationMatched = filterStudyInfoInvestigations(
+          study,
+          filters
+        )?.[0];
+        studies.push({
+          ...study,
+          studyInvestigations: firstInvestigationMatched
+            ? [firstInvestigationMatched]
+            : study.studyInvestigations,
+        });
         return studies;
       }, []) ?? [],
     [data, filters]
@@ -190,7 +188,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
     <Table
       data={aggregatedData}
       loadMoreRows={loadMoreRows}
-      totalRowCount={totalDataCount ?? 0}
+      totalRowCount={totalDataCount}
       sort={sort}
       onSort={handleSort}
       columns={columns}

--- a/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisStudiesTable.component.tsx
@@ -188,7 +188,7 @@ const ISISStudiesTable = (props: ISISStudiesTableProps): React.ReactElement => {
     <Table
       data={aggregatedData}
       loadMoreRows={loadMoreRows}
-      totalRowCount={totalDataCount}
+      totalRowCount={totalDataCount ?? 0}
       sort={sort}
       onSort={handleSort}
       columns={columns}


### PR DESCRIPTION
## Description
This PR addresses an issue where the dates of studies are sometimes incorrect when date filters are applied.

Each `Study` object has a `studyInvestigations` field which is a list of `StudyInvestigation`s that belong to the `Study`. Currently, for `Study`s with multiple `StudyInvestigation`s, only the info of the first one is shown (e.g. start date and end date). With the filters are applied, the first `StudyInvestigation` in the list may not necessarily match the active filters, causing a mismatch between the info that is shown and the active filters.

I created a new function that, given a list of `StudyInvestigation`s and the active filters, returns the `StudyInvestigations` that match the filters. Then, to show each matched `StudyInvestigation`s properly, for each matched `StudyInvestigation`s, a new `Study` object is created and added to the list of `Study`s. Finally, the aggregated list is passed to either the table view or the card view. This means a `Study` can appear as "duplicate" rows, but each row will show info of a different `StudyInvestigation`.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #1390 