### PR TITLE
Update pinned version of DataGateway API on GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           repository: ral-facilities/datagateway-api
           path: datagateway-api
-          ref: v6.3.1
+          ref: v7.1.0
 
       # DataGateway API file setup
       - name: Create search_api_mapping.json
@@ -288,7 +288,7 @@ jobs:
         with:
           repository: ral-facilities/datagateway-api
           path: datagateway-api
-          ref: v6.3.1
+          ref: v7.1.0
 
       # DataGateway API file setup
       - name: Create search_api_mapping.json
@@ -418,7 +418,7 @@ jobs:
         with:
           repository: ral-facilities/datagateway-api
           path: datagateway-api
-          ref: v6.3.1
+          ref: v7.1.0
 
       # DataGateway API file setup
       - name: Create search_api_mapping.json


### PR DESCRIPTION
## Description
A small PR to update the pinned version of DataGateway API used in the CI to generate data used for this repo's tests.

## Testing instructions
If the CI passes, then its all good

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
connect to #{issue number}
