### PR TITLE
Implement sematic search feature in datagateway search

### DIFF
--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -71,6 +71,7 @@ export const parseSearchToQuery = (queryParams: string): QueryParams => {
   const startDateString = query.get('startDate');
   const endDateString = query.get('endDate');
   const currentTab = query.get('currentTab');
+  const semanticSearchEnabled = query.get('semanticSearch');
 
   // Parse filters in the query.
   const parsedFilters: FiltersType = {};
@@ -129,6 +130,7 @@ export const parseSearchToQuery = (queryParams: string): QueryParams => {
     startDate: startDate,
     endDate: endDate,
     currentTab: currentTab ? currentTab : 'investigation',
+    semanticSearch: semanticSearchEnabled === 'true',
   };
 
   return params;
@@ -481,6 +483,23 @@ export const usePushSearchToggles = (): ((
         dataset,
         datafile,
         investigation,
+      };
+      push(`?${parseQueryToSearch(query).toString()}`);
+    },
+    [push]
+  );
+};
+
+export const usePushSemanticSearchEnabled = (): ((
+  enabled: boolean
+) => void) => {
+  const { push } = useHistory();
+
+  return React.useCallback(
+    (enabled: boolean) => {
+      const query: QueryParams = {
+        ...parseSearchToQuery(window.location.search),
+        semanticSearch: enabled,
       };
       push(`?${parseQueryToSearch(query).toString()}`);
     },

--- a/packages/datagateway-common/src/api/lucene.test.tsx
+++ b/packages/datagateway-common/src/api/lucene.test.tsx
@@ -1,14 +1,16 @@
 import { renderHook } from '@testing-library/react-hooks';
 import axios from 'axios';
-import { useLuceneSearch } from '.';
+import { useLuceneSearch, useSemanticSearch } from '.';
 import handleICATError from '../handleICATError';
 import { createReactQueryWrapper } from '../setupTests';
+import { SemanticSearchResults } from '../app.types';
 
 jest.mock('../handleICATError');
 
 describe('Lucene actions', () => {
   afterEach(() => {
     (axios.get as jest.Mock).mockClear();
+    (axios.post as jest.Mock).mockClear();
     (handleICATError as jest.Mock).mockClear();
   });
 
@@ -195,6 +197,82 @@ describe('Lucene actions', () => {
 
     expect(handleICATError).toHaveBeenCalledWith({
       message: 'Test error message',
+    });
+  });
+
+  describe('useSemanticSearch', () => {
+    const mockSemanticSearchResults: SemanticSearchResults = [
+      {
+        score: 0.1,
+        doc: {
+          id: 1,
+          visitId: '1',
+          name: 'Mock investigation 1 name',
+          title: 'Mock investigation 1',
+          summary: 'Mock investigation 1 summary',
+        },
+      },
+      {
+        score: 0.2,
+        doc: {
+          id: 2,
+          visitId: '2',
+          name: 'Mock investigation 2 name',
+          title: 'Mock investigation 2',
+          summary: 'Mock investigation 2 summary',
+        },
+      },
+      {
+        score: 0.15,
+        doc: {
+          id: 3,
+          visitId: '3',
+          name: 'Mock investigation 3 name',
+          title: 'Mock investigation 3',
+          summary: 'Mock investigation 3 summary',
+        },
+      },
+    ];
+
+    it('performs semantic search based on the given query and returns the results sorted based on relevance from most to least relevant', async () => {
+      (axios.post as jest.Mock).mockResolvedValue({
+        data: mockSemanticSearchResults,
+      });
+
+      const { result, waitFor } = renderHook(
+        () =>
+          useSemanticSearch({
+            query: 'Test query',
+            enabled: true,
+          }),
+        { wrapper: createReactQueryWrapper() }
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(result.current.data).toEqual([
+        {
+          id: 2,
+          visitId: '2',
+          name: 'Mock investigation 2 name',
+          title: 'Mock investigation 2',
+          summary: 'Mock investigation 2 summary',
+        },
+        {
+          id: 3,
+          visitId: '3',
+          name: 'Mock investigation 3 name',
+          title: 'Mock investigation 3',
+          summary: 'Mock investigation 3 summary',
+        },
+        {
+          id: 1,
+          visitId: '1',
+          name: 'Mock investigation 1 name',
+          title: 'Mock investigation 1',
+          summary: 'Mock investigation 1 summary',
+        },
+      ]);
     });
   });
 });

--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import { format, set } from 'date-fns';
 import { useQuery, UseQueryResult } from 'react-query';
 import { useSelector } from 'react-redux';
-import { StateType } from '..';
+import { Investigation, SemanticSearchResults, StateType } from '..';
 import handleICATError from '../handleICATError';
 import { readSciGatewayToken } from '../parseTokens';
 import retryICATErrors from './retryICATErrors';
@@ -111,6 +111,40 @@ export const useLuceneSearch = (
       // we want to trigger search manually via refetch
       // so disable the query to disable automatic fetching
       enabled: false,
+    }
+  );
+};
+
+export const useSemanticSearch = ({
+  query,
+  enabled,
+}: {
+  query: string;
+  enabled: boolean;
+}): UseQueryResult<Investigation[], AxiosError> => {
+  const baseUrl = 'http://172.16.103.71:4001/api';
+
+  return useQuery<SemanticSearchResults, AxiosError, Investigation[]>(
+    ['semanticSearch', query],
+    () =>
+      axios
+        .post(
+          '/search',
+          {
+            query,
+            n_top_results: 50,
+          },
+          {
+            baseURL: baseUrl,
+          }
+        )
+        .then((response) => response.data),
+    {
+      enabled,
+      select: (data) => {
+        data.sort((resultA, resultB) => resultB.score - resultA.score);
+        return data.map(({ doc }) => doc);
+      },
     }
   );
 };

--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -321,4 +321,10 @@ export interface QueryParams {
   startDate: Date | null;
   endDate: Date | null;
   currentTab: string;
+  semanticSearch: boolean;
 }
+
+export type SemanticSearchResults = {
+  score: number;
+  doc: Investigation;
+}[];

--- a/packages/datagateway-search/src/search/semanticSearchToggle.component.test.tsx
+++ b/packages/datagateway-search/src/search/semanticSearchToggle.component.test.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import type { History } from 'history';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { render, screen } from '@testing-library/react';
+import SemanticSearchToggle from './semanticSearchToggle.component';
+import userEvent from '@testing-library/user-event';
+
+describe('SemanticSearchToggle', () => {
+  let history: History;
+
+  function Wrapper({
+    children,
+  }: {
+    children: React.ReactElement;
+  }): JSX.Element {
+    return <Router history={history}>{children}</Router>;
+  }
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+  });
+
+  it('is switched on when semantic search is enabled in URL', () => {
+    history.replace('?semanticSearch=true');
+
+    render(<SemanticSearchToggle />, { wrapper: Wrapper });
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Use semantic search' })
+    ).toBeChecked();
+  });
+
+  it('is switched off when semantic search is disabled in URL', () => {
+    history.replace('?semanticSearch=false');
+
+    render(<SemanticSearchToggle />, { wrapper: Wrapper });
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Use semantic search' })
+    ).not.toBeChecked();
+  });
+
+  it('can be toggled and updates URL query params accordingly', async () => {
+    const user = userEvent.setup();
+
+    history.replace('?semanticSearch=true');
+
+    render(<SemanticSearchToggle />, { wrapper: Wrapper });
+
+    const toggle = screen.getByRole('checkbox', {
+      name: 'Use semantic search',
+    });
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Use semantic search' })
+    );
+
+    expect(toggle).not.toBeChecked();
+    expect(history.location.search).toEqual('?semanticSearch=false');
+  });
+});

