### PR TITLE
Autocomplete Recent Searches

### DIFF
--- a/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
+++ b/packages/datagateway-search/src/__snapshots__/searchBoxContainer.component.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`SearchBoxContainerSide - Tests renders searchBoxContainerSide correctly
               aria-label="searchBox.search_text_arialabel"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputTypeSearch css-1g24dm6-MuiInputBase-input-MuiOutlinedInput-input"
               id="filled-search"
+              name="dgSearchTextField"
               type="search"
               value=""
             />
@@ -245,7 +246,7 @@ exports[`SearchBoxContainerSide - Tests renders searchBoxContainerSide correctly
             aria-label="searchBox.search_button_arialabel"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-fullWidth MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-fullWidth css-189e9pj-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
-            type="button"
+            type="submit"
           >
             searchBox.search_button
             <span

--- a/packages/datagateway-search/src/search/__snapshots__/searchButton.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/searchButton.component.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Search Button component tests renders correctly 1`] = `
       aria-label="searchBox.search_button_arialabel"
       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-fullWidth MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-fullWidth css-189e9pj-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
-      type="button"
+      type="submit"
     >
       searchBox.search_button
       <span

--- a/packages/datagateway-search/src/search/__snapshots__/searchTextBox.component.test.tsx.snap
+++ b/packages/datagateway-search/src/search/__snapshots__/searchTextBox.component.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`Search text box component tests renders correctly 1`] = `
         aria-label="searchBox.search_text_arialabel"
         class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputTypeSearch css-1g24dm6-MuiInputBase-input-MuiOutlinedInput-input"
         id="filled-search"
+        name="dgSearchTextField"
         type="search"
         value=""
       />

--- a/packages/datagateway-search/src/search/searchButton.component.tsx
+++ b/packages/datagateway-search/src/search/searchButton.component.tsx
@@ -26,6 +26,7 @@ const SearchButton = (props: SearchButtonCombinedProps): React.ReactElement => {
         aria-label={t('searchBox.search_button_arialabel')}
         size="large"
         fullWidth={true}
+        type="submit"
       >
         {t('searchBox.search_button')}
       </Button>

--- a/packages/datagateway-search/src/search/searchTextBox.component.tsx
+++ b/packages/datagateway-search/src/search/searchTextBox.component.tsx
@@ -25,6 +25,7 @@ const SearchTextBox = (props: SearchTextProps): React.ReactElement => {
     <TextField
       className="tour-search-textfield"
       id="filled-search"
+      name="dgSearchTextField"
       label={t('searchBox.search_text')}
       type="search"
       margin="normal"

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -38,35 +38,41 @@ const SearchBoxContainer = (
 
   return (
     <ContainerBox data-testid="search-box-container">
-      <Grid
-        container
-        direction="row"
-        justifyContent="center"
-        id="container-searchbox"
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+        }}
       >
-        <Grid item xs="auto" style={{ flexGrow: 1 }}>
-          <SearchTextBox
-            searchText={searchText}
-            initiateSearch={initiateSearch}
-            onChange={onSearchTextChange}
-          />
-        </Grid>
-
-        <Grid item sx={{ marginTop: '8px' }}>
-          <CheckboxesGroup />
-        </Grid>
-
-        <Grid item sx={{ marginTop: '8px' }}>
-          <SelectDates initiateSearch={initiateSearch} />
-        </Grid>
-
         <Grid
-          item
-          sx={{ display: 'flex', marginTop: '24px', marginLeft: '6px' }}
+          container
+          direction="row"
+          justifyContent="center"
+          id="container-searchbox"
         >
-          <SearchButton initiateSearch={initiateSearch} />
+          <Grid item xs="auto" style={{ flexGrow: 1 }}>
+            <SearchTextBox
+              searchText={searchText}
+              initiateSearch={initiateSearch}
+              onChange={onSearchTextChange}
+            />
+          </Grid>
+
+          <Grid item sx={{ marginTop: '8px' }}>
+            <CheckboxesGroup />
+          </Grid>
+
+          <Grid item sx={{ marginTop: '8px' }}>
+            <SelectDates initiateSearch={initiateSearch} />
+          </Grid>
+
+          <Grid
+            item
+            sx={{ display: 'flex', marginTop: '24px', marginLeft: '6px' }}
+          >
+            <SearchButton initiateSearch={initiateSearch} />
+          </Grid>
         </Grid>
-      </Grid>
+      </form>
       <div style={{ display: 'flex' }}>
         <Typography
           sx={{


### PR DESCRIPTION
## Description
This PR partially implements #1471. As discussed in the issue, I have implemented a way for a user to access their recent searches using [browser autocompleting](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete):

![image](https://github.com/ral-facilities/datagateway/assets/32678030/45566793-b23d-47be-94da-1389a7cf85f3)

As Louise stated in the issue, "this persists across browser refreshes, but is locked to a single browser". This may not be enough functionality to satisfy DataGateway users (i.e. they might want recent searches to be the same across browsers) but given the low code change in this PR, it seems this is a good first step.

I updated the snapshots for the unit tests and tried to write an e2e test but I wasn't able to get the autofill field to complete in Cypress during the test (it would appear if I did the steps manually after the test) so I was unable to write a test for that.

It's rather simple, but it seems to work.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1471 
