### PR TITLE
[Hotfix] attempting to fix failing download unit tests

### DIFF
--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -373,11 +373,17 @@ describe('Admin Download Status Table', () => {
 
     await flushPromises();
 
-    expect(
-      await screen.findByRole('button', {
-        name: 'downloadStatus.restore {filename:test-file-4}',
-      })
-    ).toBeInTheDocument();
+    // without waitFor,
+    // toBeInTheDocument will complain it can't find the element
+    // even though findBy didn't throw...
+    // (it throws when the elemenet actually doesn't exist)
+    await waitFor(async () => {
+      expect(
+        await screen.findByRole('button', {
+          name: 'downloadStatus.restore {filename:test-file-4}',
+        })
+      ).toBeInTheDocument();
+    });
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (
@@ -425,6 +431,18 @@ describe('Admin Download Status Table', () => {
         name: 'downloadStatus.pause {filename:test-file-3}',
       })
     ).toBeInTheDocument();
+
+    // without waitFor,
+    // toBeInTheDocument will complain it can't find the element
+    // even though findBy didn't throw...
+    // (it throws when the elemenet actually doesn't exist)
+    // await waitFor(async () => {
+    //   expect(
+    //     await screen.findByRole('button', {
+    //       name: 'downloadStatus.pause {filename:test-file-3}',
+    //     })
+    //   ).toBeInTheDocument();
+    // });
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (
@@ -514,11 +532,13 @@ describe('Admin Download Status Table', () => {
 
     await flushPromises();
 
-    expect(
-      await screen.findByRole('button', {
-        name: 'downloadStatus.delete {filename:test-file-1}',
-      })
-    ).toBeInTheDocument();
+    await waitFor(async () => {
+      expect(
+        await screen.findByRole('button', {
+          name: 'downloadStatus.delete {filename:test-file-1}',
+        })
+      ).toBeInTheDocument();
+    });
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -629,5 +629,5 @@ describe('Admin Download Status Table', () => {
         expect(progressText).toBeInTheDocument();
       }
     });
-  });
+  }, 10000);
 });

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -15,6 +15,7 @@ import {
 } from '../setupTests';
 import userEvent from '@testing-library/user-event';
 import {
+  act,
   render,
   RenderResult,
   screen,
@@ -371,7 +372,7 @@ describe('Admin Download Status Table', () => {
   it('should send restore item and item status requests when restore button is clicked', async () => {
     renderComponent();
 
-    await flushPromises();
+    await act(async () => flushPromises());
 
     // without waitFor,
     // toBeInTheDocument will complain it can't find the element
@@ -424,7 +425,7 @@ describe('Admin Download Status Table', () => {
   it('should send pause restore request when pause button is clicked', async () => {
     renderComponent();
 
-    await flushPromises();
+    await act(async () => flushPromises());
 
     // without waitFor,
     // toBeInTheDocument will complain it can't find the element
@@ -477,7 +478,7 @@ describe('Admin Download Status Table', () => {
   it('should send resume restore request when resume button is clicked', async () => {
     renderComponent();
 
-    await flushPromises();
+    await act(async () => flushPromises());
 
     await waitFor(() => {
       expect(
@@ -526,7 +527,7 @@ describe('Admin Download Status Table', () => {
   it('should send delete item request when delete button is clicked', async () => {
     renderComponent();
 
-    await flushPromises();
+    await act(async () => flushPromises());
 
     await waitFor(async () => {
       expect(

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -427,17 +427,23 @@ describe('Admin Download Status Table', () => {
 
     await act(async () => flushPromises());
 
+    expect(
+      await screen.findByRole('button', {
+        name: 'downloadStatus.pause {filename:test-file-3}',
+      })
+    ).toBeInTheDocument();
+
     // without waitFor,
     // toBeInTheDocument will complain it can't find the element
     // even though findBy didn't throw...
     // (it throws when the elemenet actually doesn't exist)
-    await waitFor(async () => {
-      expect(
-        await screen.findByRole('button', {
-          name: 'downloadStatus.pause {filename:test-file-3}',
-        })
-      ).toBeInTheDocument();
-    });
+    // await waitFor(async () => {
+    //   expect(
+    //     await screen.findByRole('button', {
+    //       name: 'downloadStatus.pause {filename:test-file-3}',
+    //     })
+    //   ).toBeInTheDocument();
+    // });
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (
@@ -480,13 +486,11 @@ describe('Admin Download Status Table', () => {
 
     await act(async () => flushPromises());
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', {
-          name: 'downloadStatus.resume {filename:test-file-5}',
-        })
-      ).toBeInTheDocument();
-    });
+    expect(
+      screen.getByRole('button', {
+        name: 'downloadStatus.resume {filename:test-file-5}',
+      })
+    ).toBeInTheDocument();
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -423,6 +423,7 @@ describe('Admin Download Status Table', () => {
   }, 10000);
 
   it('should send pause restore request when pause button is clicked', async () => {
+    jest.useFakeTimers();
     renderComponent();
 
     await act(async () => flushPromises());
@@ -474,14 +475,20 @@ describe('Admin Download Status Table', () => {
       })
     );
 
+    jest.runAllTimers();
+    await act(async () => flushPromises());
+
     expect(
       await screen.findByRole('button', {
         name: 'downloadStatus.resume {filename:test-file-3}',
       })
     ).toBeInTheDocument();
-  });
+
+    jest.useRealTimers();
+  }, 10000);
 
   it('should send resume restore request when resume button is clicked', async () => {
+    jest.useFakeTimers();
     renderComponent();
 
     await act(async () => flushPromises());
@@ -521,14 +528,20 @@ describe('Admin Download Status Table', () => {
       })
     );
 
+    jest.runAllTimers();
+    await act(async () => flushPromises());
+
     expect(
       await screen.findByRole('button', {
         name: 'downloadStatus.pause {filename:test-file-5}',
       })
     ).toBeInTheDocument();
-  });
+
+    jest.useRealTimers();
+  }, 10000);
 
   it('should send delete item request when delete button is clicked', async () => {
+    jest.useFakeTimers();
     renderComponent();
 
     await act(async () => flushPromises());
@@ -569,12 +582,17 @@ describe('Admin Download Status Table', () => {
       })
     );
 
+    jest.runAllTimers();
+    await act(async () => flushPromises());
+
     expect(
       await screen.findByRole('button', {
         name: 'downloadStatus.restore {filename:test-file-1}',
       })
     ).toBeInTheDocument();
-  });
+
+    jest.useRealTimers();
+  }, 10000);
 
   it('should display progress ui if enabled', async () => {
     (

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -373,17 +373,11 @@ describe('Admin Download Status Table', () => {
 
     await flushPromises();
 
-    // without waitFor,
-    // toBeInTheDocument will complain it can't find the element
-    // even though findBy didn't throw...
-    // (it throws when the elemenet actually doesn't exist)
-    await waitFor(async () => {
-      expect(
-        await screen.findByRole('button', {
-          name: 'downloadStatus.restore {filename:test-file-4}',
-        })
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('button', {
+        name: 'downloadStatus.restore {filename:test-file-4}',
+      })
+    ).toBeInTheDocument();
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (
@@ -431,18 +425,6 @@ describe('Admin Download Status Table', () => {
         name: 'downloadStatus.pause {filename:test-file-3}',
       })
     ).toBeInTheDocument();
-
-    // without waitFor,
-    // toBeInTheDocument will complain it can't find the element
-    // even though findBy didn't throw...
-    // (it throws when the elemenet actually doesn't exist)
-    // await waitFor(async () => {
-    //   expect(
-    //     await screen.findByRole('button', {
-    //       name: 'downloadStatus.pause {filename:test-file-3}',
-    //     })
-    //   ).toBeInTheDocument();
-    // });
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (
@@ -532,13 +514,11 @@ describe('Admin Download Status Table', () => {
 
     await flushPromises();
 
-    await waitFor(async () => {
-      expect(
-        await screen.findByRole('button', {
-          name: 'downloadStatus.delete {filename:test-file-1}',
-        })
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('button', {
+        name: 'downloadStatus.delete {filename:test-file-1}',
+      })
+    ).toBeInTheDocument();
 
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -432,18 +432,6 @@ describe('Admin Download Status Table', () => {
       })
     ).toBeInTheDocument();
 
-    // without waitFor,
-    // toBeInTheDocument will complain it can't find the element
-    // even though findBy didn't throw...
-    // (it throws when the elemenet actually doesn't exist)
-    // await waitFor(async () => {
-    //   expect(
-    //     await screen.findByRole('button', {
-    //       name: 'downloadStatus.pause {filename:test-file-3}',
-    //     })
-    //   ).toBeInTheDocument();
-    // });
-
     (fetchAdminDownloads as jest.Mock).mockImplementation(
       (
         settings: { facilityName: string; downloadApiUrl: string },

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -15,7 +15,6 @@ import {
 } from '../setupTests';
 import userEvent from '@testing-library/user-event';
 import {
-  act,
   render,
   RenderResult,
   screen,
@@ -372,7 +371,7 @@ describe('Admin Download Status Table', () => {
   it('should send restore item and item status requests when restore button is clicked', async () => {
     renderComponent();
 
-    await act(async () => flushPromises());
+    await flushPromises();
 
     // without waitFor,
     // toBeInTheDocument will complain it can't find the element
@@ -423,10 +422,9 @@ describe('Admin Download Status Table', () => {
   }, 10000);
 
   it('should send pause restore request when pause button is clicked', async () => {
-    jest.useFakeTimers();
     renderComponent();
 
-    await act(async () => flushPromises());
+    await flushPromises();
 
     expect(
       await screen.findByRole('button', {
@@ -475,23 +473,17 @@ describe('Admin Download Status Table', () => {
       })
     );
 
-    jest.runAllTimers();
-    await act(async () => flushPromises());
-
     expect(
       await screen.findByRole('button', {
         name: 'downloadStatus.resume {filename:test-file-3}',
       })
     ).toBeInTheDocument();
-
-    jest.useRealTimers();
   }, 10000);
 
   it('should send resume restore request when resume button is clicked', async () => {
-    jest.useFakeTimers();
     renderComponent();
 
-    await act(async () => flushPromises());
+    await flushPromises();
 
     expect(
       screen.getByRole('button', {
@@ -528,23 +520,17 @@ describe('Admin Download Status Table', () => {
       })
     );
 
-    jest.runAllTimers();
-    await act(async () => flushPromises());
-
     expect(
       await screen.findByRole('button', {
         name: 'downloadStatus.pause {filename:test-file-5}',
       })
     ).toBeInTheDocument();
-
-    jest.useRealTimers();
   }, 10000);
 
   it('should send delete item request when delete button is clicked', async () => {
-    jest.useFakeTimers();
     renderComponent();
 
-    await act(async () => flushPromises());
+    await flushPromises();
 
     await waitFor(async () => {
       expect(
@@ -582,16 +568,11 @@ describe('Admin Download Status Table', () => {
       })
     );
 
-    jest.runAllTimers();
-    await act(async () => flushPromises());
-
     expect(
       await screen.findByRole('button', {
         name: 'downloadStatus.restore {filename:test-file-1}',
       })
     ).toBeInTheDocument();
-
-    jest.useRealTimers();
   }, 10000);
 
   it('should display progress ui if enabled', async () => {


### PR DESCRIPTION
## Description
The develop branch is currently being plagued by failing unit tests in DG download's admin download status table. These were recently amended in https://github.com/ral-facilities/datagateway/pull/1404/ and I think the problem originated here but it went unseen due to passing tests. I believe an underlying issue exists and this PR will attempt to address that.

I'll be merging it into [Jounaid's unrelated PR](https://github.com/ral-facilities/datagateway/pull/1434) for further testing purposes before any changes here make it to develop.

## Testing instructions
Check all tests pass and also try them locally

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Hotfix