--- a/packages/datagateway-search/src/search/semanticSearchToggle.component.tsx
+++ b/packages/datagateway-search/src/search/semanticSearchToggle.component.tsx
@@ -1,0 +1,31 @@
+import { Checkbox, FormControlLabel } from '@mui/material';
+import {
+  parseSearchToQuery,
+  usePushSemanticSearchEnabled,
+} from 'datagateway-common';
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+function SemanticSearchToggle(): JSX.Element {
+  const pushSemanticSearchEnabled = usePushSemanticSearchEnabled();
+
+  const location = useLocation();
+  const { semanticSearch } = React.useMemo(
+    () => parseSearchToQuery(location.search),
+    [location.search]
+  );
+
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={semanticSearch}
+          onChange={() => pushSemanticSearchEnabled(!semanticSearch)}
+        />
+      }
+      label="Use semantic search"
+    />
+  );
+}
+
+export default SemanticSearchToggle;

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Typography, Link, Theme, Box, styled } from '@mui/material';
+import { Box, Grid, Link, styled, Theme, Typography } from '@mui/material';
 import SelectDates from './search/datePicker.component';
 import CheckboxesGroup from './search/checkBoxes.component';
 import SearchButton from './search/searchButton.component';
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import { StateType } from './state/app.types';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { Link as RouterLink } from 'react-router-dom';
+import SemanticSearchToggle from './search/semanticSearchToggle.component';
 
 const ContainerBox = styled(Box)(({ theme }) => ({
   maxWidth: '1920px',
@@ -132,6 +133,8 @@ const SearchBoxContainer = (
           </div>
         </Box>
       </div>
+
+      <SemanticSearchToggle />
     </ContainerBox>
   );
 };

--- a/packages/datagateway-search/src/table/semanticSearchTable.component.tsx
+++ b/packages/datagateway-search/src/table/semanticSearchTable.component.tsx
@@ -1,0 +1,99 @@
+import {
+  ColumnType,
+  externalSiteLink,
+  Investigation,
+  parseSearchToQuery,
+  Table,
+  useDateFilter,
+  useSemanticSearch,
+  useSort,
+  useTextFilter,
+} from 'datagateway-common';
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { TableCellProps } from 'react-virtualized';
+import { useTranslation } from 'react-i18next';
+
+function SemanticSearchTable(): JSX.Element {
+  const location = useLocation();
+  const queryParams = React.useMemo(
+    () => parseSearchToQuery(location.search),
+    [location.search]
+  );
+  const [t] = useTranslation();
+
+  const searchText = queryParams.searchText ?? '';
+  const { data: searchResults } = useSemanticSearch({
+    query: searchText,
+    enabled: true,
+  });
+
+  const textFilter = useTextFilter(queryParams.filters);
+  const dateFilter = useDateFilter(queryParams.filters);
+  const handleSort = useSort();
+
+  const columns: ColumnType[] = React.useMemo(
+    () => [
+      {
+        label: t('investigations.title'),
+        dataKey: 'title',
+        filterComponent: textFilter,
+      },
+      {
+        label: t('investigations.visit_id'),
+        dataKey: 'visitId',
+        filterComponent: textFilter,
+      },
+      {
+        label: t('investigations.name'),
+        dataKey: 'name',
+        filterComponent: textFilter,
+      },
+      {
+        label: t('investigations.doi'),
+        dataKey: 'doi',
+        cellContentRenderer: (cellProps: TableCellProps) => {
+          const investigationData = cellProps.rowData as Investigation;
+          return externalSiteLink(
+            `https://doi.org/${investigationData.doi}`,
+            investigationData.doi,
+            'investigation-search-table-doi-link'
+          );
+        },
+        filterComponent: textFilter,
+      },
+      {
+        label: t('investigations.start_date'),
+        dataKey: 'startDate',
+        filterComponent: dateFilter,
+        cellContentRenderer: (cellProps: TableCellProps) => {
+          if (cellProps.cellData) {
+            return cellProps.cellData.toString().split(' ')[0];
+          }
+        },
+      },
+      {
+        label: t('investigations.end_date'),
+        dataKey: 'endDate',
+        filterComponent: dateFilter,
+        cellContentRenderer: (cellProps: TableCellProps) => {
+          if (cellProps.cellData) {
+            return cellProps.cellData.toString().split(' ')[0];
+          }
+        },
+      },
+    ],
+    [t, textFilter, dateFilter]
+  );
+
+  return (
+    <Table
+      data={searchResults || []}
+      columns={columns}
+      sort={queryParams.sort}
+      onSort={handleSort}
+    />
+  );
+}
+
+export default SemanticSearchTable;


### PR DESCRIPTION
## Description
This PR adds a toggle that allows the user to use semantic search in datagateway search. The video below demonstrates the feature:

https://github.com/ral-facilities/datagateway/assets/19359984/b02f6396-90ee-4253-a32b-8c866d56200d

- Semantic search results are sorted based on their relevance to the query, from the most relevant to the least. They are displayed in a table just like other types of search results. 
- When semantic search is enabled, other search result types are disabled and the tabs are not shown
- The backend powering the feature has a temporary URL, so I just hardcoded it in the code, similar to #1522 

Please feel free to suggest changes to the UI.

cc @agbeltran 

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1526 
