### PR TITLE
Suggest similar investigations based on the currently displayed investigation on investigation landing page

### DIFF
--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -61,6 +61,11 @@ export interface InvestigationInstrument {
   investigation?: Investigation;
 }
 
+export interface SuggestedInvestigation {
+  score: number;
+  doc: Investigation;
+}
+
 export interface Instrument {
   id: number;
   name: string;

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -143,6 +143,12 @@
     },
     "type": {
       "id": "Type ID"
+    },
+    "landingPage": {
+      "extraInfo": "Extra info",
+      "similarInvestigations": "Similar investigations",
+      "findingSimilarInvestigations": "Finding similar investigations…",
+      "noSuggestion": "No suggestion available"
     }
   },
   "datasets": {

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.tsx
@@ -1,9 +1,13 @@
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Divider,
   Grid,
   Link as MuiLink,
   Paper,
+  Stack,
   styled,
   Tab,
   Tabs,
@@ -17,10 +21,15 @@ import {
   Public,
   Save,
   Storage,
+  ExpandMore,
 } from '@mui/icons-material';
 import {
+  AddToCartButton,
+  ArrowTooltip,
   Dataset,
+  DownloadButton,
   formatCountOrSize,
+  getTooltipText,
   Investigation,
   InvestigationUser,
   parseSearchToQuery,
@@ -29,16 +38,13 @@ import {
   tableLink,
   useInvestigation,
   useInvestigationSizes,
-  AddToCartButton,
-  DownloadButton,
-  ArrowTooltip,
-  getTooltipText,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
 import CitationFormatter from '../../citationFormatter.component';
 import Branding from './isisBranding.component';
+import SuggestedInvestigationsSection from './suggestedInvestigationsSection.component';
 
 const Subheading = styled(Typography)(({ theme }) => ({
   marginTop: theme.spacing(1),
@@ -419,28 +425,38 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
           <Divider orientation="vertical" />
           {/* Short format information */}
           <Grid item xs={6} sm={5} md={4} lg={3} xl={2}>
-            {shortInfo.map(
-              (field, i) =>
-                data?.[0] &&
-                field.content(data[0] as Investigation) && (
-                  <ShortInfoRow key={i}>
-                    <ShortInfoLabel>
-                      {field.icon}
-                      {field.label}:
-                    </ShortInfoLabel>
-                    <ArrowTooltip
-                      title={getTooltipText(
-                        field.content(data[0] as Investigation)
-                      )}
-                    >
-                      <ShortInfoValue>
-                        {field.content(data[0] as Investigation)}
-                      </ShortInfoValue>
-                    </ArrowTooltip>
-                    z
-                  </ShortInfoRow>
-                )
+            {data && data[0].summary && (
+              <SuggestedInvestigationsSection investigation={data[0]} />
             )}
+            <Accordion defaultExpanded disableGutters elevation={0}>
+              <AccordionSummary expandIcon={<ExpandMore />}>
+                {t('investigations.landingPage.extraInfo')}
+              </AccordionSummary>
+              <AccordionDetails sx={{ px: 0.5, py: 0 }}>
+                {shortInfo.map(
+                  (field, i) =>
+                    data?.[0] &&
+                    field.content(data[0] as Investigation) && (
+                      <ShortInfoRow key={i}>
+                        <ShortInfoLabel>
+                          {field.icon}
+                          {field.label}:
+                        </ShortInfoLabel>
+                        <ArrowTooltip
+                          title={getTooltipText(
+                            field.content(data[0] as Investigation)
+                          )}
+                        >
+                          <ShortInfoValue>
+                            {field.content(data[0] as Investigation)}
+                          </ShortInfoValue>
+                        </ArrowTooltip>
+                        z
+                      </ShortInfoRow>
+                    )
+                )}
+              </AccordionDetails>
+            </Accordion>
             {/* Actions */}
             <ActionButtonsContainer data-testid="investigation-landing-action-container">
               <AddToCartButton
@@ -502,6 +518,8 @@ const LandingPage = (props: LandingPageProps): React.ReactElement => {
               </Box>
             ))}
           </Grid>
+
+          <Stack></Stack>
         </Grid>
       </Grid>
     </Paper>

--- a/packages/datagateway-dataview/src/views/landing/isis/suggestedInvestigationsSection.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/suggestedInvestigationsSection.component.test.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import type {
+  Investigation,
+  InvestigationSuggestions,
+} from 'datagateway-common';
+import axios, { AxiosResponse } from 'axios';
+import { render, screen } from '@testing-library/react';
+import SuggestedInvestigationsSection, {
+  MAX_SUGGESTION_COUNT,
+} from './suggestedInvestigationsSection.component';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+const mockSuggestions: InvestigationSuggestions = {
+  docs: [
+    {
+      doc: {
+        id: 1,
+        visitId: 'visitId',
+        name: 'Suggested investigation 1 name',
+        title: 'Suggested investigation 1',
+        summary: 'Suggested investigation 1 summary',
+        doi: 'doi1',
+      },
+      score: 0.9,
+    },
+    {
+      doc: {
+        id: 2,
+        visitId: 'visitId',
+        name: 'Suggested investigation 2 name',
+        title: 'Suggested investigation 2',
+        summary: 'Suggested investigation 2 summary',
+        doi: 'doi2',
+      },
+      score: 0.9,
+    },
+    {
+      doc: {
+        id: 3,
+        visitId: 'visitId',
+        name: 'Suggested investigation 3 name',
+        title: 'Suggested investigation 3',
+        summary: 'Suggested investigation 3 summary',
+        doi: 'doi3',
+      },
+      score: 0.9,
+    },
+    {
+      doc: {
+        id: 4,
+        visitId: 'visitId',
+        name: 'Suggested investigation 4 name',
+        title: 'Suggested investigation 4',
+        summary: 'Suggested investigation 4 summary',
+        doi: 'doi4',
+      },
+      score: 0.9,
+    },
+  ],
+  topics: [],
+};
+
+const MOCK_INVESTIGATION: Investigation = {
+  id: 1,
+  visitId: 'visitId',
+  name: 'Mock investigation name',
+  title: 'Mock investigation',
+  summary: 'Mock investigation summary',
+};
+
+describe('SuggestedInvestigationsSection', () => {
+  function Wrapper({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+      <QueryClientProvider client={new QueryClient()}>
+        {children}
+      </QueryClientProvider>
+    );
+  }
+
+  it(`should render a list of max ${MAX_SUGGESTION_COUNT} suggested investigations for the given investigation`, async () => {
+    axios.get = jest.fn().mockImplementation(
+      (): Promise<Partial<AxiosResponse<InvestigationSuggestions>>> =>
+        Promise.resolve({
+          data: mockSuggestions,
+        })
+    );
+
+    const user = userEvent.setup();
+
+    render(
+      <SuggestedInvestigationsSection investigation={MOCK_INVESTIGATION} />,
+      { wrapper: Wrapper }
+    );
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'investigations.landingPage.similarInvestigations',
+      })
+    );
+
+    const suggestionLinks = await screen.findAllByRole('link');
+    expect(suggestionLinks).toHaveLength(MAX_SUGGESTION_COUNT);
+
+    expect(
+      await screen.findByRole('link', { name: 'Suggested investigation 1' })
+    ).toHaveAttribute('href', 'https://doi.org/doi1');
+    expect(
+      await screen.findByRole('link', { name: 'Suggested investigation 2' })
+    ).toHaveAttribute('href', 'https://doi.org/doi2');
+    expect(
+      await screen.findByRole('link', { name: 'Suggested investigation 3' })
+    ).toHaveAttribute('href', 'https://doi.org/doi3');
+  });
+
+  it('should show loading label and be un-expandable when fetching suggestions', () => {
+    axios.get = jest.fn().mockImplementation(
+      () =>
+        new Promise((_) => {
+          // never resolve the promise to pretend the query is loading
+        })
+    );
+
+    render(
+      <SuggestedInvestigationsSection investigation={MOCK_INVESTIGATION} />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'investigations.landingPage.findingSimilarInvestigations',
+      })
+    ).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should show empty message when no suggestion is available for the investigation', async () => {
+    axios.get = jest.fn().mockImplementation(
+      (): Promise<Partial<AxiosResponse<InvestigationSuggestions>>> =>
+        Promise.resolve({
+          data: {
+            docs: [],
+            topics: [],
+          },
+        })
+    );
+
+    const user = userEvent.setup();
+
+    render(
+      <SuggestedInvestigationsSection investigation={MOCK_INVESTIGATION} />,
+      { wrapper: Wrapper }
+    );
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'investigations.landingPage.similarInvestigations',
+      })
+    );
+
+    expect(
+      await screen.findByText('investigations.landingPage.noSuggestion')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/datagateway-dataview/src/views/landing/isis/suggestedInvestigationsSection.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/suggestedInvestigationsSection.component.tsx
@@ -1,0 +1,93 @@
+import { ExpandMore } from '@mui/icons-material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  CircularProgress,
+  Divider,
+  Link,
+  List,
+  ListItem,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import {
+  Investigation,
+  SuggestedInvestigation,
+  useSimilarInvestigations,
+} from 'datagateway-common';
+import { useTranslation } from 'react-i18next';
+
+interface SuggestedSectionProps {
+  investigation: Investigation;
+}
+
+const MAX_SUGGESTION_COUNT = 3;
+
+function SuggestedInvestigationsSection({
+  investigation,
+}: SuggestedSectionProps): JSX.Element {
+  const [t] = useTranslation();
+  const { data: suggestedResults, isLoading } = useSimilarInvestigations({
+    investigation,
+  });
+
+  return (
+    <Accordion disabled={isLoading} disableGutters elevation={0}>
+      <AccordionSummary
+        disabled={isLoading}
+        expandIcon={isLoading ? <CircularProgress size={24} /> : <ExpandMore />}
+      >
+        <Typography>
+          {isLoading
+            ? t('investigations.landingPage.findingSimilarInvestigations')
+            : t('investigations.landingPage.similarInvestigations')}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ padding: 0 }}>
+        {suggestedResults && suggestedResults.length > 0 ? (
+          <SuggestionList suggestions={suggestedResults} />
+        ) : (
+          <Typography sx={{ padding: 2 }}>
+            {t('investigations.landingPage.noSuggestion')}
+          </Typography>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+function SuggestionList({
+  suggestions,
+}: {
+  suggestions: SuggestedInvestigation[];
+}): JSX.Element {
+  function constructFullDoiUrl(doi: string): string {
+    return `https://doi.org/${doi}`;
+  }
+
+  return (
+    <List dense disablePadding>
+      {suggestions.slice(0, MAX_SUGGESTION_COUNT).map((suggestion, i) => {
+        const isLastItem = i === MAX_SUGGESTION_COUNT - 1;
+        return (
+          <React.Fragment key={suggestion.doc.id}>
+            <ListItem dense>
+              {suggestion.doc.doi ? (
+                <Link href={constructFullDoiUrl(suggestion.doc.doi)}>
+                  {suggestion.doc.title}
+                </Link>
+              ) : (
+                <Typography>{suggestion.doc.title}</Typography>
+              )}
+            </ListItem>
+            {!isLastItem && <Divider />}
+          </React.Fragment>
+        );
+      })}
+    </List>
+  );
+}
+
+export default SuggestedInvestigationsSection;
+export { MAX_SUGGESTION_COUNT };


### PR DESCRIPTION
## Description
This PR adds a section on investigation landing pages that suggests similar investigations based on the currently displayed investigations. Investigation suggestions and extra info for the investigation are grouped into 2 accordions for better visual clarity. This video demonstrates the new UI:


https://user-images.githubusercontent.com/19359984/233374428-8d1c78f0-f6e1-46aa-88eb-0516023f35c4.mp4

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1521 
