### PR TITLE
Bump node version in CI from v14 to v16

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
## Description
A quick hotfix PR that bumps the version of Node used in CI from v14.x to v16.x, mostly to support `Array.at` so that checks will pass in #1401. 

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Hotfix. Closes nothing.
