### PR TITLE
Fix refresh button in user download table

### DIFF
--- a/packages/datagateway-dataview/cypress/e2e/card/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/datasets.cy.ts
@@ -84,7 +84,7 @@ describe('Datasets Cards', () => {
       .parent()
       .find('button')
       .click();
-    cy.get('.MuiPickersDay-root[tabindex="-1"]')
+    cy.get('.MuiPickersDay-root[type="button"]')
       .first()
       .click()
       .wait(['@getDatasetsCount'], { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/e2e/card/dls/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/dls/datasets.cy.ts
@@ -129,7 +129,7 @@ describe('DLS - Datasets Cards', () => {
         .parent()
         .find('button')
         .click();
-      cy.get('.MuiPickersDay-root[tabindex="-1"]')
+      cy.get('.MuiPickersDay-root[type="button"]')
         .first()
         .click()
         .wait(['@getDatasetsCount'], { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/e2e/card/dls/visits.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/dls/visits.cy.ts
@@ -136,7 +136,7 @@ describe('DLS - Visits Cards', () => {
         .parent()
         .find('button')
         .click();
-      cy.get('.MuiPickersDay-root[tabindex="-1"]')
+      cy.get('.MuiPickersDay-root[type="button"]')
         .first()
         .click()
         .wait(['@getInvestigationsCount'], { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/e2e/card/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/investigations.cy.ts
@@ -146,7 +146,7 @@ describe('Investigations Cards', () => {
       .parent()
       .find('button')
       .click();
-    cy.get('.MuiPickersDay-root[tabindex="-1"]')
+    cy.get('.MuiPickersDay-root[type="button"]')
       .first()
       .click()
       .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {

--- a/packages/datagateway-dataview/cypress/e2e/card/isis/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/isis/datasets.cy.ts
@@ -134,7 +134,7 @@ describe('ISIS - Datasets Cards', () => {
         .parent()
         .find('button')
         .click();
-      cy.get('.MuiPickersDay-root[tabindex="-1"]')
+      cy.get('.MuiPickersDay-root[type="button"]')
         .first()
         .click()
         .wait(['@getDatasetsCount'], { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/e2e/card/isis/facilityCycles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/isis/facilityCycles.cy.ts
@@ -99,7 +99,7 @@ describe('ISIS - FacilityCycles Cards', () => {
         .parent()
         .find('button')
         .click();
-      cy.get('.MuiPickersDay-root[tabindex="-1"]')
+      cy.get('.MuiPickersDay-root[type="button"]')
         .first()
         .click()
         .wait(['@getFacilityCyclesCount'], { timeout: 10000 });

--- a/packages/datagateway-dataview/cypress/e2e/table/datafiles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/datafiles.cy.ts
@@ -205,7 +205,7 @@ describe('Datafiles Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/datasets.cy.ts
@@ -159,7 +159,7 @@ describe('Datasets Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/datafiles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/datafiles.cy.ts
@@ -204,7 +204,7 @@ describe('DLS - Datafiles Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/myData.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/myData.cy.ts
@@ -218,7 +218,7 @@ describe('DLS - MyData Table', () => {
           .find('button')
           .click();
 
-        cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+        cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
         const date = new Date();
         date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/visits.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/visits.cy.ts
@@ -167,7 +167,7 @@ describe('DLS - Visits Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
@@ -187,7 +187,7 @@ describe('Investigations Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/datafiles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/datafiles.cy.ts
@@ -125,7 +125,7 @@ describe('ISIS - Datafiles Table', () => {
           .find('button')
           .click();
 
-        cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+        cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
         const date = new Date();
         date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/datasets.cy.ts
@@ -201,7 +201,7 @@ describe('ISIS - Datasets Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/facilityCycles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/facilityCycles.cy.ts
@@ -171,7 +171,7 @@ describe('ISIS - FacilityCycles Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/investigations.cy.ts
@@ -215,7 +215,7 @@ describe('ISIS - Investigations Table', () => {
         .find('button')
         .click();
 
-      cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
       const date = new Date();
       date.setDate(1);

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/myData.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/myData.cy.ts
@@ -233,7 +233,7 @@ describe('ISIS - MyData Table', () => {
           .find('button')
           .click();
 
-        cy.get('.MuiPickersDay-root[tabindex="-1"]').first().click();
+        cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
         const date = new Date();
         date.setDate(1);

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -342,7 +342,7 @@ describe('Download Status Table', () => {
     cleanupDatePickerWorkaround();
   });
 
-  it('should show download progress ui if enabled', async () => {
+  it('should display download progress ui if enabled', async () => {
     (
       getPercentageComplete as jest.MockedFunction<typeof getPercentageComplete>
     ).mockResolvedValue(20);
@@ -365,6 +365,54 @@ describe('Download Status Table', () => {
         expect(progressBar).toBeInTheDocument();
       }
       for (const progressText of screen.getAllByText('20%')) {
+        expect(progressText).toBeInTheDocument();
+      }
+    });
+  });
+
+  it('should refresh download progress when refresh button is clicked', async () => {
+    (
+      getPercentageComplete as jest.MockedFunction<typeof getPercentageComplete>
+    ).mockResolvedValue(30);
+
+    renderComponent({
+      settings: {
+        ...mockedSettings,
+        uiFeatures: {
+          downloadProgress: true,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      for (const progressBar of screen.getAllByRole('progressbar')) {
+        expect(progressBar).toBeInTheDocument();
+      }
+      for (const progressText of screen.getAllByText('30%')) {
+        expect(progressText).toBeInTheDocument();
+      }
+    });
+
+    // pretend the server returns an updated value
+    (
+      getPercentageComplete as jest.MockedFunction<typeof getPercentageComplete>
+    ).mockResolvedValue(50);
+
+    // pretend table is refreshed
+    renderComponent({
+      settings: {
+        ...mockedSettings,
+        uiFeatures: {
+          downloadProgress: true,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      for (const progressBar of screen.getAllByRole('progressbar')) {
+        expect(progressBar).toBeInTheDocument();
+      }
+      for (const progressText of screen.getAllByText('50%')) {
         expect(progressText).toBeInTheDocument();
       }
     });


### PR DESCRIPTION
## Description
This PR applies the refresh progress bar fix that was implemented within the admin download table previously, into the user download table as well. Fix was tested via mocking the server response and returning dummy data, so further testing with an actual download object on dls would be useful. See:

![chrome_UdKaUiwmAt](https://user-images.githubusercontent.com/52418954/215793542-b714053d-caf4-4593-88bf-fd5ff8c01a0e.gif)

## Testing instructions
With download items in progress, refresh the user download table and the progress bar should update appropriately. 

## Agile board tracking
connect to #1473
