### PR TITLE
Bumping @mui/x-date-pickers to v5.0.9

### DIFF
--- a/packages/datagateway-common/package.json
+++ b/packages/datagateway-common/package.json
@@ -10,7 +10,7 @@
     "@date-io/date-fns": "2.16.0",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",
-    "@mui/x-date-pickers": "5.0.0-beta.5",
+    "@mui/x-date-pickers": "5.0.9",
     "@types/lodash.debounce": "4.0.6",
     "axios": "0.27.2",
     "connected-react-router": "6.9.1",

--- a/packages/datagateway-search/package.json
+++ b/packages/datagateway-search/package.json
@@ -9,7 +9,7 @@
     "@emotion/styled": "11.10.0",
     "@mui/icons-material": "5.10.3",
     "@mui/material": "5.10.0",
-    "@mui/x-date-pickers": "5.0.0-beta.5",
+    "@mui/x-date-pickers": "5.0.9",
     "@types/history": "4.7.11",
     "@types/jest": "29.2.1",
     "@types/jsrsasign": "10.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,12 +1447,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.20.0
   resolution: "@babel/runtime@npm:7.20.0"
   dependencies:
     regenerator-runtime: ^0.13.10
   checksum: 637fca51db34f3a59d329b7e0d01163769fe94915fdb04e4ac4ba62de9f1ca637ce3a564fe3b0166ccdd7f02f14b6a5707ee3e550b3e01c72327c6620d8e6a8b
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.20.1":
+  version: 7.20.6
+  resolution: "@babel/runtime@npm:7.20.6"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 42a8504db21031b1859fbc0f52d698a3d2f5ada9519eb76c6f96a7e657d8d555732a18fe71ef428a67cc9fc81ca0d3562fb7afdc70549c5fec343190cbaa9b03
   languageName: node
   linkType: hard
 
@@ -1624,14 +1633,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@date-io/core@npm:^2.14.0, @date-io/core@npm:^2.15.0, @date-io/core@npm:^2.16.0":
+"@date-io/core@npm:^2.15.0, @date-io/core@npm:^2.16.0":
   version: 2.16.0
   resolution: "@date-io/core@npm:2.16.0"
   checksum: 336d0dd90fd0848116472cfb0e694e85860b2916952304201bb4d3a23d453d44589d346494584faba0fc05751cc38f1880889ce48cd982377aac2bfb20469b8a
   languageName: node
   linkType: hard
 
-"@date-io/date-fns@npm:2.16.0, @date-io/date-fns@npm:^2.14.0":
+"@date-io/date-fns@npm:2.16.0, @date-io/date-fns@npm:^2.15.0":
   version: 2.16.0
   resolution: "@date-io/date-fns@npm:2.16.0"
   dependencies:
@@ -1645,45 +1654,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@date-io/dayjs@npm:^2.14.0":
-  version: 2.15.0
-  resolution: "@date-io/dayjs@npm:2.15.0"
+"@date-io/dayjs@npm:^2.15.0":
+  version: 2.16.0
+  resolution: "@date-io/dayjs@npm:2.16.0"
   dependencies:
-    "@date-io/core": ^2.15.0
+    "@date-io/core": ^2.16.0
   peerDependencies:
     dayjs: ^1.8.17
   peerDependenciesMeta:
     dayjs:
       optional: true
-  checksum: 3c06544f00ee33ea08d9002e988555f156559f06142bffcc9877f284057ae1aaa53967d97df771afabbb1fa87643d2f10130ee4d1f0fd7337ebdf2eba57a3018
+  checksum: bb8192207addbf6430c35da7664b97761f87d2c6cf4a3eaf464584a980e6cecaede581af1a40c5ba0a0189dc6bff2ac16408a95ec88e542b16915430191298c8
   languageName: node
   linkType: hard
 
-"@date-io/luxon@npm:^2.14.0":
-  version: 2.15.0
-  resolution: "@date-io/luxon@npm:2.15.0"
+"@date-io/luxon@npm:^2.15.0":
+  version: 2.16.1
+  resolution: "@date-io/luxon@npm:2.16.1"
   dependencies:
-    "@date-io/core": ^2.15.0
+    "@date-io/core": ^2.16.0
   peerDependencies:
-    luxon: ^1.21.3 || ^2.x
+    luxon: ^1.21.3 || ^2.x || ^3.x
   peerDependenciesMeta:
     luxon:
       optional: true
-  checksum: 727ae1341040459fdf9ec4b818f46f926dba4f2b7258ae1f0c5da3b040e520322d451a5c5db6c1e6c150173e2a2ea384b56fc2d158352804c2b4e984324fceaf
+  checksum: ac3f667ff122728e7559fac96f75bc85109d0054bf3955c1aea9d8365e08bd49ed51780f7f3900160773c0ed584db21556ea7d49acf075c61a30eb0b0e5da935
   languageName: node
   linkType: hard
 
-"@date-io/moment@npm:^2.14.0":
-  version: 2.15.0
-  resolution: "@date-io/moment@npm:2.15.0"
+"@date-io/moment@npm:^2.15.0":
+  version: 2.16.1
+  resolution: "@date-io/moment@npm:2.16.1"
   dependencies:
