### PR TITLE
Feature/add exact filter #1540

### DIFF
--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -262,6 +262,7 @@ describe('generic api functions', () => {
         filters: {
           name: { value: 'test', type: 'include' },
           title: { value: 'test', type: 'exclude' },
+          doi: { value: 'test', type: 'exact' },
           startDate: {
             startDate: '2021-08-05',
             endDate: '2021-08-06',
@@ -276,6 +277,7 @@ describe('generic api functions', () => {
       params.append('order', JSON.stringify('id asc'));
       params.append('where', JSON.stringify({ name: { ilike: 'test' } }));
       params.append('where', JSON.stringify({ title: { nilike: 'test' } }));
+      params.append('where', JSON.stringify({ doi: { eq: 'test' } }));
       params.append(
         'where',
         JSON.stringify({ startDate: { gte: '2021-08-05 00:00:00' } })
@@ -296,6 +298,7 @@ describe('generic api functions', () => {
         filters: {
           name: { value: 'test', type: 'include' },
           title: { value: 'test', type: 'exclude' },
+          doi: { value: 'test', type: 'exact' },
           startDate: {
             startDate: '2021-08-05',
             endDate: '2021-08-06',
@@ -309,6 +312,7 @@ describe('generic api functions', () => {
       params.append('order', JSON.stringify('name asc'));
       params.append('where', JSON.stringify({ name: { ilike: 'test' } }));
       params.append('where', JSON.stringify({ title: { nilike: 'test' } }));
+      params.append('where', JSON.stringify({ doi: { eq: 'test' } }));
       params.append(
         'where',
         JSON.stringify({ startDate: { gte: '2021-08-05 00:00:00' } })

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -231,10 +231,15 @@ export const getApiParams = (
               'where',
               JSON.stringify({ [column]: { ilike: filter.value } })
             );
-          } else {
+          } else if (filter.type === 'exclude') {
             searchParams.append(
               'where',
               JSON.stringify({ [column]: { nilike: filter.value } })
+            );
+          } else {
+            searchParams.append(
+              'where',
+              JSON.stringify({ [column]: { eq: filter.value } })
             );
           }
         }

--- a/packages/datagateway-common/src/table/columnFilters/__snapshots__/textColumnFilter.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/columnFilters/__snapshots__/textColumnFilter.component.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Text filter component renders correctly 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="include or exclude"
+              aria-label="include, exclude or exact"
               aria-labelledby="test-select-filter-type"
               class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
               id="test-select-filter-type"
@@ -108,7 +108,7 @@ exports[`Text filter component usePrincipalExperimenterFilter hook returns a fun
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="include or exclude"
+              aria-label="include, exclude or exact"
               aria-labelledby="Principal Investigator-select-filter-type"
               class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
               id="Principal Investigator-select-filter-type"
@@ -181,7 +181,7 @@ exports[`Text filter component useTextFilter hook returns a function which can g
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label="include or exclude"
+              aria-label="include, exclude or exact"
               aria-labelledby="Name-select-filter-type"
               class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
               id="Name-select-filter-type"

--- a/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.test.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.test.tsx
@@ -90,6 +90,35 @@ describe('Text filter component', () => {
     });
   });
 
+  it('calls the onChange method once when input is typed while exact filter type is selected and calls again by debounced function after timeout', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <TextColumnFilter
+        value={{ value: 'test', type: 'exact' }}
+        label="test"
+        onChange={onChange}
+      />
+    );
+
+    // We simulate a change in the input from 'test' to 'test-again'.
+    const textFilterInput = await screen.findByRole('textbox', {
+      name: 'Filter by test',
+      hidden: true,
+    });
+
+    await user.clear(textFilterInput);
+    await user.type(textFilterInput, 'test-again');
+
+    jest.advanceTimersByTime(DEBOUNCE_DELAY);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith({
+      value: 'test-again',
+      type: 'exact',
+    });
+  });
+
   it('calls the onChange method once when include filter type is selected while there is input', async () => {
     const onChange = jest.fn();
 
@@ -104,7 +133,7 @@ describe('Text filter component', () => {
     // We simulate a change in the select from 'exclude' to 'include'.
     await user.click(
       await screen.findByRole('button', {
-        name: 'include or exclude',
+        name: 'include, exclude or exact',
         hidden: true,
       })
     );
@@ -131,7 +160,7 @@ describe('Text filter component', () => {
     // We simulate a change in the select from 'include' to 'exclude'.
     await user.click(
       await screen.findByRole('button', {
-        name: 'include or exclude',
+        name: 'include, exclude or exact',
         hidden: true,
       })
     );
@@ -141,6 +170,33 @@ describe('Text filter component', () => {
     expect(onChange).toHaveBeenLastCalledWith({
       value: 'test',
       type: 'exclude',
+    });
+  });
+
+  it('calls the onChange method once when exact filter type is selected while there is input', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <TextColumnFilter
+        value={{ value: 'test', type: 'include' }}
+        label="test"
+        onChange={onChange}
+      />
+    );
+
+    // We simulate a change in the select from 'include' to 'exact'.
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'include, exclude or exact',
+        hidden: true,
+      })
+    );
+    await user.click(await screen.findByText('Exact'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith({
+      value: 'test',
+      type: 'exact',
     });
   });
 
@@ -182,7 +238,7 @@ describe('Text filter component', () => {
     // We simulate a change in the select from 'exclude' to 'include'.
     await user.click(
       await screen.findByRole('button', {
-        name: 'include or exclude',
+        name: 'include, exclude or exact',
         hidden: true,
       })
     );

--- a/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
@@ -95,7 +95,7 @@ const TextColumnFilter = (props: {
                 renderValue={() => ''}
                 onChange={(e) => handleSelectChange(e.target.value as string)}
                 SelectDisplayProps={{
-                  'aria-label': `include or exclude`,
+                  'aria-label': `include, exclude or exact`,
                 }}
                 variant="standard"
               >
@@ -112,6 +112,13 @@ const TextColumnFilter = (props: {
                   value="exclude"
                 >
                   Exclude
+                </MenuItem>
+                <MenuItem
+                  key="exact"
+                  id="select-filter-type-exact"
+                  value="exact"
+                >
+                  Exact
                 </MenuItem>
               </Select>
             </InputAdornment>

--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Data column header component renders correctly with filter but no sort 
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-label="include or exclude"
+                  aria-label="include, exclude or exact"
                   aria-labelledby="Test-select-filter-type"
                   class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                   id="Test-select-filter-type"
@@ -187,7 +187,7 @@ exports[`Data column header component renders correctly with sort and filter 1`]
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-label="include or exclude"
+                  aria-label="include, exclude or exact"
                   aria-labelledby="Test-select-filter-type"
                   class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                   id="Test-select-filter-type"

--- a/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
@@ -174,50 +174,6 @@ describe('Investigations Table', () => {
   });
 
   describe('should be able to filter by', () => {
-    it('text', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('wide');
-
-      cy.get('[aria-rowcount="4"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('85');
-
-      // check that size is correct after filtering
-      cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.34 GB');
-    });
-
-    it('date between', () => {
-      cy.get('input[id="Start Date filter from"]').type('2012-01-01');
-
-      cy.get('input[aria-label="Start Date filter to"]')
-        .parent()
-        .find('button')
-        .click();
-
-      cy.get('.MuiPickersDay-root[type="button"]').first().click();
-
-      const date = new Date();
-      date.setDate(1);
-
-      cy.get('input[id="Start Date filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
-
-      cy.get('[aria-rowcount="12"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Why news west bar sing tax. Drive up more near member article.'
-      );
-    });
-
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('wide');
-
-      cy.get('[aria-label="Filter by Visit ID"]').first().type('7');
-
-      cy.get('[aria-rowcount="3"]').should('exist');
-    });
-  });
-
-  describe('should be able to use text filters', () => {
     it('exclude', () => {
       cy.get('input[aria-label="Filter by Name"]')
         .parent()
@@ -251,6 +207,7 @@ describe('Investigations Table', () => {
       // check that size is correct after filtering
       cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
     });
+
     it('exact', () => {
       cy.get('input[aria-label="Filter by Name"]')
         .parent()
@@ -266,6 +223,38 @@ describe('Investigations Table', () => {
 
       // check that size is correct after filtering
       cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
+    });
+
+    it('date between', () => {
+      cy.get('input[id="Start Date filter from"]').type('2012-01-01');
+
+      cy.get('input[aria-label="Start Date filter to"]')
+        .parent()
+        .find('button')
+        .click();
+
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
+
+      const date = new Date();
+      date.setDate(1);
+
+      cy.get('input[id="Start Date filter to"]').should(
+        'have.value',
+        date.toISOString().slice(0, 10)
+      );
+
+      cy.get('[aria-rowcount="12"]').should('exist');
+      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+        'Why news west bar sing tax. Drive up more near member article.'
+      );
+    });
+
+    it('multiple columns', () => {
+      cy.get('[aria-label="Filter by Title"]').first().type('wide');
+
+      cy.get('[aria-label="Filter by Visit ID"]').first().type('7');
+
+      cy.get('[aria-rowcount="3"]').should('exist');
     });
   });
 

--- a/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
@@ -22,7 +22,7 @@ describe('Investigations Table', () => {
 
   it('should disable the hover tool tip by pressing escape', () => {
     // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    // eslint-disable-next-line cypress/no-unnecessary-waiting, cypress/unsafe-to-chain-command
     cy.get('[data-testid="investigation-table-title"]')
       .first()
       .trigger('mouseover', { force: true })
@@ -78,6 +78,7 @@ describe('Investigations Table', () => {
       expect(width).to.equal(columnWidth);
     });
 
+    // eslint-disable-next-line cypress/unsafe-to-chain-command
     cy.get('.react-draggable')
       .first()
       .trigger('mousedown')
@@ -95,6 +96,7 @@ describe('Investigations Table', () => {
     });
 
     // table width should grow if a column grows too large
+    // eslint-disable-next-line cypress/unsafe-to-chain-command
     cy.get('.react-draggable')
       .first()
       .trigger('mousedown')
@@ -212,6 +214,58 @@ describe('Investigations Table', () => {
       cy.get('[aria-label="Filter by Visit ID"]').first().type('7');
 
       cy.get('[aria-rowcount="3"]').should('exist');
+    });
+  });
+
+  describe('should be able to use text filters', () => {
+    it('exclude', () => {
+      cy.get('input[aria-label="Filter by Name"]')
+        .parent()
+        .find('[aria-label="include, exclude or exact"]')
+        .click();
+
+      cy.get('#select-filter-type-exclude').click();
+
+      cy.get('[aria-label="Filter by Name"]').first().type('INVESTIGATION 1');
+
+      cy.get('[aria-rowcount="48"]').should('exist');
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('87');
+
+      // check that size is correct after filtering
+      cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.38 GB');
+    });
+
+    it('include', () => {
+      cy.get('input[aria-label="Filter by Name"]')
+        .parent()
+        .find('[aria-label="include, exclude or exact"]')
+        .click();
+
+      cy.get('#select-filter-type-include').click();
+
+      cy.get('[aria-label="Filter by Name"]').first().type('INVESTIGATION 1');
+
+      cy.get('[aria-rowcount="11"]').should('exist');
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('70');
+
+      // check that size is correct after filtering
+      cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
+    });
+    it('exact', () => {
+      cy.get('input[aria-label="Filter by Name"]')
+        .parent()
+        .find('[aria-label="include, exclude or exact"]')
+        .click();
+
+      cy.get('#select-filter-type-exact').click();
+
+      cy.get('[aria-label="Filter by Name"]').first().type('INVESTIGATION 1');
+
+      cy.get('[aria-rowcount="1"]').should('exist');
+      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('70');
+
+      // check that size is correct after filtering
+      cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
     });
   });
 

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                                     <div
                                       aria-expanded="false"
                                       aria-haspopup="listbox"
-                                      aria-label="include or exclude"
+                                      aria-label="include, exclude or exact"
                                       aria-labelledby="downloadStatus.id-select-filter-type"
                                       class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                       id="downloadStatus.id-select-filter-type"
@@ -280,7 +280,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                                     <div
                                       aria-expanded="false"
                                       aria-haspopup="listbox"
-                                      aria-label="include or exclude"
+                                      aria-label="include, exclude or exact"
                                       aria-labelledby="downloadStatus.fullname-select-filter-type"
                                       class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                       id="downloadStatus.fullname-select-filter-type"
@@ -403,7 +403,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                                     <div
                                       aria-expanded="false"
                                       aria-haspopup="listbox"
-                                      aria-label="include or exclude"
+                                      aria-label="include, exclude or exact"
                                       aria-labelledby="downloadStatus.username-select-filter-type"
                                       class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                       id="downloadStatus.username-select-filter-type"
@@ -526,7 +526,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                                     <div
                                       aria-expanded="false"
                                       aria-haspopup="listbox"
-                                      aria-label="include or exclude"
+                                      aria-label="include, exclude or exact"
                                       aria-labelledby="downloadStatus.preparedId-select-filter-type"
                                       class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                       id="downloadStatus.preparedId-select-filter-type"
@@ -649,7 +649,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                                     <div
                                       aria-expanded="false"
                                       aria-haspopup="listbox"
-                                      aria-label="include or exclude"
+                                      aria-label="include, exclude or exact"
                                       aria-labelledby="downloadStatus.transport-select-filter-type"
                                       class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                       id="downloadStatus.transport-select-filter-type"
@@ -772,7 +772,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                                     <div
                                       aria-expanded="false"
                                       aria-haspopup="listbox"
-                                      aria-label="include or exclude"
+                                      aria-label="include, exclude or exact"
                                       aria-labelledby="downloadStatus.status-select-filter-type"
                                       class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                       id="downloadStatus.status-select-filter-type"

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`Download Status Table should render correctly 1`] = `
                               <div
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
-                                aria-label="include or exclude"
+                                aria-label="include, exclude or exact"
                                 aria-labelledby="downloadStatus.filename-select-filter-type"
                                 class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                 id="downloadStatus.filename-select-filter-type"
@@ -240,7 +240,7 @@ exports[`Download Status Table should render correctly 1`] = `
                               <div
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
-                                aria-label="include or exclude"
+                                aria-label="include, exclude or exact"
                                 aria-labelledby="downloadStatus.transport-select-filter-type"
                                 class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                 id="downloadStatus.transport-select-filter-type"
@@ -363,7 +363,7 @@ exports[`Download Status Table should render correctly 1`] = `
                               <div
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
-                                aria-label="include or exclude"
+                                aria-label="include, exclude or exact"
                                 aria-labelledby="downloadStatus.status-select-filter-type"
                                 class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                 id="downloadStatus.status-select-filter-type"

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -273,7 +273,9 @@ describe('Admin Download Status Table', () => {
 
       // We simulate a change in the select from 'include' to 'exclude'.
       // click on the select box
-      await user.click(screen.getAllByLabelText('include or exclude')[5]);
+      await user.click(
+        screen.getAllByLabelText('include, exclude or exact')[5]
+      );
       // click on exclude option
       await user.click(
         within(await screen.findByRole('listbox')).getByText('Exclude')

--- a/packages/datagateway-download/src/downloadTab/__snapshots__/downloadTab.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadTab/__snapshots__/downloadTab.component.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`DownloadTab should render correctly 1`] = `
                                       <div
                                         aria-expanded="false"
                                         aria-haspopup="listbox"
-                                        aria-label="include or exclude"
+                                        aria-label="include, exclude or exact"
                                         aria-labelledby="downloadCart.name-select-filter-type"
                                         class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                         id="downloadCart.name-select-filter-type"
@@ -301,7 +301,7 @@ exports[`DownloadTab should render correctly 1`] = `
                                       <div
                                         aria-expanded="false"
                                         aria-haspopup="listbox"
-                                        aria-label="include or exclude"
+                                        aria-label="include, exclude or exact"
                                         aria-labelledby="downloadCart.type-select-filter-type"
                                         class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                                         id="downloadCart.type-select-filter-type"


### PR DESCRIPTION
## Description
This PR adds an `Exact` text filter. This filter returns only the results with fields exactly matching the query.

![image](https://github.com/ral-facilities/datagateway/assets/72079517/6bf56eb7-7807-4ad9-a0ad-99781e8602b5) ![image](https://github.com/ral-facilities/datagateway/assets/72079517/7257517a-e5c6-4a23-be20-9f75e76dd52c)

- Added e2e tests to test `include`, `exclude` and `exact` filters (datagateway-dataview).
- Had to add `// eslint-disable-next-line cypress/unsafe-to-chain-command` before some of the existing lines in `investigations.cy.ts`, otherwise cypress wouldn't let me commit.
- Added unit tests for testing `exact` filter (datagateway-common).
- Changed `aria-label` of text filters button from "include or exclude" to "include, exclude or exact"


## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1540 
