### PR TITLE
Updating yarn.lock to remove unnecessary package

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9977,13 +9977,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"functional-red-black-tree@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "functional-red-black-tree@npm:1.0.1"
-  checksum: ca6c170f37640e2d94297da8bb4bf27a1d12bea3e00e6a3e007fd7aa32e37e000f5772acf941b4e4f3cf1c95c3752033d0c509af157ad8f526e7f00723b9eb9f
-  languageName: node
-  linkType: hard
-
 "functions-have-names@npm:^1.2.2":
   version: 1.2.2
   resolution: "functions-have-names@npm:1.2.2"


### PR DESCRIPTION
## Description
The package is functional-red-black-tree. This seemed to occur when I merged the package update to eslint. See the job output here: https://github.com/ral-facilities/datagateway/actions/runs/3135025960/jobs/5105091193

## Testing instructions
The CI tests should pass

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Hotfix