-    "@date-io/core": ^2.15.0
+    "@date-io/core": ^2.16.0
   peerDependencies:
     moment: ^2.24.0
   peerDependenciesMeta:
     moment:
       optional: true
-  checksum: a2d5061ae2c7204f06bf5ced285685f2b1d73d8f89235c5344878b41266a920de72388d5c2b004be22b50982519efc824e5a9e9e89725de86bd6afd0740c5934
+  checksum: 37a541661c504e1005904fab27b7b01d0c5d6c9c8c8a3b0a69d42a578aee8c52de7c181f917ad7acb14a9d7356d240c7e107777edf10efa11a453535977fc905
   languageName: node
   linkType: hard
 
@@ -2350,7 +2359,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^5.4.1, @mui/utils@npm:^5.9.3":
+"@mui/utils@npm:^5.10.3":
+  version: 5.10.16
+  resolution: "@mui/utils@npm:5.10.16"
+  dependencies:
+    "@babel/runtime": ^7.20.1
+    "@types/prop-types": ^15.7.5
+    "@types/react-is": ^16.7.1 || ^17.0.0
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: 2db4ac76544fe19856b5d456b2ddfb55baf505ce24f27f1d06900758d61067b74ceb94069d34cb82467e4be5fa33d613a0f2f947fc7b29315317090ac8cacbeb
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^5.9.3":
   version: 5.9.3
   resolution: "@mui/utils@npm:5.9.3"
   dependencies:
@@ -2365,21 +2389,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/x-date-pickers@npm:5.0.0-beta.5":
-  version: 5.0.0-beta.5
-  resolution: "@mui/x-date-pickers@npm:5.0.0-beta.5"
+"@mui/x-date-pickers@npm:5.0.9":
+  version: 5.0.9
+  resolution: "@mui/x-date-pickers@npm:5.0.9"
   dependencies:
-    "@babel/runtime": ^7.18.6
-    "@date-io/core": ^2.14.0
-    "@date-io/date-fns": ^2.14.0
-    "@date-io/dayjs": ^2.14.0
-    "@date-io/luxon": ^2.14.0
-    "@date-io/moment": ^2.14.0
-    "@mui/utils": ^5.4.1
+    "@babel/runtime": ^7.18.9
+    "@date-io/core": ^2.15.0
+    "@date-io/date-fns": ^2.15.0
+    "@date-io/dayjs": ^2.15.0
+    "@date-io/luxon": ^2.15.0
+    "@date-io/moment": ^2.15.0
+    "@mui/utils": ^5.10.3
     "@types/react-transition-group": ^4.4.5
     clsx: ^1.2.1
     prop-types: ^15.7.2
-    react-transition-group: ^4.4.2
+    react-transition-group: ^4.4.5
     rifm: ^0.12.1
   peerDependencies:
     "@emotion/react": ^11.9.0
@@ -2405,7 +2429,7 @@ __metadata:
       optional: true
     moment:
       optional: true
-  checksum: 95da0c7b41595f62a9a2bd97b975950d500a966034bda6bb03390b391dee6fff3aaa809f1907d8ee533c0408f8342917eb68b1bf4b773e09c8fa03fc0be90832
+  checksum: 11c7414b59bdc34ac5708ccb0fd799a928915b792f2b9342994e74a61d5c718803aea32a92c3de2aed7ee7383b6fc5ba01689559a6b93946a10ecb7e7b9f4a18
   languageName: node
   linkType: hard
 
@@ -6156,7 +6180,7 @@ __metadata:
     "@emotion/styled": 11.10.0
     "@mui/icons-material": 5.10.3
     "@mui/material": 5.10.0
-    "@mui/x-date-pickers": 5.0.0-beta.5
+    "@mui/x-date-pickers": 5.0.9
     "@testing-library/jest-dom": 5.16.4
     "@testing-library/react": 12.1.3
     "@testing-library/react-hooks": 8.0.1
@@ -6368,7 +6392,7 @@ __metadata:
     "@emotion/styled": 11.10.0
     "@mui/icons-material": 5.10.3
     "@mui/material": 5.10.0
-    "@mui/x-date-pickers": 5.0.0-beta.5
+    "@mui/x-date-pickers": 5.0.9
     "@testing-library/react": 12.1.3
     "@types/enzyme": 3.10.10
     "@types/history": 4.7.11
@@ -13303,7 +13327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-transition-group@npm:^4.4.2, react-transition-group@npm:^4.4.5":
+"react-transition-group@npm:^4.4.5":
   version: 4.4.5
   resolution: "react-transition-group@npm:4.4.5"
   dependencies:
@@ -13455,6 +13479,13 @@ __metadata:
   version: 0.13.10
   resolution: "regenerator-runtime@npm:0.13.10"
   checksum: 09893f5a9e82932642d9a999716b6c626dc53ef2a01307c952ebbf8e011802360163a37c304c18a6c358548be5a72b448e37209954a18696f21e438c81cbb4b9
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Noticed we are still using a beta version of this library and renovate wasn't updating it. This should keep things updated.

## Testing instructions
Check I've updated to v5.0.9 and tests still pass.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Hotfix