### PR TITLE
Improve e2e tests & fix sorting bug

### DIFF
--- a/packages/datagateway-common/package.json
+++ b/packages/datagateway-common/package.json
@@ -43,6 +43,7 @@
     "react-router-dom": ">= 5.2.0 < 6"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.22.5",
     "@mui/icons-material": "5.11.0",
     "@mui/material": "5.11.0",
     "@testing-library/jest-dom": "5.16.4",
@@ -56,7 +57,6 @@
     "@types/react-virtualized": "9.21.10",
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
-    "@babel/eslint-parser": "7.22.5",
     "eslint": "8.44.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-config-react-app": "7.0.0",

--- a/packages/datagateway-common/src/api/dataPublications.test.tsx
+++ b/packages/datagateway-common/src/api/dataPublications.test.tsx
@@ -36,7 +36,7 @@ describe('data publications api functions', () => {
     ];
     history = createMemoryHistory({
       initialEntries: [
-        '/?sort={"name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
+        '/?sort={"name":"asc","title":"desc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
       ],
     });
     params = new URLSearchParams();
@@ -53,7 +53,7 @@ describe('data publications api functions', () => {
         data: mockData,
       });
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useDataPublicationsPaginated([
             {
@@ -74,6 +74,7 @@ describe('data publications api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -103,6 +104,16 @@ describe('data publications api functions', () => {
         params.toString()
       );
       expect(result.current.data).toEqual(mockData);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(2);
     });
 
     it('sends axios request to fetch paginated data publications and calls handleICATError on failure', async () => {
@@ -143,7 +154,7 @@ describe('data publications api functions', () => {
           : Promise.resolve({ data: mockData[1] })
       );
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useDataPublicationsInfinite([
             {
@@ -164,6 +175,7 @@ describe('data publications api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -219,6 +231,16 @@ describe('data publications api functions', () => {
         mockData[0],
         mockData[1],
       ]);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(3);
     });
 
     it('sends axios request to fetch infinite data publications and calls handleICATError on failure', async () => {

--- a/packages/datagateway-common/src/api/dataPublications.tsx
+++ b/packages/datagateway-common/src/api/dataPublications.tsx
@@ -67,7 +67,7 @@ export const useDataPublicationsPaginated = (
     [
       string,
       {
-        sort: SortType;
+        sort: string;
         filters: FiltersType;
         page: number;
         results: number;
@@ -77,11 +77,16 @@ export const useDataPublicationsPaginated = (
   >(
     [
       'dataPublication',
-      { sort, filters, page: page ?? 1, results: results ?? 10 },
+      {
+        sort: JSON.stringify(sort), // need to stringify sort as property order is important!
+        filters,
+        page: page ?? 1,
+        results: results ?? 10,
+      },
       additionalFilters,
     ],
     (params) => {
-      const { sort, filters, page, results } = params.queryKey[1];
+      const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
       return fetchDataPublications(
@@ -110,15 +115,13 @@ export const useDataPublicationsInfinite = (
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
 
-  return useInfiniteQuery<
-    DataPublication[],
-    AxiosError,
-    DataPublication[],
-    [string, { sort: SortType; filters: FiltersType }, AdditionalFilters?]
-  >(
-    ['dataPublication', { sort, filters }, additionalFilters],
+  return useInfiniteQuery(
+    [
+      'dataPublication',
+      { sort: JSON.stringify(sort), filters }, // need to stringify sort as property order is important!
+      additionalFilters,
+    ],
     (params) => {
-      const { sort, filters } = params.queryKey[1];
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
       return fetchDataPublications(
         apiUrl,

--- a/packages/datagateway-common/src/api/datafiles.test.tsx
+++ b/packages/datagateway-common/src/api/datafiles.test.tsx
@@ -40,7 +40,7 @@ describe('datafile api functions', () => {
     ];
     history = createMemoryHistory({
       initialEntries: [
-        '/?sort={"name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
+        '/?sort={"name":"asc","title":"desc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
       ],
     });
     params = new URLSearchParams();
@@ -58,7 +58,7 @@ describe('datafile api functions', () => {
         data: mockData,
       });
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useDatafilesPaginated([
             {
@@ -76,6 +76,7 @@ describe('datafile api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -102,6 +103,16 @@ describe('datafile api functions', () => {
         params.toString()
       );
       expect(result.current.data).toEqual(mockData);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(2);
     });
 
     it('sends axios request to fetch paginated datafiles and calls handleICATError on failure', async () => {
@@ -139,7 +150,7 @@ describe('datafile api functions', () => {
           : Promise.resolve({ data: mockData[1] })
       );
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useDatafilesInfinite([
             {
@@ -157,6 +168,7 @@ describe('datafile api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -209,6 +221,16 @@ describe('datafile api functions', () => {
         mockData[0],
         mockData[1],
       ]);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(3);
     });
 
     it('sends axios request to fetch infinite datafiles and calls handleICATError on failure', async () => {

--- a/packages/datagateway-common/src/api/datafiles.tsx
+++ b/packages/datagateway-common/src/api/datafiles.tsx
@@ -69,7 +69,7 @@ export const useDatafilesPaginated = (
     [
       string,
       {
-        sort: SortType;
+        sort: string;
         filters: FiltersType;
         page: number;
         results: number;
@@ -79,11 +79,16 @@ export const useDatafilesPaginated = (
   >(
     [
       'datafile',
-      { sort, filters, page: page ?? 1, results: results ?? 10 },
+      {
+        sort: JSON.stringify(sort), // need to stringify sort as property order is important!
+        filters,
+        page: page ?? 1,
+        results: results ?? 10,
+      },
       additionalFilters,
     ],
     (params) => {
-      const { sort, filters, page, results } = params.queryKey[1];
+      const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
       return fetchDatafiles(apiUrl, { sort, filters }, additionalFilters, {
@@ -107,15 +112,9 @@ export const useDatafilesInfinite = (
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
 
-  return useInfiniteQuery<
-    Datafile[],
-    AxiosError,
-    Datafile[],
-    [string, { sort: SortType; filters: FiltersType }, AdditionalFilters?]
-  >(
-    ['datafile', { sort, filters }, additionalFilters],
+  return useInfiniteQuery(
+    ['datafile', { sort: JSON.stringify(sort), filters }, additionalFilters], // need to stringify sort as property order is important!
     (params) => {
-      const { sort, filters } = params.queryKey[1];
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
       return fetchDatafiles(
         apiUrl,

--- a/packages/datagateway-common/src/api/datasets.test.tsx
+++ b/packages/datagateway-common/src/api/datasets.test.tsx
@@ -45,7 +45,7 @@ describe('dataset api functions', () => {
     ];
     history = createMemoryHistory({
       initialEntries: [
-        '/?sort={"name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
+        '/?sort={"name":"asc","title":"desc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
       ],
     });
     params = new URLSearchParams();
@@ -126,7 +126,7 @@ describe('dataset api functions', () => {
         data: mockData,
       });
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useDatasetsPaginated([
             {
@@ -144,6 +144,7 @@ describe('dataset api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -170,6 +171,16 @@ describe('dataset api functions', () => {
         params.toString()
       );
       expect(result.current.data).toEqual(mockData);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(2);
     });
 
     it('sends axios request to fetch paginated datasets and calls handleICATError on failure', async () => {
@@ -207,7 +218,7 @@ describe('dataset api functions', () => {
           : Promise.resolve({ data: mockData[1] })
       );
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useDatasetsInfinite([
             {
@@ -225,6 +236,7 @@ describe('dataset api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -277,6 +289,16 @@ describe('dataset api functions', () => {
         mockData[0],
         mockData[1],
       ]);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(3);
     });
 
     it('sends axios request to fetch infinite datasets and calls handleICATError on failure', async () => {

--- a/packages/datagateway-common/src/api/datasets.tsx
+++ b/packages/datagateway-common/src/api/datasets.tsx
@@ -108,7 +108,7 @@ export const useDatasetsPaginated = (
     [
       string,
       {
-        sort: SortType;
+        sort: string;
         filters: FiltersType;
         page: number;
         results: number;
@@ -118,11 +118,16 @@ export const useDatasetsPaginated = (
   >(
     [
       'dataset',
-      { sort, filters, page: page ?? 1, results: results ?? 10 },
+      {
+        sort: JSON.stringify(sort), // need to stringify sort as property order is important!
+        filters,
+        page: page ?? 1,
+        results: results ?? 10,
+      },
       additionalFilters,
     ],
     (params) => {
-      const { sort, filters, page, results } = params.queryKey[1];
+      const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
       return fetchDatasets(apiUrl, { sort, filters }, additionalFilters, {
@@ -146,15 +151,9 @@ export const useDatasetsInfinite = (
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
 
-  return useInfiniteQuery<
-    Dataset[],
-    AxiosError,
-    Dataset[],
-    [string, { sort: SortType; filters: FiltersType }, AdditionalFilters?]
-  >(
-    ['dataset', { sort, filters }, additionalFilters],
+  return useInfiniteQuery(
+    ['dataset', { sort: JSON.stringify(sort), filters }, additionalFilters], // need to stringify sort as property order is important!
     (params) => {
-      const { sort, filters } = params.queryKey[1];
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
       return fetchDatasets(
         apiUrl,

--- a/packages/datagateway-common/src/api/facilityCycles.test.tsx
+++ b/packages/datagateway-common/src/api/facilityCycles.test.tsx
@@ -36,7 +36,7 @@ describe('facility cycle api functions', () => {
     ];
     history = createMemoryHistory({
       initialEntries: [
-        '/?sort={"name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
+        '/?sort={"name":"asc","title":"desc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
       ],
     });
     params = new URLSearchParams();
@@ -88,7 +88,7 @@ describe('facility cycle api functions', () => {
         data: mockData,
       });
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () => useFacilityCyclesPaginated(1),
         {
           wrapper: createReactQueryWrapper(history),
@@ -98,6 +98,7 @@ describe('facility cycle api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -131,6 +132,16 @@ describe('facility cycle api functions', () => {
         params.toString()
       );
       expect(result.current.data).toEqual(mockData);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(2);
     });
 
     it('sends axios request to fetch paginated facility cycles and calls handleICATError on failure', async () => {
@@ -184,7 +195,7 @@ describe('facility cycle api functions', () => {
           : Promise.resolve({ data: mockData[1] })
       );
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () => useFacilityCyclesInfinite(1),
         {
           wrapper: createReactQueryWrapper(history),
@@ -194,6 +205,7 @@ describe('facility cycle api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -253,6 +265,16 @@ describe('facility cycle api functions', () => {
         mockData[0],
         mockData[1],
       ]);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(3);
     });
 
     it('sends axios request to fetch infinite facility cycles and calls handleICATError on failure', async () => {

--- a/packages/datagateway-common/src/api/facilityCycles.tsx
+++ b/packages/datagateway-common/src/api/facilityCycles.tsx
@@ -106,7 +106,7 @@ export const useFacilityCyclesPaginated = (
       string,
       number,
       {
-        sort: SortType;
+        sort: string;
         filters: FiltersType;
         page: number;
         results: number;
@@ -116,10 +116,15 @@ export const useFacilityCyclesPaginated = (
     [
       'facilityCycle',
       instrumentId,
-      { sort, filters, page: page ?? 1, results: results ?? 10 },
+      {
+        sort: JSON.stringify(sort), // need to stringify sort as property order is important!
+        filters,
+        page: page ?? 1,
+        results: results ?? 10,
+      },
     ],
     (params) => {
-      const { sort, filters, page, results } = params.queryKey[2];
+      const { page, results } = params.queryKey[2];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
       return fetchFacilityCycles(
@@ -148,15 +153,9 @@ export const useFacilityCyclesInfinite = (
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
 
-  return useInfiniteQuery<
-    FacilityCycle[],
-    AxiosError,
-    FacilityCycle[],
-    [string, number, { sort: SortType; filters: FiltersType }]
-  >(
-    ['facilityCycle', instrumentId, { sort, filters }],
+  return useInfiniteQuery(
+    ['facilityCycle', instrumentId, { sort: JSON.stringify(sort), filters }],
     (params) => {
-      const { sort, filters } = params.queryKey[2];
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
       return fetchFacilityCycles(
         apiUrl,

--- a/packages/datagateway-common/src/api/instruments.tsx
+++ b/packages/datagateway-common/src/api/instruments.tsx
@@ -69,16 +69,24 @@ export const useInstrumentsPaginated = (
     [
       string,
       {
-        sort: SortType;
+        sort: string;
         filters: FiltersType;
         page: number;
         results: number;
       }
     ]
   >(
-    ['instrument', { sort, filters, page: page ?? 1, results: results ?? 10 }],
+    [
+      'instrument',
+      {
+        sort: JSON.stringify(sort), // need to stringify sort as property order is important!
+        filters,
+        page: page ?? 1,
+        results: results ?? 10,
+      },
+    ],
     (params) => {
-      const { sort, filters, page, results } = params.queryKey[1];
+      const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
       return fetchInstruments(apiUrl, { sort, filters }, additionalFilters, {
@@ -102,15 +110,9 @@ export const useInstrumentsInfinite = (
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
 
-  return useInfiniteQuery<
-    Instrument[],
-    AxiosError,
-    Instrument[],
-    [string, { sort: SortType; filters: FiltersType }]
-  >(
-    ['instrument', { sort, filters }],
+  return useInfiniteQuery(
+    ['instrument', { sort: JSON.stringify(sort), filters }], // need to stringify sort as property order is important!
     (params) => {
-      const { sort, filters } = params.queryKey[1];
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
       return fetchInstruments(
         apiUrl,

--- a/packages/datagateway-common/src/api/investigations.test.tsx
+++ b/packages/datagateway-common/src/api/investigations.test.tsx
@@ -51,7 +51,7 @@ describe('investigation api functions', () => {
     ];
     history = createMemoryHistory({
       initialEntries: [
-        '/?sort={"name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
+        '/?sort={"name":"asc","title":"desc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20',
       ],
     });
     params = new URLSearchParams();
@@ -132,7 +132,7 @@ describe('investigation api functions', () => {
         data: mockData,
       });
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useInvestigationsPaginated([
             {
@@ -150,6 +150,7 @@ describe('investigation api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -176,6 +177,16 @@ describe('investigation api functions', () => {
         params.toString()
       );
       expect(result.current.data).toEqual(mockData);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}&page=2&results=20'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(2);
     });
 
     it('sends axios request to fetch paginated investigations and returns successful response when ignoreIDSort is true', async () => {
@@ -204,6 +215,7 @@ describe('investigation api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append(
         'where',
         JSON.stringify({
@@ -269,7 +281,7 @@ describe('investigation api functions', () => {
           : Promise.resolve({ data: mockData[1] })
       );
 
-      const { result, waitFor } = renderHook(
+      const { result, waitFor, rerender } = renderHook(
         () =>
           useInvestigationsInfinite([
             {
@@ -287,6 +299,7 @@ describe('investigation api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append('order', JSON.stringify('id asc'));
       params.append(
         'where',
@@ -339,6 +352,16 @@ describe('investigation api functions', () => {
         mockData[0],
         mockData[1],
       ]);
+
+      // test that order of sort object triggers new query
+      history.push(
+        '/?sort={"title":"desc", "name":"asc"}&filters={"name":{"value":"test","type":"include"}}'
+      );
+      rerender();
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(axios.get as jest.Mock).toHaveBeenCalledTimes(3);
     });
 
     it('sends axios request to fetch infinite investigations and returns successful response when ignoreIDSort is true', async () => {
@@ -369,6 +392,7 @@ describe('investigation api functions', () => {
       await waitFor(() => result.current.isSuccess);
 
       params.append('order', JSON.stringify('name asc'));
+      params.append('order', JSON.stringify('title desc'));
       params.append(
         'where',
         JSON.stringify({

--- a/packages/datagateway-common/src/api/investigations.tsx
+++ b/packages/datagateway-common/src/api/investigations.tsx
@@ -110,7 +110,7 @@ export const useInvestigationsPaginated = (
     [
       string,
       {
-        sort: SortType;
+        sort: string;
         filters: FiltersType;
         page: number;
         results: number;
@@ -121,12 +121,17 @@ export const useInvestigationsPaginated = (
   >(
     [
       'investigation',
-      { sort, filters, page: page ?? 1, results: results ?? 10 },
+      {
+        sort: JSON.stringify(sort), // need to stringify sort as property order is important!
+        filters,
+        page: page ?? 1,
+        results: results ?? 10,
+      },
       additionalFilters,
       ignoreIDSort,
     ],
     (params) => {
-      const { sort, filters, page, results } = params.queryKey[1];
+      const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
       return fetchInvestigations(
@@ -157,20 +162,14 @@ export const useInvestigationsInfinite = (
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
 
-  return useInfiniteQuery<
-    Investigation[],
-    AxiosError,
-    Investigation[],
+  return useInfiniteQuery(
     [
-      string,
-      { sort: SortType; filters: FiltersType },
-      AdditionalFilters?,
-      boolean?
-    ]
-  >(
-    ['investigation', { sort, filters }, additionalFilters, ignoreIDSort],
+      'investigation',
+      { sort: JSON.stringify(sort), filters }, // need to stringify sort as property order is important!
+      additionalFilters,
+      ignoreIDSort,
+    ],
     (params) => {
-      const { sort, filters } = params.queryKey[1];
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
       return fetchInvestigations(
         apiUrl,

--- a/packages/datagateway-dataview/cypress.config.ts
+++ b/packages/datagateway-dataview/cypress.config.ts
@@ -29,4 +29,7 @@ export default defineConfig({
     },
     baseUrl: 'http://127.0.0.1:3000',
   },
+  env: {
+    CI: process.env.CI ?? false,
+  },
 });

--- a/packages/datagateway-dataview/cypress/e2e/breadcrumbs.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/breadcrumbs.cy.ts
@@ -19,10 +19,8 @@ describe('Breadcrumbs Component', () => {
 
   it('should click on investigation and add breadcrumbs correctly', () => {
     // Click on the first investigation in the table.
-    cy.get('[role="gridcell"] a')
-      .first()
-      .click({ force: true })
-      .wait('@getInvestigation');
+    cy.get('[role="gridcell"] a').first().click({ force: true });
+    cy.wait('@getInvestigation');
 
     // Check to see if the breadcrumbs have been added correctly.
     // Get the first link on the page which is a link to
@@ -77,7 +75,8 @@ describe('Breadcrumbs Component', () => {
     cy.visit('/browse/investigation/1/dataset').wait('@getInvestigation');
 
     // Click on the first link with Dataset 1.
-    cy.contains('DATASET 1').click({ force: true }).wait('@getDataset');
+    cy.contains('DATASET 1').click({ force: true });
+    cy.wait('@getDataset');
 
     // Check to ensure the location is the datafile.
     cy.location('pathname').should(
@@ -122,7 +121,8 @@ describe('Breadcrumbs Component', () => {
     cy.visit('/browse/investigation/1/dataset').wait('@getInvestigation');
 
     // Click on the first link with Dataset 1.
-    cy.contains('DATASET 1').click({ force: true }).wait('@getDataset');
+    cy.contains('DATASET 1').click({ force: true });
+    cy.wait('@getDataset');
 
     // Check to ensure the location is the datafile.
     cy.location('pathname').should(
@@ -132,19 +132,16 @@ describe('Breadcrumbs Component', () => {
 
     // The hover tool tip has an enter delay of 100ms.
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.contains('span', 'DATASET 1')
-      .trigger('mouseover', { force: true })
-      .wait(300)
-      .get('[role="tooltip"]')
-      .should('not.exist');
+    cy.contains('span', 'DATASET 1').trigger('mouseover', { force: true });
+
+    cy.get('[role="tooltip"]').should('not.exist');
 
     // The hover tool tip has an enter delay of 100ms.
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.contains('span', 'Analysis reflect')
-      .trigger('mouseover', { force: true })
-      .wait(300)
-      .get('[role="tooltip"]')
-      .contains('Analysis reflect');
+    cy.contains('span', 'Analysis reflect').trigger('mouseover', {
+      force: true,
+    });
+    cy.get('[role="tooltip"]').contains('Analysis reflect');
   });
 
   it('breadcrumbs should be sticky', () => {
@@ -156,9 +153,10 @@ describe('Breadcrumbs Component', () => {
       'Investigations'
     );
 
-    cy.get('[data-testid="card"]').eq(5).scrollIntoView().should('be.visible');
+    cy.get('[data-testid="card"]').eq(5).scrollIntoView();
+    cy.get('[data-testid="card"]').eq(5).should('be.visible');
 
     // Check the breadcrumbs are still visible
-    cy.get('[data-testid="Breadcrumb-base"]').isScrolledTo();
+    cy.get('[data-testid="Breadcrumb-base"]').should('be.visible');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/breadcrumbs.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/breadcrumbs.cy.ts
@@ -131,13 +131,11 @@ describe('Breadcrumbs Component', () => {
     );
 
     // The hover tool tip has an enter delay of 100ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.contains('span', 'DATASET 1').trigger('mouseover', { force: true });
 
     cy.get('[role="tooltip"]').should('not.exist');
 
     // The hover tool tip has an enter delay of 100ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.contains('span', 'Analysis reflect').trigger('mouseover', {
       force: true,
     });

--- a/packages/datagateway-dataview/cypress/e2e/card/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/datasets.cy.ts
@@ -3,15 +3,10 @@ describe('Datasets Cards', () => {
     cy.intercept('**/datasets/count*').as('getDatasetsCount');
     cy.intercept('**/datasets?order*').as('getDatasetsOrder');
     cy.login();
-    cy.visit('/browse/investigation/1/dataset').wait(
-      ['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'],
+    cy.visit('/browse/investigation/1/dataset?view=card').wait(
+      ['@getDatasetsCount', '@getDatasetsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page view Display as cards"]')
-      .click()
-      .wait(['@getDatasetsOrder'], {
-        timeout: 10000,
-      });
   });
 
   it('should load correctly', () => {
@@ -30,67 +25,70 @@ describe('Datasets Cards', () => {
     );
   });
 
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+  it('should be able to sort by one field or multiple', () => {
+    // ascending
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
       timeout: 10000,
     });
     cy.contains('[role="button"]', 'asc').should('exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
     cy.get('[data-testid="card"]').first().contains('DATASET 1');
 
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+    // descending
+    cy.get('@nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
       timeout: 10000,
     });
     cy.contains('[role="button"]', 'asc').should('not.exist');
     cy.contains('[role="button"]', 'desc').should('exist');
     cy.get('[data-testid="card"]').first().contains('DATASET 61');
 
-    cy.contains('[role="button"]', 'Name').click();
+    // no order
+    cy.get('@nameSortButton').click();
     cy.contains('[role="button"]', 'asc').should('not.exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
     cy.get('[data-testid="card"]').first().contains('DATASET 1');
-  });
 
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Create Time')
-      .click()
-      .wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('[data-testid="card"]').first().contains('DATASET 1');
-
-    cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
+    // multiple fields
+    cy.contains('[role="button"]', 'Create Time').click();
+    cy.wait('@getDatasetsOrder', {
       timeout: 10000,
     });
-    cy.contains('[role="button"]', 'asc').should('exist');
+
+    cy.get('@nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
+    });
+    cy.contains('[aria-label="Sort by NAME"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by CREATE TIME"]', 'asc').should('exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
+
     cy.get('[data-testid="card"]').first().contains('DATASET 1');
   });
 
   it('should be able to filter by multiple fields', () => {
     cy.get('[data-testid="advanced-filters-link"]').click();
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('61')
-      .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
+    cy.get('[aria-label="Filter by Name"]').first().type('61');
+    cy.wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
     cy.get('[data-testid="card"]').first().contains('DATASET 61');
 
-    cy.get('input[id="Create Time filter from"]')
-      .click()
-      .type('2019-01-01')
-      .wait(['@getDatasetsCount'], { timeout: 10000 });
+    cy.get('input[id="Create Time filter from"]').type('2019-01-01');
+    cy.wait(['@getDatasetsCount'], { timeout: 10000 });
+    cy.get('[data-testid="card"]').first().contains('DATASET 61');
+
     cy.get('input[aria-label="Create Time filter to"]')
       .parent()
       .find('button')
       .click();
-    cy.get('.MuiPickersDay-root[type="button"]')
-      .first()
-      .click()
-      .wait(['@getDatasetsCount'], { timeout: 10000 });
+    cy.get('.MuiPickersCalendarHeader-label').click();
+    cy.contains('2020').click();
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
+    cy.wait(['@getDatasetsCount'], { timeout: 10000 });
+
     const date = new Date();
     date.setDate(1);
+    date.setFullYear(2020);
     cy.get('input[id="Create Time filter to"]').should(
       'have.value',
       date.toISOString().slice(0, 10)

--- a/packages/datagateway-dataview/cypress/e2e/card/dls/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/dls/datasets.cy.ts
@@ -3,17 +3,11 @@ describe('DLS - Datasets Cards', () => {
     cy.intercept('**/datasets/count*').as('getDatasetsCount');
     cy.intercept('**/datasets?order*').as('getDatasetsOrder');
     cy.login();
-    cy.visit('/browse/proposal/INVESTIGATION%201/investigation/1/dataset').wait(
-      ['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'],
-      {
-        timeout: 10000,
-      }
-    );
-    cy.get('[aria-label="page view Display as cards"]')
-      .click()
-      .wait(['@getDatasetsOrder'], {
-        timeout: 10000,
-      });
+    cy.visit(
+      '/browse/proposal/INVESTIGATION%201/investigation/1/dataset?view=card'
+    ).wait(['@getDatasetsCount', '@getDatasetsOrder'], {
+      timeout: 10000,
+    });
   });
 
   it('should load correctly', () => {
@@ -25,7 +19,7 @@ describe('DLS - Datasets Cards', () => {
     cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
-  it('should be able to click an investigation to see its datasets', () => {
+  it('should be able to click a dataset to see its datafiles', () => {
     cy.get('[data-testid="card"]')
       .first()
       .contains('DATASET 61')
@@ -58,111 +52,81 @@ describe('DLS - Datasets Cards', () => {
       .contains('DATASETTYPE 3');
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@getDatasetsOrder', { timeout: 10000 });
-    });
-
-    it('one field', () => {
-      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 1');
-
-      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 61');
-
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 1');
-    });
-
-    it('multiple fields', () => {
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@getDatasetsOrder', {
-          timeout: 10000,
-        });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 1');
-
-      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 1');
-    });
-  });
-
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@getDatasetsOrder', { timeout: 10000 });
-    });
-
-    it('multiple fields', () => {
-      cy.get('[data-testid="advanced-filters-link"]').click();
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('61')
-        .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
-      cy.get('[data-testid="card"]').first().contains('DATASET 61');
-
-      cy.get('input[id="Create Time filter from"]')
-        .click()
-        .type('2019-01-01')
-        .wait(['@getDatasetsCount'], { timeout: 10000 });
-      cy.get('input[aria-label="Create Time filter to"]')
-        .parent()
-        .find('button')
-        .click();
-      cy.get('.MuiPickersDay-root[type="button"]')
-        .first()
-        .click()
-        .wait(['@getDatasetsCount'], { timeout: 10000 });
-      const date = new Date();
-      date.setDate(1);
-      cy.get('input[id="Create Time filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
-      cy.get('[data-testid="card"]').should('not.exist');
-    });
-  });
-
-  it('should display correct datafile count after filtering', () => {
-    cy.visit('/browse/proposal/INVESTIGATION%202/investigation/2/dataset').wait(
-      ['@getDatasetsCount', '@getDatasetsOrder'],
-      {
-        timeout: 10000,
-      }
-    );
+  it('should be able to sort by one field or multiple', () => {
     //Revert the default sort
-    cy.contains('[role="button"]', 'Create Time')
-      .click()
-      .wait('@getDatasetsOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'Create Time').as('timeSortButton').click();
+    cy.wait('@getDatasetsOrder', { timeout: 10000 });
 
+    // ascending
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
+    });
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('DATASET 1');
+
+    // descending
+    cy.get('@nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
+    });
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('[data-testid="card"]').first().contains('DATASET 61');
+
+    // no order
+    cy.get('@nameSortButton').click();
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('DATASET 1');
+
+    // multiple fields
+    cy.get('@timeSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
+    });
+
+    cy.get('@nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
+    });
+    cy.contains('[aria-label="Sort by NAME"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by CREATE TIME"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+
+    cy.get('[data-testid="card"]').first().contains('DATASET 1');
+  });
+
+  it('should be able to filter by multiple fields', () => {
     cy.get('[data-testid="advanced-filters-link"]').click();
+    cy.get('[aria-label="Filter by Name"]').first().type('61');
+    cy.wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
 
-    cy.get('[aria-label="Filter by Name"]')
-      .first()
-      .type('DATASET 62')
-      .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
+    cy.get('[data-testid="card"]').first().contains('DATASET 61');
+    // check that count is correct after filtering
+    cy.get('[data-testid="card"]').first().contains('15');
 
-    cy.get('[data-testid="card"]').first().contains('62');
+    cy.get('input[id="Create Time filter from"]').type('2019-01-01');
+    cy.wait(['@getDatasetsCount'], { timeout: 10000 });
+    cy.get('[data-testid="card"]').first().contains('DATASET 61');
+
+    cy.get('input[aria-label="Create Time filter to"]')
+      .parent()
+      .find('button')
+      .click();
+    cy.get('.MuiPickersCalendarHeader-label').click();
+    cy.contains('2020').click();
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
+    cy.wait(['@getDatasetsCount'], { timeout: 10000 });
+
+    const date = new Date();
+    date.setDate(1);
+    date.setFullYear(2020);
+    cy.get('input[id="Create Time filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
+    cy.get('[data-testid="card"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/card/dls/proposals.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/dls/proposals.cy.ts
@@ -3,15 +3,10 @@ describe('DLS - Proposals Cards', () => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
     cy.login();
-    cy.visit('/browse/proposal/').wait(
+    cy.visit('/browse/proposal?view=card').wait(
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page view Display as cards"]')
-      .click()
-      .wait(['@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
   });
 
   it('should load correctly', () => {
@@ -19,7 +14,7 @@ describe('DLS - Proposals Cards', () => {
     cy.get('#datagateway-dataview').should('be.visible');
   });
 
-  it('should be able to click an investigation to see its datasets', () => {
+  it('should be able to click a proposal to see its visits', () => {
     cy.get('[data-testid="card"]')
       .first()
       .contains('A air avoid beautiful.')
@@ -30,48 +25,23 @@ describe('DLS - Proposals Cards', () => {
     );
   });
 
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="card"]')
-      .get('[data-testid="dls-proposal-card-title"]')
-      .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+  it('should be able to filter by multiple fields', () => {
+    cy.get('[data-testid="advanced-filters-link"]').click();
 
-    cy.get('body').type('{esc}');
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="card"]')
-      .get('[data-testid="dls-proposal-card-title"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
-      .should('not.exist');
-  });
-
-  describe('should be able to filter by', () => {
-    it('multiple fields', () => {
-      cy.get('[data-testid="advanced-filters-link"]').click();
-      cy.get('[aria-label="Filter by Title"]')
-        .first()
-        .type('Dog')
-        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-          timeout: 10000,
-        });
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Majority about dog idea bag summer.');
-
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('2')
-        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-          timeout: 10000,
-        });
-      cy.get('[data-testid="card"]').first().contains('INVESTIGATION 52');
+    cy.get('[aria-label="Filter by Name"]').first().type('2');
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
     });
+    cy.get('[data-testid="card"]').first().contains('INVESTIGATION 21');
+    cy.contains('[aria-label="view-count"]', '15').should('be.visible');
+
+    cy.get('[aria-label="Filter by Title"]').first().type('Dog');
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
+    });
+    cy.get('[data-testid="card"]')
+      .first()
+      .contains('Majority about dog idea bag summer.');
+    cy.get('[data-testid="card"]').should('have.length', 1);
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/card/dls/visits.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/dls/visits.cy.ts
@@ -3,15 +3,10 @@ describe('DLS - Visits Cards', () => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
     cy.login();
-    cy.visit('/browse/proposal/INVESTIGATION%201/investigation/').wait(
+    cy.visit('/browse/proposal/INVESTIGATION%201/investigation?view=card').wait(
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 10000 }
     );
-    cy.get('[aria-label="page view Display as cards"]')
-      .click()
-      .wait(['@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
   });
 
   it('should load correctly', () => {
@@ -65,89 +60,65 @@ describe('DLS - Visits Cards', () => {
       .contains('Simple notice since view check over through there.');
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-    });
+  // only 1 visit, so no point in testing sorting
+  it.skip('should be able to sort by one field or multiple', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Start Date').as('dateSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
 
-    it('one field', () => {
-      cy.contains('[role="button"]', 'Visit ID')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('70');
+    // ascending
+    cy.contains('[role="button"]', 'Visit ID').as('visitIdSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('70');
 
-      cy.contains('[role="button"]', 'Visit ID')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('exist');
-      cy.get('[data-testid="card"]').first().contains('70');
+    // descending
+    cy.get('@visitIdSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('[data-testid="card"]').first().contains('70');
 
-      cy.contains('[role="button"]', 'Visit ID').click();
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('70');
-    });
+    // no order
+    cy.get('@visitIdSortButton').click();
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('70');
 
-    it('multiple fields', () => {
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('70');
+    // multiple fields
+    cy.get('@dateSortButton').click();
+    cy.get('@visitIdSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
 
-      cy.contains('[role="button"]', 'Visit ID')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').contains('70');
-    });
+    cy.contains('[aria-label="Sort by VISIT ID"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by START DATE"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('70');
   });
 
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
+  it('should be able to filter by multiple fields', () => {
+    cy.get('[data-testid="advanced-filters-link"]').click();
+    cy.get('[aria-label="Filter by Visit ID"]').first().type('7');
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
     });
+    cy.get('[data-testid="card"]').first().contains('70');
 
-    it('multiple fields', () => {
-      cy.get('[data-testid="advanced-filters-link"]').click();
-      cy.get('[aria-label="Filter by Visit ID"]')
-        .first()
-        .type('7')
-        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-          timeout: 10000,
-        });
-      cy.get('[data-testid="card"]').first().contains('70');
-
-      cy.get('input[id="Start Date filter from"]')
-        .click()
-        .type('2000-05-01')
-        .wait(['@getInvestigationsCount'], { timeout: 10000 });
-      cy.get('input[aria-label="Start Date filter to"]')
-        .parent()
-        .find('button')
-        .click();
-      cy.get('.MuiPickersDay-root[type="button"]')
-        .first()
-        .click()
-        .wait(['@getInvestigationsCount'], { timeout: 10000 });
-      const date = new Date();
-      date.setDate(1);
-      cy.get('input[id="Start Date filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
-      cy.get('[data-testid="card"]').should('not.exist');
-    });
+    cy.get('input[id="Start Date filter from"]').type('2000-05-01');
+    cy.wait(['@getInvestigationsCount'], { timeout: 10000 });
+    cy.get('input[aria-label="Start Date filter to"]')
+      .parent()
+      .find('button')
+      .click();
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
+    cy.wait(['@getInvestigationsCount'], { timeout: 10000 });
+    const date = new Date();
+    date.setDate(1);
+    cy.get('input[id="Start Date filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
+    cy.get('[data-testid="card"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/card/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/investigations.cy.ts
@@ -3,27 +3,16 @@ describe('Investigations Cards', () => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
     cy.login();
-    cy.visit('/browse/investigation').wait(
+    cy.visit('/browse/investigation?view=card').wait(
       ['@getInvestigationsCount', '@getInvestigationsOrder'],
       { timeout: 15000 }
     );
-    cy.get('[aria-label="page view Display as cards"]').click();
   });
 
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
-  });
 
-  it('should be able to click an investigation to see its datasets', () => {
-    cy.get('[data-testid="card"]')
-      .first()
-      .contains('Analysis reflect work or hour color maybe.')
-      .click({ force: true });
-    cy.location('pathname').should('eq', '/browse/investigation/1/dataset');
-  });
-
-  it('should have the correct url for the DOI link', () => {
     cy.get('[data-testid="card"]')
       .first()
       .get('[data-testid="investigation-card-doi-link"]')
@@ -41,69 +30,46 @@ describe('Investigations Cards', () => {
       });
   });
 
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
+  it('should be able to click an investigation to see its datasets', () => {
     cy.get('[data-testid="card"]')
-      .get('[data-testid="investigation-card-title"]')
       .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
-
-    cy.get('body').type('{esc}');
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="card"]')
-      .get('[data-testid="investigation-card-title"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
-      .should('not.exist');
+      .contains('Analysis reflect work or hour color maybe.')
+      .click({ force: true });
+    cy.location('pathname').should('eq', '/browse/investigation/1/dataset');
   });
 
-  it('should be able to sort by one field', () => {
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
+  it('should be able to sort by one field or multiple', () => {
+    // ascending
+    cy.contains('[role="button"]', 'Title').as('titleSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
     cy.contains('[role="button"]', 'asc').should('exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
     cy.get('[data-testid="card"]').first().contains('A air avoid beautiful.');
 
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
+    // descending
+    cy.get('@titleSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
     cy.contains('[role="button"]', 'asc').should('not.exist');
     cy.contains('[role="button"]', 'desc').should('exist');
     cy.get('[data-testid="card"]')
       .first()
       .contains('Why news west bar sing tax.');
 
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
+    // no order
+    cy.get('@titleSortButton').click();
     cy.contains('[role="button"]', 'asc').should('not.exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
     cy.get('[data-testid="card"]')
       .first()
       .contains('Analysis reflect work or hour color maybe.');
-  });
 
-  it('should be able to sort by multiple fields', () => {
-    cy.contains('[role="button"]', 'Start Date')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
-    cy.contains('[role="button"]', 'desc').should('not.exist');
-    cy.get('[data-testid="card"]')
-      .first()
-      .contains('Analysis reflect work or hour color maybe.');
+    // multiple fields
+    cy.contains('[role="button"]', 'Start Date').click();
+    cy.get('@titleSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
 
-    cy.contains('[role="button"]', 'Title')
-      .click()
-      .wait('@getInvestigationsOrder', { timeout: 10000 });
-    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by TITLE"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by START DATE"]', 'asc').should('exist');
     cy.contains('[role="button"]', 'desc').should('not.exist');
     cy.get('[data-testid="card"]')
       .first()
@@ -115,10 +81,10 @@ describe('Investigations Cards', () => {
     cy.contains('[role="button"]', 'Type ID')
       .parent()
       .contains('[role="button"]', '1')
-      .click()
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 30000,
-      });
+      .click();
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 30000,
+    });
     cy.contains('[role="button"]', 'Type ID - 1').should('exist');
     cy.get('[data-testid="card"]')
       .first()
@@ -126,12 +92,10 @@ describe('Investigations Cards', () => {
 
     cy.get('[data-testid="advanced-filters-link"]').click();
 
-    cy.get('[aria-label="Filter by Title"]')
-      .first()
-      .type('off', { delay: 20 })
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Filter by Title"]').first().type('off', { delay: 20 });
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
+    });
 
     cy.get('[data-testid="advanced-filters-link"]').click();
 
@@ -141,25 +105,21 @@ describe('Investigations Cards', () => {
 
     cy.get('[data-testid="advanced-filters-link"]').click();
 
-    cy.get('input[id="Start Date filter from"]')
-      .click()
-      .type('2014-01-01')
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
+    cy.get('input[aria-label="Start Date filter from"]').type('2014-01-01');
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
+    });
     cy.get('input[aria-label="Start Date filter to"]')
       .parent()
       .find('button')
       .click();
-    cy.get('.MuiPickersDay-root[type="button"]')
-      .first()
-      .click()
-      .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-        timeout: 10000,
-      });
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
+    });
     const date = new Date();
     date.setDate(1);
-    cy.get('input[id="Start Date filter to"]').should(
+    cy.get('input[aria-label="Start Date filter to"]').should(
       'have.value',
       date.toISOString().slice(0, 10)
     );

--- a/packages/datagateway-dataview/cypress/e2e/card/isis/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/isis/datasets.cy.ts
@@ -4,15 +4,10 @@ describe('ISIS - Datasets Cards', () => {
     cy.intercept('**/datasets?order*').as('getDatasetsOrder');
     cy.login();
     cy.visit(
-      '/browse/instrument/1/facilityCycle/19/investigation/19/dataset'
-    ).wait(['@getDatasetsCount', '@getDatasetsOrder', '@getDatasetsOrder'], {
+      '/browse/instrument/1/facilityCycle/19/investigation/19/dataset?view=card'
+    ).wait(['@getDatasetsCount', '@getDatasetsOrder'], {
       timeout: 10000,
     });
-    cy.get('[aria-label="page view Display as cards"]')
-      .click()
-      .wait(['@getDatasetsOrder'], {
-        timeout: 10000,
-      });
   });
 
   it('should load correctly', () => {
@@ -24,7 +19,7 @@ describe('ISIS - Datasets Cards', () => {
     cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
-  it('should be able to click an investigation to see its datasets', () => {
+  it('should be able to click a dataset to see its datafiles', () => {
     cy.get('[data-testid="card"]')
       .first()
       .contains('DATASET 79')
@@ -37,9 +32,8 @@ describe('ISIS - Datasets Cards', () => {
 
   it('should be able to expand "More Information"', () => {
     //Revert the default sort
-    cy.contains('[role="button"]', 'Create Time')
-      .click()
-      .wait('@getDatasetsOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'Create Time').click();
+    cy.wait('@getDatasetsOrder', { timeout: 10000 });
 
     cy.get('[data-testid="card"]')
       .first()
@@ -61,91 +55,81 @@ describe('ISIS - Datasets Cards', () => {
     );
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@getDatasetsOrder', { timeout: 10000 });
+  it('should be able to sort by one field or multiple', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Create Time').as('timeSortButton').click();
+    cy.wait('@getDatasetsOrder', { timeout: 10000 });
+
+    // ascending
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
+    });
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('DATASET 19');
+
+    // descending
+    cy.get('@nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
+    });
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('[data-testid="card"]').first().contains('DATASET 79');
+
+    // no order
+    cy.get('@nameSortButton').click();
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('DATASET 19');
+
+    // multiple fields
+    cy.get('@timeSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
     });
 
-    it('one field', () => {
-      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 19');
-
-      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 79');
-
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 19');
+    cy.get('@nameSortButton').click();
+    cy.wait('@getDatasetsOrder', {
+      timeout: 10000,
     });
+    cy.contains('[aria-label="Sort by NAME"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by CREATE TIME"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
 
-    it('multiple fields', () => {
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@getDatasetsOrder', {
-          timeout: 10000,
-        });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 19');
-
-      cy.contains('[role="button"]', 'Name').click().wait('@getDatasetsOrder', {
-        timeout: 10000,
-      });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('DATASET 19');
-    });
+    cy.get('[data-testid="card"]').first().contains('DATASET 19');
   });
 
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@getDatasetsOrder', { timeout: 10000 });
-    });
+  it('should be able to filter by multiple fields', () => {
+    cy.get('[data-testid="advanced-filters-link"]').click();
+    cy.get('[aria-label="Filter by Name"]').first().type('19');
+    cy.wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
 
-    it('multiple fields', () => {
-      cy.get('[data-testid="advanced-filters-link"]').click();
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('19')
-        .wait(['@getDatasetsCount', '@getDatasetsOrder'], { timeout: 10000 });
-      cy.get('[data-testid="card"]').first().contains('DATASET 19');
-      // check that size is correct after filtering
-      cy.get('[data-testid="card"]').first().contains('1.47 GB');
+    cy.get('[data-testid="card"]').first().contains('DATASET 19');
+    // check that size is correct after filtering
+    cy.get('[data-testid="card"]').first().contains('1.47 GB');
 
-      cy.get('input[id="Create Time filter from"]')
-        .click()
-        .type('2019-01-01')
-        .wait(['@getDatasetsCount'], { timeout: 10000 });
-      cy.get('input[aria-label="Create Time filter to"]')
-        .parent()
-        .find('button')
-        .click();
-      cy.get('.MuiPickersDay-root[type="button"]')
-        .first()
-        .click()
-        .wait(['@getDatasetsCount'], { timeout: 10000 });
-      const date = new Date();
-      date.setDate(1);
-      cy.get('input[id="Create Time filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
-      cy.get('[data-testid="card"]').should('not.exist');
-    });
+    cy.get('input[id="Create Time filter from"]').type('2019-01-01');
+    cy.wait(['@getDatasetsCount'], { timeout: 10000 });
+    cy.get('[data-testid="card"]').first().contains('DATASET 19');
+
+    cy.get('input[aria-label="Create Time filter to"]')
+      .parent()
+      .find('button')
+      .click();
+    cy.get('.MuiPickersCalendarHeader-label').click();
+    cy.contains('2020').click();
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
+    cy.wait(['@getDatasetsCount'], { timeout: 10000 });
+
+    const date = new Date();
+    date.setDate(1);
+    date.setFullYear(2020);
+    cy.get('input[id="Create Time filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
+    cy.get('[data-testid="card"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/card/isis/facilityCycles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/isis/facilityCycles.cy.ts
@@ -18,7 +18,7 @@ describe('ISIS - FacilityCycles Cards', () => {
     cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
-  it('should be able to click an investigation to see its datasets', () => {
+  it('should be able to click a facility cycle to see its investigations', () => {
     cy.get('[data-testid="card"]')
       .first()
       .contains('2004 cycle 3')
@@ -29,87 +29,67 @@ describe('ISIS - FacilityCycles Cards', () => {
     );
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-    });
-    // Note that Name and Description currently fail to sort
-    it('one field', () => {
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('2001 cycle 2');
+  it('should be able to sort by one field or multiple', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Start Date').as('dateSortButton').click();
+    cy.wait('@getFacilityCyclesOrder', { timeout: 10000 });
 
-      cy.contains('[role="button"]', 'Start Date').click();
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('exist');
-      cy.get('[data-testid="card"]').first().contains('2004 cycle 3');
+    // ascending
+    cy.get('@dateSortButton').click();
+    cy.wait('@getFacilityCyclesOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('2001 cycle 2');
 
-      cy.contains('[role="button"]', 'Start Date').click();
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('2001 cycle 2');
-    });
+    // descending
+    cy.get('@dateSortButton').click();
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('[data-testid="card"]').first().contains('2004 cycle 3');
 
-    it('multiple fields', () => {
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('2001 cycle 2');
+    // no order
+    cy.get('@dateSortButton').click();
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('2001 cycle 2');
 
-      cy.contains('[role="button"]', 'End Date')
-        .click()
-        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('2001 cycle 2');
-    });
+    // multiple fields
+    cy.get('@dateSortButton').click();
+    cy.contains('[role="button"]', 'End Date').click();
+    cy.wait('@getFacilityCyclesOrder', { timeout: 10000 });
+
+    cy.contains('[aria-label="Sort by START DATE"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by END DATE"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('2001 cycle 2');
   });
 
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getFacilityCyclesOrder', { timeout: 10000 });
-    });
+  it('should be able to filter by multiple fields', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Start Date').as('dateSortButton').click();
+    cy.wait('@getFacilityCyclesOrder', { timeout: 10000 });
 
-    it('multiple fields', () => {
-      cy.get('[data-testid="advanced-filters-link"]').click();
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('3')
-        .wait(['@getFacilityCyclesCount', '@getFacilityCyclesOrder'], {
-          timeout: 10000,
-        });
-      cy.get('[data-testid="card"]').first().contains('2002 cycle 3');
-
-      cy.get('input[id="Start Date filter from"]')
-        .click()
-        .type('2004-06-01')
-        .wait(['@getFacilityCyclesCount'], { timeout: 10000 });
-      cy.get('input[aria-label="Start Date filter to"]')
-        .parent()
-        .find('button')
-        .click();
-      cy.get('.MuiPickersDay-root[type="button"]')
-        .first()
-        .click()
-        .wait(['@getFacilityCyclesCount'], { timeout: 10000 });
-      const date = new Date();
-      date.setDate(1);
-      cy.get('input[id="Start Date filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
-      cy.get('[data-testid="card"]').first().contains('2004 cycle 3');
+    cy.get('[data-testid="advanced-filters-link"]').click();
+    cy.get('[aria-label="Filter by Name"]').first().type('3');
+    cy.wait(['@getFacilityCyclesCount', '@getFacilityCyclesOrder'], {
+      timeout: 10000,
     });
+    cy.get('[data-testid="card"]').first().contains('2002 cycle 3');
+
+    cy.get('input[id="Start Date filter from"]').type('2004-06-01');
+    cy.wait(['@getFacilityCyclesCount'], { timeout: 10000 });
+    cy.get('input[aria-label="Start Date filter to"]')
+      .parent()
+      .find('button')
+      .click();
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
+    cy.wait(['@getFacilityCyclesCount'], { timeout: 10000 });
+    const date = new Date();
+    date.setDate(1);
+    cy.get('input[id="Start Date filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
+    cy.get('[data-testid="card"]').first().contains('2004 cycle 3');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/card/isis/instruments.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/isis/instruments.cy.ts
@@ -19,34 +19,12 @@ describe('ISIS - Instruments Cards', () => {
     cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
   });
 
-  it('should be able to click an investigation to see its datasets', () => {
+  it('should be able to click an instrument to see its facility cycles', () => {
     cy.get('[data-testid="card"]')
       .first()
       .contains('Eight imagine picture tough.')
       .click({ force: true });
     cy.location('pathname').should('eq', '/browse/instrument/11/facilityCycle');
-  });
-
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="card"]')
-      .get('[data-testid="isis-instrument-card-name"]')
-      .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
-
-    cy.get('body').type('{esc}');
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="card"]')
-      .get('[data-testid="isis-instrument-card-name"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
-      .should('not.exist');
   });
 
   it('should be able to expand "More Information"', () => {
@@ -65,92 +43,73 @@ describe('ISIS - Instruments Cards', () => {
       .contains('Kim Ramirez');
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .click()
-        .wait('@getInstrumentsOrder', { timeout: 10000 });
-    });
+  it('should be able to sort by one field or multiple', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.get('@nameSortButton').click();
+    cy.wait('@getInstrumentsOrder', { timeout: 10000 });
 
-    it('one field', () => {
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@getInstrumentsOrder', {
-          timeout: 10000,
-        });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Eight imagine picture tough.');
+    // ascending
+    cy.get('@nameSortButton').click();
+    cy.wait('@getInstrumentsOrder', { timeout: 10000 });
 
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@getInstrumentsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('exist');
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Whether number computer economy design now serious appear.');
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]')
+      .first()
+      .contains('Eight imagine picture tough.');
 
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@getInstrumentsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Stop prove field onto think suffer measure.');
-    });
+    // descending
+    cy.get('@nameSortButton').click();
+    cy.wait('@getInstrumentsOrder', { timeout: 10000 });
 
-    it('multiple fields', () => {
-      cy.contains('[role="button"]', 'Description')
-        .click()
-        .wait('@getInstrumentsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Sound low certain challenge yet sport happy.');
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('[data-testid="card"]')
+      .first()
+      .contains('Whether number computer economy design now serious appear.');
 
-      cy.contains('[role="button"]', 'Type')
-        .click()
-        .wait('@getInstrumentsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('10');
-    });
+    // no order
+    cy.get('@nameSortButton').click();
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]')
+      .first()
+      .contains('Stop prove field onto think suffer measure.');
+
+    cy.contains('[role="button"]', 'Description').click();
+    cy.wait('@getInstrumentsOrder', { timeout: 10000 });
+    cy.get('[data-testid="card"]')
+      .first()
+      .contains('Sound low certain challenge yet sport happy.');
+
+    cy.contains('[role="button"]', 'Type').click();
+    cy.wait('@getInstrumentsOrder', { timeout: 10000 });
+    cy.contains('[aria-label="Sort by DESCRIPTION"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by TYPE"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('10');
   });
 
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .click()
-        .wait('@getInstrumentsOrder', { timeout: 10000 });
-    });
-    it('multiple fields', () => {
-      cy.get('[data-testid="advanced-filters-link"]').click();
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('oil')
-        .wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
-          timeout: 10000,
-        });
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Eight imagine picture tough.');
+  it('should be able to filter by multiple fields', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.get('@nameSortButton').click();
+    cy.wait('@getInstrumentsOrder', { timeout: 10000 });
 
-      cy.get('[aria-label="Filter by Type"]')
-        .first()
-        .type('11')
-        .wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
-          timeout: 10000,
-        });
-      cy.get('[data-testid="card"]').first().contains('11');
+    cy.get('[data-testid="advanced-filters-link"]').click();
+    cy.get('[aria-label="Filter by Name"]').first().type('oil');
+    cy.wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
+      timeout: 10000,
     });
+    cy.get('[data-testid="card"]')
+      .first()
+      .contains('Eight imagine picture tough.');
+
+    cy.get('[aria-label="Filter by Type"]').first().type('11');
+    cy.wait(['@getInstrumentsCount', '@getInstrumentsOrder'], {
+      timeout: 10000,
+    });
+    cy.get('[data-testid="card"]').first().contains('11');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/card/isis/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/isis/investigations.cy.ts
@@ -3,56 +3,17 @@ describe('ISIS - Investigations Cards', () => {
     cy.intercept('**/investigations/count*').as('getInvestigationsCount');
     cy.intercept('**/investigations?order*').as('getInvestigationsOrder');
     cy.login();
-    cy.visit('/browse/instrument/13/facilityCycle/12/investigation').wait(
-      ['@getInvestigationsCount', '@getInvestigationsOrder'],
-      { timeout: 10000 }
-    );
-    cy.get('[aria-label="page view Display as cards"]').click();
+    cy.visit(
+      '/browse/instrument/13/facilityCycle/12/investigation?view=card'
+    ).wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
+    });
   });
 
   it('should load correctly', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
 
-    //Default sort
-    cy.contains('[role="button"]', 'desc').should('exist');
-    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
-  });
-
-  it('should be able to click an investigation to see its datasets', () => {
-    cy.get('[data-testid="card"]')
-      .first()
-      .contains('Stop system investment')
-      .click({ force: true });
-    cy.location('pathname').should(
-      'eq',
-      '/browse/instrument/13/facilityCycle/12/investigation/31'
-    );
-  });
-
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="card"]')
-      .get('[data-testid="isis-investigations-card-title"]')
-      .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
-
-    cy.get('body').type('{esc}');
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="card"]')
-      .get('[data-testid="isis-investigations-card-title"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
-      .should('not.exist');
-  });
-
-  it('should have the correct url for the DOI link', () => {
     cy.get('[data-testid="card"]')
       .first()
       .get('[data-testid="isis-investigations-card-doi-link"]')
@@ -68,6 +29,21 @@ describe('ISIS - Investigations Cards', () => {
           .first()
           .should('have.attr', 'href', url);
       });
+
+    //Default sort
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
+  });
+
+  it('should be able to click an investigation to see its datasets', () => {
+    cy.get('[data-testid="card"]')
+      .first()
+      .contains('Stop system investment')
+      .click({ force: true });
+    cy.location('pathname').should(
+      'eq',
+      '/browse/instrument/13/facilityCycle/12/investigation/31'
+    );
   });
 
   it('should be able to expand "More Information"', () => {
@@ -145,84 +121,58 @@ describe('ISIS - Investigations Cards', () => {
     );
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-    });
+  it('should be able to sort by one field or multiple', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Start Date').as('dateSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
 
-    it('one field', () => {
-      cy.contains('[role="button"]', 'Title')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('Stop system investment');
+    // ascending
+    cy.contains('[role="button"]', 'Title').as('titleSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('Stop system investment');
 
-      cy.contains('[role="button"]', 'Title')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('exist');
-      cy.get('[data-testid="card"]').first().contains('Stop system investment');
+    // descending
+    cy.get('@titleSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('exist');
+    cy.get('[data-testid="card"]').first().contains('Stop system investment');
 
-      cy.contains('[role="button"]', 'Title')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('not.exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('Stop system investment');
-    });
+    // no order
+    cy.get('@titleSortButton').click();
+    cy.contains('[role="button"]', 'asc').should('not.exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('Stop system investment');
 
-    it('multiple fields', () => {
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('Stop system investment');
+    // multiple fields
+    cy.get('@dateSortButton').click();
+    cy.get('@titleSortButton').click();
+    cy.wait('@getInvestigationsOrder', { timeout: 10000 });
 
-      cy.contains('[role="button"]', 'Title')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'asc').should('exist');
-      cy.contains('[role="button"]', 'desc').should('not.exist');
-      cy.get('[data-testid="card"]').first().contains('Stop system investment');
-    });
+    cy.contains('[aria-label="Sort by TITLE"]', 'asc').should('exist');
+    cy.contains('[aria-label="Sort by START DATE"]', 'asc').should('exist');
+    cy.contains('[role="button"]', 'desc').should('not.exist');
+    cy.get('[data-testid="card"]').first().contains('Stop system investment');
   });
 
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date')
-        .click()
-        .wait('@getInvestigationsOrder', { timeout: 10000 });
+  it('should be able to filter by multiple fields', () => {
+    cy.get('[data-testid="advanced-filters-link"]').click();
+    cy.get('[aria-label="Filter by Title"]').first().type('stop');
+    cy.wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
+      timeout: 10000,
     });
 
-    it('multiple fields', () => {
-      cy.get('[data-testid="advanced-filters-link"]').click();
-      cy.get('[aria-label="Filter by Title"]')
-        .first()
-        .type('stop')
-        .wait(['@getInvestigationsCount', '@getInvestigationsOrder'], {
-          timeout: 10000,
-        });
+    cy.get('[data-testid="card"]').first().contains('Stop system investment');
+    // check that size is correct after filtering
+    cy.get('[data-testid="card"]').first().contains('3.31 GB');
 
-      cy.get('[data-testid="card"]').first().contains('Stop system investment');
-      // check that size is correct after filtering
-      cy.get('[data-testid="card"]').first().contains('3.31 GB');
-
-      cy.get('input[id="Start Date filter from"]')
-        .click()
-        .type('2007-08-01')
-        .wait(['@getInvestigationsCount'], { timeout: 10000 });
-      cy.get('[data-testid="card"]').first().contains('Stop system investment');
-      cy.get('input[id="Start Date filter to"]')
-        .type('2007-08-02')
-        .wait(['@getInvestigationsCount'], { timeout: 10000 });
-      cy.get('[data-testid="card"]').should('not.exist');
-    });
+    cy.get('input[id="Start Date filter from"]').type('2007-08-01');
+    cy.wait(['@getInvestigationsCount'], { timeout: 10000 });
+    cy.get('[data-testid="card"]').first().contains('Stop system investment');
+    cy.get('input[id="Start Date filter to"]').type('2007-08-02');
+    cy.wait(['@getInvestigationsCount'], { timeout: 10000 });
+    cy.get('[data-testid="card"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/card/pageContainer.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/card/pageContainer.cy.ts
@@ -29,9 +29,7 @@ describe('PageContainer Component', () => {
     cy.get('[aria-label="Go to selections"]').should('exist');
 
     cy.get('[aria-label="page view Display as table"]').should('exist');
-  });
 
-  it('should display correct entity count', () => {
     // Check that the entity count has displayed correctly.
     cy.get('[aria-label="view-count"]')
       .should('be.visible')
@@ -212,29 +210,20 @@ describe('PageContainer Component', () => {
 
   it('should display tooltips correctly', () => {
     // The hover tool tip has an enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="card"]')
       .get('[data-testid="investigation-card-title"]')
       .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+      .trigger('mouseover', { force: true });
+    cy.get('[role="tooltip"]').should('exist');
   });
 
   it('should not display tooltips after making the window bigger', () => {
     cy.viewport(3500, 750);
 
-    // The hover tool tip has an enter delay of 500ms and also need to
-    // wait after the viewport change as it takes a moment to resize
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200)
-      .get('[data-testid="card"]')
+    cy.get('[data-testid="card"]')
       .get('[data-testid="investigation-card-title"]')
       .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('not.exist');
+      .trigger('mouseover', { force: true });
+    cy.get('[role="tooltip"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/cartSelection.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/cartSelection.cy.ts
@@ -37,12 +37,8 @@ describe('Add/remove from cart functionality', () => {
           .then((text) => {
             expect(text.trim()).equal('1 item has been added to selection.');
           });
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
+        // and uncheck
         cy.get('[aria-label="select row 0"]').uncheck();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
@@ -55,6 +51,10 @@ describe('Add/remove from cart functionality', () => {
               '1 item has been removed from selection.'
             );
           });
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -85,13 +85,45 @@ describe('Add/remove from cart functionality', () => {
           .then((text) => {
             expect(text.trim()).equal('15 items have been added to selection.');
           });
+
+        // and uncheck
+
+        cy.get('[aria-label="grid"]').scrollTo('top', {
+          ensureScrollable: false,
+        });
+
+        cy.get('[aria-label="select all rows"]').uncheck();
+        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
+          'not.be.checked'
+        );
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
+        cy.get(
+          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
+        ).should('not.be.checked');
+
+        cy.get('[aria-label="grid"]').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.get(`[aria-label="select row 14"]`).should('not.be.checked');
+        cy.get('[aria-label="select all rows"]').should('not.be.checked');
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
+
+        cy.get('[aria-label="selection-alert-text"]')
+          .invoke('text')
+          .then((text) => {
+            expect(text.trim()).equal(
+              '15 items have been removed from selection.'
+            );
+          });
       });
 
       it('by all items in a filtered table', () => {
-        cy.get('[aria-label="Filter by Location"]')
-          .first()
-          .type('s')
-          .wait(['@getDatafiles', '@getDatafiles', '@getDatafileCount']);
+        cy.get('[aria-label="Filter by Location"]').first().type('s');
+        cy.wait(['@getDatafiles', '@getDatafiles', '@getDatafileCount']);
 
         cy.get('[aria-label="select all rows"]').check();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
@@ -116,7 +148,6 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="select row 1"]').should('not.be.checked');
 
-        //cy.get('[aria-label="grid"]').scrollTo(0, 350);
         cy.get('[aria-label="select row 9"]').should('not.be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo('bottom', {
@@ -125,75 +156,17 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="grid"]').scrollTo('bottom', {
           ensureScrollable: false,
         });
+
         cy.get('[aria-label="select row 12"]').should('be.checked');
         cy.get('[aria-label="select row 14"]').should('be.checked');
-      });
-
-      it('and unselect all items', () => {
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
-        cy.reload().wait([
-          '@getDatafiles',
-          '@getDatafiles',
-          '@getDatafileCount',
-          '@getDataset',
-          '@getDataset',
-          '@getInvestigation',
-        ]);
-
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-        cy.get('[aria-label="select all rows"]').uncheck();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'not.be.checked'
-        );
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-        cy.get(
-          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
-        ).should('not.be.checked');
-
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get(`[aria-label="select row 14"]`).should('not.be.checked');
-        cy.get('[aria-label="select all rows"]').should('not.be.checked');
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-
-        cy.get('[aria-label="selection-alert-text"]')
-          .invoke('text')
-          .then((text) => {
-            expect(text.trim()).equal(
-              '15 items have been removed from selection.'
-            );
-          });
       });
 
       it('by shift clicking', () => {
         cy.get('[aria-label="select row 0"]').click();
         cy.get('[aria-label="select row 0"]').should('be.checked');
 
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
+        cy.get('body').type('{shift}', { release: false });
+        cy.get('[aria-label="select row 5"]').click();
         cy.get('[aria-label="select row 5"]').should('be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo('top');
@@ -207,19 +180,9 @@ describe('Add/remove from cart functionality', () => {
           .then((text) => {
             expect(text.trim()).equal('5 items have been added to selection.');
           });
-      });
 
-      it('and unselect by shift clicking', () => {
-        cy.get('[aria-label="select row 0"]').click();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
+        // and uncheck
 
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
-        cy.get('[aria-label="select row 5"]').should('be.checked');
-
-        cy.get('[aria-label="grid"]').scrollTo('top');
         cy.get('[aria-label="select row 2"]').click();
         cy.get('[aria-label="select row 2"]').should('not.be.checked');
 
@@ -240,15 +203,6 @@ describe('Add/remove from cart functionality', () => {
             );
           });
       });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
-      });
     });
 
     describe('in DLS table', () => {
@@ -264,17 +218,18 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'true');
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
+        // and uncheck
         cy.get('[aria-label="select row 0"]').uncheck();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -300,13 +255,40 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]', { timeout: 10000 })
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
+
+        // and uncheck
+
+        cy.get('[aria-label="grid"]').scrollTo('top', {
+          ensureScrollable: false,
+        });
+
+        cy.get('[aria-label="select all rows"]').uncheck();
+        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
+          'not.be.checked'
+        );
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
+        cy.get(
+          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
+        ).should('not.be.checked');
+
+        cy.get('[aria-label="grid"]').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.get('[aria-label="grid"]').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.get(`[aria-label="select row 14"]`).should('not.be.checked');
+        cy.get('[aria-label="select all rows"]').should('not.be.checked');
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
       });
 
       it('by all items in a filtered table', () => {
-        cy.get('[aria-label="Filter by Location"]')
-          .first()
-          .type('s')
-          .wait(['@getDatafiles', '@getDatafiles', '@getDatafileCount']);
+        cy.get('[aria-label="Filter by Location"]').first().type('s');
+        cy.wait(['@getDatafiles', '@getDatafiles', '@getDatafileCount']);
 
         cy.get('[aria-label="select all rows"]').check();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
@@ -331,9 +313,6 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="select row 1"]').should('not.be.checked');
 
-        //cy.get('[aria-label="grid"]').scrollTo(0, 350);
-        //cy.get('[aria-label="select row 14"]').should('not.be.checked');
-
         cy.get('[aria-label="grid"]').scrollTo('bottom', {
           ensureScrollable: false,
         });
@@ -344,56 +323,12 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 14"]').should('be.checked');
       });
 
-      it('and unselect all items', () => {
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        }); //.wait('@getDatafiles');
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
-        cy.reload().wait(['@getDatafiles', '@getDatafiles']);
-
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-        cy.get('[aria-label="select all rows"]').uncheck();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'not.be.checked'
-        );
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-        cy.get(
-          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
-        ).should('not.be.checked');
-
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get(`[aria-label="select row 14"]`).should('not.be.checked');
-        cy.get('[aria-label="select all rows"]').should('not.be.checked');
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-      });
-
       it('by shift clicking', () => {
         cy.get('[aria-label="select row 0"]').click();
         cy.get('[aria-label="select row 0"]').should('be.checked');
 
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
+        cy.get('body').type('{shift}', { release: false });
+        cy.get('[aria-label="select row 5"]').click();
         cy.get('[aria-label="select row 5"]').should('be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo('top');
@@ -401,19 +336,8 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 3"]').should('be.checked');
         cy.get('[aria-label="select row 2"]').should('be.checked');
         cy.get('[aria-label="select row 1"]').should('be.checked');
-      });
 
-      it('and unselect by shift clicking', () => {
-        cy.get('[aria-label="select row 0"]').click();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
-        cy.get('[aria-label="select row 5"]').should('be.checked');
-
-        cy.get('[aria-label="grid"]').scrollTo('top');
+        // and uncheck
         cy.get('[aria-label="select row 2"]').click();
         cy.get('[aria-label="select row 2"]').should('not.be.checked');
 
@@ -425,15 +349,6 @@ describe('Add/remove from cart functionality', () => {
 
         cy.get('[aria-label="select row 1"]').should('be.checked');
         cy.get('[aria-label="select row 0"]').should('be.checked');
-      });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
       });
     });
 
@@ -450,17 +365,19 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'true');
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
+        // and uncheck
 
         cy.get('[aria-label="select row 0"]').uncheck();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -486,13 +403,38 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]', { timeout: 10000 })
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
+
+        // and uncheck
+        cy.get('[aria-label="grid"]').scrollTo('top', {
+          ensureScrollable: false,
+        });
+        cy.get('[aria-label="select all rows"]').uncheck();
+        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
+          'not.be.checked'
+        );
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
+        cy.get(
+          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
+        ).should('not.be.checked');
+
+        cy.get('[aria-label="grid"]').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.get('[aria-label="grid"]').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.get(`[aria-label="select row 14"]`).should('not.be.checked');
+        cy.get('[aria-label="select all rows"]').should('not.be.checked');
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
       });
 
       it('by all items in a filtered table', () => {
-        cy.get('[aria-label="Filter by Location"]')
-          .first()
-          .type('g')
-          .wait(['@getDatafiles', '@getDatafiles']);
+        cy.get('[aria-label="Filter by Location"]').first().type('g');
+        cy.wait(['@getDatafiles', '@getDatafiles']);
 
         cy.get('[aria-label="select all rows"]').check();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
@@ -518,9 +460,10 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 10"]').should('not.be.checked');
         cy.get('[aria-label="select row 0"]').should('be.checked');
 
-        cy.get('[aria-label="grid"]')
-          .scrollTo('bottom', { ensureScrollable: false })
-          .wait('@getDatafiles');
+        cy.get('[aria-label="grid"]').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.wait('@getDatafiles');
         cy.get('[aria-label="grid"]').scrollTo('bottom', {
           ensureScrollable: false,
         });
@@ -528,60 +471,12 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 14"]').should('be.checked');
       });
 
-      it('and unselect all items', () => {
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
-        cy.reload().wait([
-          '@getDatafiles',
-          '@getDatafiles',
-          '@getDatafileCount',
-        ]);
-
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-        cy.get('[aria-label="select all rows"]').uncheck();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'not.be.checked'
-        );
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-        cy.get(
-          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
-        ).should('not.be.checked');
-
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get(`[aria-label="select row 14"]`).should('not.be.checked');
-        cy.get('[aria-label="select all rows"]').should('not.be.checked');
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-      });
-
       it('by shift clicking', () => {
         cy.get('[aria-label="select row 0"]').click();
         cy.get('[aria-label="select row 0"]').should('be.checked');
 
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
+        cy.get('body').type('{shift}', { release: false });
+        cy.get('[aria-label="select row 5"]').click();
         cy.get('[aria-label="select row 5"]').should('be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo('top');
@@ -589,19 +484,8 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 3"]').should('be.checked');
         cy.get('[aria-label="select row 2"]').should('be.checked');
         cy.get('[aria-label="select row 1"]').should('be.checked');
-      });
 
-      it('and unselect by shift clicking', () => {
-        cy.get('[aria-label="select row 0"]').click();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
-        cy.get('[aria-label="select row 5"]').should('be.checked');
-
-        cy.get('[aria-label="grid"]').scrollTo('top');
+        // and uncheck
         cy.get('[aria-label="select row 2"]').click();
         cy.get('[aria-label="select row 2"]').should('not.be.checked');
 
@@ -613,15 +497,6 @@ describe('Add/remove from cart functionality', () => {
 
         cy.get('[aria-label="select row 1"]').should('be.checked');
         cy.get('[aria-label="select row 0"]').should('be.checked');
-      });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
       });
     });
   });
@@ -653,12 +528,8 @@ describe('Add/remove from cart functionality', () => {
           .then((text) => {
             expect(text.trim()).equal('1 item has been added to selection.');
           });
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
+        // and uncheck
         cy.get('[aria-label="select row 0"]').uncheck();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
@@ -672,6 +543,11 @@ describe('Add/remove from cart functionality', () => {
               '1 item has been removed from selection.'
             );
           });
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -690,16 +566,8 @@ describe('Add/remove from cart functionality', () => {
           .then((text) => {
             expect(text.trim()).equal('2 items have been added to selection.');
           });
-      });
 
-      it('and unselect all items', () => {
-        cy.get(`[aria-label="select row 0"]`).should('exist');
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
+        // and uncheck
         cy.get('[aria-label="select all rows"]').uncheck();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
           'not.be.checked'
@@ -715,15 +583,6 @@ describe('Add/remove from cart functionality', () => {
               '2 items have been removed from selection.'
             );
           });
-      });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
       });
     });
 
@@ -741,18 +600,19 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'true');
         cy.get('[aria-label="select all rows"]').should('not.be.checked');
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
+        // and uncheck
         cy.get('[aria-label="select row 0"]').uncheck();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get('[aria-label="select all rows"]').should('not.be.checked');
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -766,16 +626,8 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
-      });
 
-      it('and unselect all items', () => {
-        cy.get(`[aria-label="select row 0"]`).should('exist');
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
+        // and uncheck
         cy.get('[aria-label="select all rows"]').uncheck();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
           'not.be.checked'
@@ -784,15 +636,6 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
-      });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
       });
     });
 
@@ -810,18 +653,19 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'true');
         cy.get('[aria-label="select all rows"]').should('not.be.checked');
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
+        // and uncheck
         cy.get('[aria-label="select row 0"]').uncheck();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get('[aria-label="select all rows"]').should('not.be.checked');
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -835,16 +679,8 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
-      });
 
-      it('and unselect all items', () => {
-        cy.get(`[aria-label="select row 0"]`).should('exist');
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
+        // and uncheck
         cy.get('[aria-label="select all rows"]').uncheck();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
           'not.be.checked'
@@ -853,15 +689,6 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
-      });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
       });
     });
   });
@@ -892,12 +719,8 @@ describe('Add/remove from cart functionality', () => {
           .then((text) => {
             expect(text.trim()).equal('1 item has been added to selection.');
           });
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
+        // and uncheck
         cy.get('[aria-label="select row 0"]').uncheck();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
@@ -910,6 +733,11 @@ describe('Add/remove from cart functionality', () => {
               '1 item has been removed from selection.'
             );
           });
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -940,13 +768,42 @@ describe('Add/remove from cart functionality', () => {
           .then((text) => {
             expect(text.trim()).equal('59 items have been added to selection.');
           });
+
+        // and uncheck
+        cy.get('[aria-label="grid"]').scrollTo('top', {
+          ensureScrollable: false,
+        });
+        cy.get('[aria-label="select all rows"]').uncheck();
+        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
+          'not.be.checked'
+        );
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
+        cy.get(
+          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
+        ).should('not.be.checked');
+
+        cy.get('[aria-label="grid"]').scrollTo('bottom', {
+          ensureScrollable: false,
+        });
+        cy.get(`[aria-label="select row 50"]`).should('not.be.checked');
+        cy.get('[aria-label="select all rows"]')
+          .should('have.attr', 'data-indeterminate')
+          .and('eq', 'false');
+
+        cy.get('[aria-label="selection-alert-text"]')
+          .invoke('text')
+          .then((text) => {
+            expect(text.trim()).equal(
+              '59 items have been removed from selection.'
+            );
+          });
       });
 
       it('by all items in a filtered table', () => {
-        cy.get('[aria-label="Filter by Visit ID"]')
-          .first()
-          .type('7')
-          .wait(['@getInvestigations', '@getInvestigations']);
+        cy.get('[aria-label="Filter by Visit ID"]').first().type('7');
+        cy.wait(['@getInvestigations', '@getInvestigations']);
 
         cy.get('[aria-label="select all rows"]').check();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
@@ -983,63 +840,12 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 58"]').should('not.be.checked');
       });
 
-      it('and unselect all items', () => {
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
-        cy.reload().wait(['@getInvestigations', '@getInvestigations']);
-
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-        cy.get('[aria-label="select all rows"]').uncheck();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'not.be.checked'
-        );
-        cy.get(
-          `[aria-label="select row ${Math.floor(Math.random() * 10)}"]`
-        ).should('not.be.checked');
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get('[aria-label="grid"]').scrollTo('bottom', {
-          ensureScrollable: false,
-        });
-        cy.get(`[aria-label="select row 14"]`).should('not.be.checked');
-        cy.get('[aria-label="select all rows"]')
-          .should('have.attr', 'data-indeterminate')
-          .and('eq', 'false');
-
-        cy.get('[aria-label="selection-alert-text"]')
-          .invoke('text')
-          .then((text) => {
-            expect(text.trim()).equal(
-              '59 items have been removed from selection.'
-            );
-          });
-      });
-
       it('by shift clicking', () => {
         cy.get('[aria-label="select row 0"]').click();
         cy.get('[aria-label="select row 0"]').should('be.checked');
 
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
+        cy.get('body').type('{shift}', { release: false });
+        cy.get('[aria-label="select row 5"]').click();
         cy.get('[aria-label="select row 5"]').should('be.checked');
 
         cy.get('[aria-label="grid"]').scrollTo('top');
@@ -1048,24 +854,8 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select row 2"]').should('be.checked');
         cy.get('[aria-label="select row 1"]').should('be.checked');
 
-        cy.get('[aria-label="selection-alert-text"]')
-          .invoke('text')
-          .then((text) => {
-            expect(text.trim()).equal('5 items have been added to selection.');
-          });
-      });
+        // and uncheck
 
-      it('and unselect by shift clicking', () => {
-        cy.get('[aria-label="select row 0"]').click();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
-        cy.get('body')
-          .type('{shift}', { release: false })
-          .get('[aria-label="select row 5"]')
-          .click();
-        cy.get('[aria-label="select row 5"]').should('be.checked');
-
-        cy.get('[aria-label="grid"]').scrollTo('top');
         cy.get('[aria-label="select row 2"]').click();
         cy.get('[aria-label="select row 2"]').should('not.be.checked');
 
@@ -1086,15 +876,6 @@ describe('Add/remove from cart functionality', () => {
             );
           });
       });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
-      });
     });
 
     describe('in ISIS browse table', () => {
@@ -1113,18 +894,19 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get('[aria-label="select all rows"]').should('be.checked');
-      });
 
-      it('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').click();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-
+        // and uncheck
         cy.get('[aria-label="select row 0"]').click();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get('[aria-label="select all rows"]').should('not.be.checked');
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
       it('by all items', () => {
@@ -1138,16 +920,8 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
-      });
 
-      it('and unselect all items', () => {
-        cy.get(`[aria-label="select row 0"]`).should('exist');
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
+        // and uncheck
         cy.get('[aria-label="select all rows"]').uncheck();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
           'not.be.checked'
@@ -1157,19 +931,19 @@ describe('Add/remove from cart functionality', () => {
           .and('eq', 'false');
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
       });
-
-      it('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
-      });
     });
 
     describe('in ISIS my data table', () => {
       beforeEach(() => {
+        cy.login(
+          {
+            username: 'root',
+            password: 'pw',
+            mechanism: 'simple',
+          },
+          'Richard459'
+        );
+
         cy.visit('/my-data/ISIS').wait([
           '@getInvestigations',
           '@getInvestigations',
@@ -1177,18 +951,15 @@ describe('Add/remove from cart functionality', () => {
         ]);
       });
 
-      it.skip('individually', () => {
+      it('individually', () => {
         cy.get('[aria-label="select row 0"]').click();
         cy.get('[aria-label="select row 0"]').should('be.checked');
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get('[aria-label="select all rows"]').should('be.checked');
-      });
 
-      it.skip('and unselect them individually', () => {
-        cy.get('[aria-label="select row 0"]').click();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
+        // and uncheck
 
         cy.get('[aria-label="select row 0"]').click();
         cy.get('[aria-label="select row 0"]').should('not.be.checked');
@@ -1196,9 +967,14 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get('[aria-label="select all rows"]').should('not.be.checked');
+
+        cy.get('[aria-label="selection-alert-link"]').click();
+        cy.location().should((loc) => {
+          expect(loc.pathname).to.equal('/download');
+        });
       });
 
-      it.skip('by all items', () => {
+      it('by all items', () => {
         cy.get(`[aria-label="select row 0"]`).should('exist');
 
         cy.get('[aria-label="select all rows"]').check();
@@ -1209,16 +985,8 @@ describe('Add/remove from cart functionality', () => {
         cy.get('[aria-label="select all rows"]')
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
-      });
 
-      it.skip('and unselect all items', () => {
-        cy.get(`[aria-label="select row 0"]`).should('exist');
-
-        cy.get('[aria-label="select all rows"]').check();
-        cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
-          'be.checked'
-        );
-
+        // and uncheck
         cy.get('[aria-label="select all rows"]').uncheck();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
           'not.be.checked'
@@ -1227,15 +995,6 @@ describe('Add/remove from cart functionality', () => {
           .should('have.attr', 'data-indeterminate')
           .and('eq', 'false');
         cy.get(`[aria-label="select row 0"]`).should('not.be.checked');
-      });
-
-      it.skip('and navigate to selection using banner', () => {
-        cy.get('[aria-label="select row 0"]').check();
-        cy.get('[aria-label="select row 0"]').should('be.checked');
-        cy.get('[aria-label="selection-alert-link"]').click();
-        cy.location().should((loc) => {
-          expect(loc.pathname).to.equal('/download');
-        });
       });
     });
   });

--- a/packages/datagateway-dataview/cypress/e2e/landing/isis/dataPublication.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/landing/isis/dataPublication.cy.ts
@@ -8,6 +8,22 @@ describe('ISIS - Data Publication Landing', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
     cy.contains('Yourself good together red across.').should('be.visible');
+    cy.contains('a', '0-7602-7584-X').should(
+      'have.attr',
+      'href',
+      'https://doi.org/0-7602-7584-X'
+    );
+    cy.get('[data-testid="landing-dataPublication-pid-link"]')
+      .first()
+      .then(($pid) => {
+        const pid = $pid.text();
+
+        const url = `https://doi.org/${pid}`;
+
+        cy.get('[data-testid="landing-dataPublication-pid-link"]')
+          .first()
+          .should('have.attr', 'href', url);
+      });
   });
 
   it('should be able to click tab to see investigations', () => {
@@ -31,28 +47,6 @@ describe('ISIS - Data Publication Landing', () => {
     );
   });
 
-  it('should be able to click a DOI render the correct webpage ', () => {
-    cy.contains('a', '0-7602-7584-X').should(
-      'have.attr',
-      'href',
-      'https://doi.org/0-7602-7584-X'
-    );
-  });
-
-  it('should have the correct urls for the DOI link and Data Publication PID', () => {
-    cy.get('[data-testid="landing-dataPublication-pid-link"]')
-      .first()
-      .then(($pid) => {
-        const pid = $pid.text();
-
-        const url = `https://doi.org/${pid}`;
-
-        cy.get('[data-testid="landing-dataPublication-pid-link"]')
-          .first()
-          .should('have.attr', 'href', url);
-      });
-  });
-
   it('should load correctly when investigation missing', () => {
     cy.intercept('**/datapublications?*', [
       {
@@ -72,20 +66,14 @@ describe('ISIS - Data Publication Landing', () => {
         pid: '10.5286/ISIS.E.RB1810842',
       },
     ]);
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="landing-dataPublication-pid-link"]')
       .first()
-      .trigger('mouseover')
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+      .trigger('mouseover');
+    cy.get('[role="tooltip"]').should('exist');
 
     cy.get('body').type('{esc}');
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="landing-dataPublication-pid-link"]')
-      .wait(700)
       .first()
       .get('[role="tooltip"]')
       .should('not.exist');

--- a/packages/datagateway-dataview/cypress/e2e/landing/isis/dataset.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/landing/isis/dataset.cy.ts
@@ -10,6 +10,20 @@ describe('ISIS - Dataset Landing', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
     cy.contains('DATASET 79').should('be.visible');
+
+    // DOI
+
+    cy.get('[data-testid="isis-dataset-landing-doi-link"]')
+      .first()
+      .then(($doi) => {
+        const doi = $doi.text();
+
+        const url = `https://doi.org/${doi}`;
+
+        cy.get('[data-testid="isis-dataset-landing-doi-link"]')
+          .first()
+          .should('have.attr', 'href', url);
+      });
   });
 
   it('should be able to click a dataset to see its datafiles', () => {
@@ -22,7 +36,7 @@ describe('ISIS - Dataset Landing', () => {
 
   it('should disable the hover tool tip by pressing escape', () => {
     cy.intercept(
-      '/datasets?where=%7B%22id%22%3A%7B%22eq%22%3A79%7D%7D&include=%22type%22',
+      '**/datasets?where=%7B%22id%22%3A%7B%22eq%22%3A79%7D%7D&include=%22type%22',
       [
         {
           id: 79,
@@ -38,38 +52,16 @@ describe('ISIS - Dataset Landing', () => {
       ]
     );
 
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="isis-dataset-landing-doi-link"]')
       .first()
-      .trigger('mouseover')
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+      .trigger('mouseover');
+    cy.get('[role="tooltip"]').should('exist');
 
     cy.get('body').type('{esc}');
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="isis-dataset-landing-doi-link"]')
-      .wait(700)
       .first()
       .get('[role="tooltip"]')
       .should('not.exist');
-  });
-
-  it('should have the correct url for the DOI link', () => {
-    // DOI
-
-    cy.get('[data-testid="isis-dataset-landing-doi-link"]')
-      .first()
-      .then(($doi) => {
-        const doi = $doi.text();
-
-        const url = `https://doi.org/${doi}`;
-
-        cy.get('[data-testid="isis-dataset-landing-doi-link"]')
-          .first()
-          .should('have.attr', 'href', url);
-      });
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/landing/isis/investigation.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/landing/isis/investigation.cy.ts
@@ -8,17 +8,7 @@ describe('ISIS - Investigation Landing', () => {
     cy.title().should('equal', 'DataGateway DataView');
     cy.get('#datagateway-dataview').should('be.visible');
     cy.contains('Stop system investment').should('be.visible');
-  });
 
-  it('should be able to click an investigation to see its datasets', () => {
-    cy.get('#investigation-datasets-tab').first().click({ force: true });
-    cy.location('pathname').should(
-      'eq',
-      '/browse/instrument/13/facilityCycle/12/investigation/31/dataset'
-    );
-  });
-
-  it('should have the correct urls for the DOI link and parent DOI link', () => {
     // DOI
 
     cy.get('[data-testid="isis-investigation-landing-doi-link"]')
@@ -46,6 +36,14 @@ describe('ISIS - Investigation Landing', () => {
           .first()
           .should('have.attr', 'href', url);
       });
+  });
+
+  it('should be able to click an investigation to see its datasets', () => {
+    cy.get('#investigation-datasets-tab').first().click({ force: true });
+    cy.location('pathname').should(
+      'eq',
+      '/browse/instrument/13/facilityCycle/12/investigation/31/dataset'
+    );
   });
 
   it('should be able to click a specific dataset', () => {
@@ -96,37 +94,26 @@ describe('ISIS - Investigation Landing', () => {
       },
     ]);
 
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="isis-investigations-landing-parent-doi-link"]')
       .first()
-      .trigger('mouseover')
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+      .trigger('mouseover');
+    cy.get('[role="tooltip"]').should('exist');
 
     cy.get('body').type('{esc}');
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="isis-investigations-landing-parent-doi-link"]')
-      .wait(700)
       .first()
       .get('[role="tooltip"]')
       .should('not.exist');
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="isis-investigation-landing-doi-link"]')
       .first()
-      .trigger('mouseover')
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+      .trigger('mouseover');
+    cy.get('[role="tooltip"]').should('exist');
 
     cy.get('body').type('{esc}');
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.get('[data-testid="isis-investigation-landing-doi-link"]')
-      .wait(700)
       .first()
       .get('[role="tooltip"]')
       .should('not.exist');

--- a/packages/datagateway-dataview/cypress/e2e/table/datafiles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/datafiles.cy.ts
@@ -20,66 +20,6 @@ describe('Datafiles Table', () => {
     cy.get('[role="grid"]').should('not.exist');
   });
 
-  it('should be able to resize a column', () => {
-    let columnWidth = 0;
-
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        // Account for select, details and actions column widths
-        columnWidth = (windowWidth - 40 - 40 - 70) / 4;
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
-
-    cy.get('[role="columnheader"]').eq(2).as('nameColumn');
-    cy.get('[role="columnheader"]').eq(3).as('locationColumn');
-
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
-
-    cy.get('@locationColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
-
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 400 })
-      .trigger('mouseup');
-
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
-
-    cy.get('@locationColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
-
-    // table width should grow if a column grows too large
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 800 })
-      .trigger('mouseup');
-
-    cy.get('@locationColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
-  });
-
   // Unable to test lazy loading as there are only 15 datafiles in
   it.skip('should be able to scroll down and load more rows', () => {
     cy.get('[aria-rowcount="50"]').should('exist');
@@ -87,175 +27,128 @@ describe('Datafiles Table', () => {
     cy.get('[aria-rowcount="55"]').should('exist');
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      cy.wait(
-        [
-          '@investigations',
-          '@datafilesCount',
-          '@datasets',
-          '@datafilesOrder',
-          '@datafilesOrder',
-        ],
-        {
-          timeout: 10000,
-        }
-      );
-    });
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    cy.wait(
+      [
+        '@investigations',
+        '@datafilesCount',
+        '@datasets',
+        '@datafilesOrder',
+        '@datafilesOrder',
+      ],
+      {
+        timeout: 10000,
+      }
+    );
 
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
+    // ascending
+    cy.contains('[role="button"]', 'Location').as('locationSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-        '/able/leg/policy.gif'
-      );
-    });
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/able/leg/policy.gif'
+    );
 
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
+    // descending
+    cy.get('@locationSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-        '/writer/family/pull.bmp'
-      );
-    });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/writer/family/pull.bmp'
+    );
 
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Location').click();
+    // no order
+    cy.get('@locationSortButton').click();
 
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-        '/five/with/question.bmp'
-      );
-    });
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/five/with/question.bmp'
+    );
 
-    it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Modified Time')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
+    // multiple columns
+    cy.contains('[role="button"]', 'Name').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'Modified Time').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Datafile 119'
-      );
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 1071');
   });
 
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      cy.wait(
-        [
-          '@investigations',
-          '@datafilesCount',
-          '@datasets',
-          '@datafilesOrder',
-          '@datafilesOrder',
-        ],
-        {
-          timeout: 10000,
-        }
-      );
-    });
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    cy.wait(
+      [
+        '@investigations',
+        '@datafilesCount',
+        '@datasets',
+        '@datafilesOrder',
+        '@datafilesOrder',
+      ],
+      {
+        timeout: 10000,
+      }
+    );
+    // test text filter
+    cy.get('[aria-label="Filter by Location"]').first().type('candidate');
 
-    it('text', () => {
-      cy.get('[aria-label="Filter by Location"]').first().type('candidate');
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 1071');
 
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Datafile 1071'
-      );
-    });
+    // test date filter
+    cy.get('input[id="Modified Time filter from"]').type('2019-01-01');
 
-    it('date between', () => {
-      cy.get('input[id="Modified Time filter from"]').type('2019-01-01');
-      const date = new Date();
-      cy.get('input[aria-label="Modified Time filter to"]').type(
-        date.toISOString().slice(0, 10)
-      );
+    cy.get('[aria-rowcount="1"]').should('exist');
 
-      cy.get('[aria-rowcount="15"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Datafile 119'
-      );
-      cy.get('[aria-rowindex="2"] [aria-colindex="3"]').contains(
-        'Datafile 238'
-      );
-    });
+    cy.get('input[aria-label="Modified Time filter to"]')
+      .parent()
+      .find('button')
+      .click();
+    const date = new Date();
+    date.setDate(1);
+    date.setFullYear(2020);
 
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('4')
-        .wait('@datafilesCount', { timeout: 10000 });
-      cy.get('[aria-label="Filter by Location"]')
-        .first()
-        .type('.gif')
-        .wait('@datafilesCount', { timeout: 10000 });
+    cy.get('.MuiPickersCalendarHeader-label').click();
+    cy.contains('2020').click();
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
-      cy.get('[aria-rowcount="2"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Datafile 476'
-      );
-    });
+    cy.get('input[id="Modified Time filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
+
+    cy.get('[aria-rowcount="0"]').should('exist');
   });
 
-  describe('should be able to view details', () => {
-    it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]').first().click();
+  it('should be able to view details', () => {
+    cy.get('[aria-label="Show details"]').eq(1).click();
 
-      cy.get('#details-panel').should('be.visible');
-      cy.get('[aria-label="Hide details"]').should('exist');
-    });
+    cy.get('#details-panel').should('be.visible');
+    cy.get('#details-panel').contains('Datafile 238').should('be.visible');
+    cy.get('[aria-label="Hide details"]').should('exist');
 
-    it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]').eq(1).click();
+    cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-label="Show details"]').first().click();
+    cy.get('#details-panel').contains('Datafile 119').should('be.visible');
+    cy.get('#details-panel').contains('Datafile 238').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('have.length', 1);
 
-      cy.get('#details-panel').contains('Datafile 119').should('be.visible');
-      cy.get('#details-panel').contains('Datafile 238').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('have.length', 1);
-    });
+    cy.get('[aria-label="Hide details"]').first().click();
 
-    it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-label="Hide details"]').first().click();
-
-      cy.get('#details-panel').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('not.exist');
-    });
+    cy.get('#details-panel').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/datasets.cy.ts
@@ -24,66 +24,6 @@ describe('Datasets Table', () => {
     );
   });
 
-  it('should be able to resize a column', () => {
-    let columnWidth = 0;
-
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        // Account for select and details column widths
-        columnWidth = (windowWidth - 40 - 40) / 4;
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
-
-    cy.get('[role="columnheader"]').eq(2).as('nameColumn');
-    cy.get('[role="columnheader"]').eq(3).as('sizeColumn');
-
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
-
-    cy.get('@sizeColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
-
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 400 })
-      .trigger('mouseup');
-
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
-
-    cy.get('@sizeColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
-
-    // table width should grow if a column grows too large
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 800 })
-      .trigger('mouseup');
-
-    cy.get('@sizeColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
-  });
-
   // current example data only has 2 datasets per investigation, so can't test lazy loading
   it.skip('should be able to scroll down and load more rows', () => {
     cy.get('[aria-rowcount="50"]').should('exist');
@@ -91,124 +31,96 @@ describe('Datasets Table', () => {
     cy.get('[aria-rowcount="75"]').should('exist');
   });
 
-  describe('should be able to sort by', () => {
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Name').click();
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    // ascending order
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 1');
-    });
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 1');
 
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'Name').click();
+    // descending order
+    cy.get('@nameSortButton').click();
 
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 61');
-    });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 61');
 
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'Name').click();
+    // no order
+    cy.get('@nameSortButton').click();
 
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 1');
-    });
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 1');
 
-    it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Create Time').click();
-      cy.contains('[role="button"]', 'Create Time').click();
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'Name').click();
+    cy.contains('[role="button"]', 'Create Time').as('timeSortButton').click();
+    cy.get('@timeSortButton').click();
+    cy.get('@nameSortButton').click();
+    cy.get('@nameSortButton').click();
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 61');
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 61');
   });
 
-  describe('should be able to filter by', () => {
-    it('text', () => {
-      cy.get('[aria-label="Filter by Name"]').first().type('DATASET 1');
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    // test text filter
+    cy.get('[aria-label="Filter by Name"]').first().type('6');
 
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 1');
-    });
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 61');
 
-    it.skip('date between', () => {
-      // Unable to test as cypress doesn't want to type into date fields.
-      cy.get('input[id="Create Time filter from"]').type('2006-01-01', {
-        force: true,
-      });
+    // test date filter
+    cy.get('input[id="Create Time filter from"]').type('2006-01-01');
 
-      cy.get('input[aria-label="Create Time filter to"]')
-        .parent()
-        .find('button')
-        .click();
+    cy.get('[aria-rowcount="1"]').should('exist');
 
-      cy.get('.MuiPickersDay-root[type="button"]').first().click();
+    cy.get('input[aria-label="Create Time filter to"]')
+      .parent()
+      .find('button')
+      .click();
 
-      const date = new Date();
-      date.setDate(1);
+    const date = new Date();
+    date.setDate(1);
+    date.setFullYear(2020);
 
-      cy.get('input[id="Create Time filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
+    cy.get('.MuiPickersCalendarHeader-label').click();
+    cy.contains('2020').click();
 
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 241');
-    });
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Name"]').first().type('6');
-      const date = new Date();
-      cy.get('input[id="Create Time filter to"]').type(
-        date.toISOString().slice(0, 10)
-      );
+    cy.get('input[id="Create Time filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
 
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 61');
-    });
+    cy.get('[aria-rowcount="0"]').should('exist');
   });
 
-  describe('should be able to view details', () => {
-    it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]').first().click();
+  it('should be able to view details', () => {
+    cy.get('[aria-label="Show details"]').eq(1).click();
 
-      cy.get('#details-panel').should('be.visible');
-      cy.get('[aria-label="Hide details"]').should('exist');
-    });
+    cy.get('#details-panel').should('be.visible');
+    cy.get('#details-panel').contains('DATASET 61').should('be.visible');
+    cy.get('[aria-label="Hide details"]').should('exist');
 
-    it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]').eq(1).click();
+    cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-label="Show details"]').first().click();
+    cy.get('#details-panel').contains('DATASET 1').should('be.visible');
+    cy.get('#details-panel').contains('DATASET 61').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('have.length', 1);
 
-      cy.get('#details-panel').contains('DATASET 1').should('be.visible');
-      cy.get('#details-panel').contains('DATASET 61').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('have.length', 1);
-    });
+    cy.get('[aria-label="Hide details"]').first().click();
 
-    it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-label="Hide details"]').first().click();
-
-      cy.get('#details-panel').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('not.exist');
-    });
+    cy.get('#details-panel').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/datafiles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/datafiles.cy.ts
@@ -37,231 +37,90 @@ describe('DLS - Datafiles Table', () => {
     cy.get('[aria-rowcount="55"]').should('exist');
   });
 
-  it('should be able to resize a column', () => {
-    // Filtering results so vertical scrollbar won't appear as this can impact on the
-    // column width causing these types of tests to intermittently fail
-    cy.get('[aria-label="Filter by Location"]').first().type('rise');
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Create Time').as('timeSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-    let columnWidth = 0;
+    // ascending order
+    cy.contains('[role="button"]', 'Location').as('locationSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        // Account for select and details column widths
-        columnWidth = (windowWidth - 40 - 40) / 4;
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/analysis/unit/bank.tiff'
+    );
 
-    cy.get('[role="columnheader"]').eq(2).as('nameColumn');
-    cy.get('[role="columnheader"]').eq(3).as('locationColumn');
+    // descending order
+    cy.get('@locationSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/to/total/according.tiff'
+    );
 
-    cy.get('@locationColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
+    // no order
+    cy.get('@locationSortButton').click();
 
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 400 })
-      .trigger('mouseup');
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/time/run/drug.jpeg'
+    );
 
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
+    // multiple columns
+    cy.get('@timeSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
+    cy.get('@nameSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-    cy.get('@locationColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
-
-    // table width should grow if a column grows too large
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 800 })
-      .trigger('mouseup');
-
-    cy.get('@locationColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 60');
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-    });
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    // test text filter
+    cy.get('input[aria-label="Filter by Location"]').type('unit');
 
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 1369');
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-        '/analysis/unit/bank.tiff'
-      );
-    });
+    // test date filter
+    cy.get('input[aria-label="Create Time filter to"]').type('2019-01-01');
 
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-        '/to/total/according.tiff'
-      );
-    });
-
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Location')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-        '/time/run/drug.jpeg'
-      );
-    });
-
-    it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 60');
-    });
+    cy.get('[aria-rowcount="0"]').should('exist');
   });
 
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-    });
+  it('should be able to view details', () => {
+    cy.get('[aria-label="Show details"]').eq(1).click();
 
-    it('text', () => {
-      cy.get('[aria-label="Filter by Location"]').first().type('unit');
+    cy.get('#details-panel').should('be.visible');
+    cy.get('[aria-label="Hide details"]').should('exist');
+    cy.get('#details-panel').contains('Datafile 1607').should('be.visible');
 
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Datafile 1369'
-      );
-    });
+    cy.get('[aria-label="Show details"]').first().click();
 
-    it('date between', () => {
-      cy.get('input[id="Create Time filter from"]').type('2019-01-01');
+    cy.get('#details-panel').contains('Datafile 1726').should('be.visible');
+    cy.get('#details-panel').contains('Datafile 1607').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('have.length', 1);
 
-      const date = new Date();
+    cy.get('[aria-label="Hide details"]').first().click();
 
-      cy.get('input[aria-label="Create Time filter to"]').type(
-        date.toISOString().slice(0, 10)
-      );
-
-      cy.get('[aria-rowcount="15"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 60');
-      cy.get('[aria-rowindex="2"] [aria-colindex="3"]').contains(
-        'Datafile 179'
-      );
-    });
-
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('5')
-        .wait('@datafilesCount', { timeout: 10000 });
-
-      cy.get('[aria-label="Filter by Location"]')
-        .first()
-        .type('.gif')
-        .wait('@datafilesCount', { timeout: 10000 });
-
-      cy.get('[aria-rowcount="2"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Datafile 536'
-      );
-    });
-  });
-
-  describe('should be able to view details', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@datafilesOrder', { timeout: 10000 });
-    });
-
-    it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('#details-panel').should('be.visible');
-      cy.get('[aria-label="Hide details"]').should('exist');
-    });
-
-    it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]').eq(1).click();
-
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('#details-panel').contains('Datafile 60').should('be.visible');
-      cy.get('#details-panel').contains('Datafile 179').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('have.length', 1);
-    });
-
-    it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-label="Hide details"]').first().click();
-
-      cy.get('#details-panel').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('not.exist');
-    });
+    cy.get('#details-panel').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/myData.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/myData.cy.ts
@@ -29,23 +29,6 @@ describe('DLS - MyData Table', () => {
       cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
     });
 
-    it('should be able to click clear filters button to clear filters', () => {
-      cy.url().should('include', 'filters');
-
-      cy.url().then((url) => {
-        cy.get('[aria-rowcount="2"]').should('exist');
-        cy.get('input[id="Title-filter"]').type('star');
-
-        cy.wait('@getInvestigations');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('72');
-
-        cy.get('[data-testid="clear-filters-button"]').click();
-        cy.url().should('eq', url);
-      });
-    });
-
     it('should be able to click an investigation to see its datasets', () => {
       cy.get('[role="gridcell"] a').first().click({ force: true });
 
@@ -55,249 +38,122 @@ describe('DLS - MyData Table', () => {
       );
     });
 
-    it('should disable the hover tool tip by pressing escape', () => {
-      // The hover tool tip has a enter delay of 500ms.
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.get('[data-testid="dls-mydata-table-name"]')
-        .first()
-        .trigger('mouseover', { force: true })
-        .wait(700)
-        .get('[role="tooltip"]')
-        .should('exist');
+    it('should be able to sort by all sort directions on single and multiple columns', () => {
+      //Revert the default sort
+      cy.contains('[role="button"]', 'Start Date').click();
 
-      cy.get('body').type('{esc}');
+      // ascending order
+      cy.contains('[role="button"]', 'Title').as('titleSortButton').click();
 
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.get('[data-testid="dls-mydata-table-name"]')
-        .wait(700)
-        .first()
-        .get('[role="tooltip"]')
+      cy.get('[aria-sort="ascending"]').should('exist');
+      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+        'Across prepare why go.'
+      );
+
+      // descending order
+      cy.get('@titleSortButton').click();
+
+      cy.get('[aria-sort="descending"]').should('exist');
+      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+        'not.have.css',
+        'opacity',
+        '0'
+      );
+      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+        'Star enter wide nearly off.'
+      );
+
+      // no order
+      cy.get('@titleSortButton').click();
+      cy.get('[aria-sort="ascending"]').should('not.exist');
+      cy.get('[aria-sort="descending"]').should('not.exist');
+      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+        'have.css',
+        'opacity',
+        '0'
+      );
+      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+        'Star enter wide nearly off.'
+      );
+
+      // multiple columns
+      cy.get('@titleSortButton').click();
+      cy.contains('[role="button"]', 'Instrument').click();
+
+      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+        'Across prepare why go.'
+      );
+    });
+
+    it('should be able to filter with role, text & date filters on multiple columns', () => {
+      // role
+      cy.get('[aria-rowcount="2"]').should('exist');
+
+      cy.get('#role-selector').click();
+      cy.get('[role="listbox"]')
+        .find('[role="option"]')
+        .should('have.length', 3);
+      cy.get('[role="option"][data-value="PI"]').click();
+
+      cy.get('[aria-rowcount="1"]').should('exist');
+      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('72');
+
+      cy.get('#role-selector').click();
+      cy.get('[role="option"]').first().click();
+      cy.get('[aria-rowcount="2"]').should('exist');
+
+      // test text filter
+      cy.get('[aria-rowcount="2"]').should('exist');
+      cy.get('input[id="Title-filter"]').type('star');
+
+      cy.get('[aria-rowcount="1"]').should('exist');
+      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('72');
+
+      // test date filter
+      cy.get('input[id="Start Date filter from"]').type('2004-01-01');
+
+      cy.get('[aria-rowcount="0"]').should('exist');
+    });
+
+    it('should be able to view details', () => {
+      cy.get('[aria-label="Show details"]').eq(1).click();
+
+      cy.get('#details-panel').should('be.visible');
+      cy.get('[aria-label="Hide details"]').should('exist');
+      cy.get('#details-panel')
+        .contains('Star enter wide nearly off.')
+        .should('be.visible');
+
+      cy.get('[aria-label="Show details"]').first().click();
+
+      cy.get('#details-panel')
+        .contains('Across prepare why go.')
+        .should('be.visible');
+      cy.get('#details-panel')
+        .contains('Star enter wide nearly off.')
         .should('not.exist');
-    });
+      cy.get('[aria-label="Hide details"]').should('have.length', 1);
 
-    it('should be able to resize a column', () => {
-      let columnWidth = 0;
+      cy.get('[aria-controls="visit-samples-panel"]').click();
+      cy.get('#visit-samples-panel').should('not.have.attr', 'hidden');
+      cy.get('#details-panel').contains('SAMPLE 21').should('be.visible');
 
-      cy.window()
-        .then((window) => {
-          const windowWidth = window.innerWidth;
-          columnWidth = (windowWidth - 40) / 6;
-        })
-        .then(() => expect(columnWidth).to.not.equal(0));
+      cy.get('[aria-controls="visit-users-panel"]').click();
+      cy.get('#visit-users-panel').should('not.have.attr', 'hidden');
+      cy.get('#details-panel').contains('Thomas Chambers').should('be.visible');
 
-      cy.get('[role="columnheader"]').eq(1).as('titleColumn');
-      cy.get('[role="columnheader"]').eq(2).as('visitIdColumn');
+      cy.get('[aria-controls="visit-publications-panel"]').click();
+      cy.get('#visit-publications-panel').should('not.have.attr', 'hidden');
+      cy.get('#details-panel').contains(
+        'From central effort glass evidence life.'
+      );
 
-      cy.get('@titleColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.equal(columnWidth);
-      });
+      cy.get('[aria-label="Hide details"]').first().click();
 
-      cy.get('@visitIdColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.equal(columnWidth);
-      });
-
-      cy.get('.react-draggable')
-        .first()
-        .trigger('mousedown')
-        .trigger('mousemove', { clientX: 400 })
-        .trigger('mouseup');
-
-      cy.get('@titleColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.greaterThan(columnWidth);
-      });
-
-      cy.get('@visitIdColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.lessThan(columnWidth);
-      });
-
-      // table width should grow if a column grows too large
-      cy.get('.react-draggable')
-        .first()
-        .trigger('mousedown')
-        .trigger('mousemove', { clientX: 800 })
-        .trigger('mouseup');
-
-      cy.get('@visitIdColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.equal(84);
-      });
-
-      cy.get('[aria-label="grid"]').then(($grid) => {
-        const { width } = $grid[0].getBoundingClientRect();
-        cy.window().should(($window) => {
-          expect(width).to.be.greaterThan($window.innerWidth);
-        });
-      });
-    });
-
-    describe('should be able to sort by', () => {
-      beforeEach(() => {
-        //Revert the default sort
-        cy.contains('[role="button"]', 'Start Date').click();
-      });
-
-      it('ascending order', () => {
-        cy.contains('[role="button"]', 'Title').click();
-
-        cy.get('[aria-sort="ascending"]').should('exist');
-        cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-        cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-          'Across prepare why go.'
-        );
-      });
-
-      it('descending order', () => {
-        cy.contains('[role="button"]', 'Title').click();
-        cy.contains('[role="button"]', 'Title').click();
-        cy.get('[aria-sort="descending"]').should('exist');
-        cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-          'not.have.css',
-          'opacity',
-          '0'
-        );
-        cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-          'Star enter wide nearly off.'
-        );
-      });
-
-      it('no order', () => {
-        cy.get('[aria-sort="ascending"]').should('not.exist');
-        cy.get('[aria-sort="descending"]').should('not.exist');
-        cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-        cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-          'have.css',
-          'opacity',
-          '0'
-        );
-        cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-          'Star enter wide nearly off.'
-        );
-      });
-
-      it('multiple columns', () => {
-        cy.contains('[role="button"]', 'Title').click();
-        cy.contains('[role="button"]', 'Instrument').click();
-
-        cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-          'Across prepare why go.'
-        );
-      });
-    });
-
-    describe('should be able to filter by', () => {
-      it('role', () => {
-        cy.get('[aria-rowcount="2"]').should('exist');
-
-        cy.get('#role-selector').click();
-        cy.get('[role="listbox"]')
-          .find('[role="option"]')
-          .should('have.length', 3);
-        cy.get('[role="option"][data-value="PI"]').click();
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('72');
-
-        cy.get('#role-selector').click();
-        cy.get('[role="option"]').first().click();
-        cy.get('[aria-rowcount="2"]').should('exist');
-      });
-
-      it('text', () => {
-        cy.get('[aria-rowcount="2"]').should('exist');
-        cy.get('input[id="Title-filter"]').type('star');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('72');
-      });
-
-      it('date between', () => {
-        cy.get('[aria-rowcount="2"]').should('exist');
-
-        const date = new Date();
-
-        cy.get('input[aria-label="Start Date filter to"]').type(
-          date.toISOString().slice(0, 10)
-        );
-
-        cy.get('[aria-rowcount="2"]').should('exist');
-
-        cy.get('input[id="Start Date filter from"]').type('2004-01-01');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-      });
-
-      it('multiple columns', () => {
-        cy.get('input[id="Start Date filter from"]').first().type('2004-01-01');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-
-        cy.get('[aria-label="Filter by Title"]').first().type('or');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-      });
-    });
-
-    describe('should be able to view details', () => {
-      it('when no other row is showing details', () => {
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('#details-panel').should('be.visible');
-        cy.get('[aria-label="Hide details"]').should('exist');
-      });
-
-      it('and view visit users, samples and publications', () => {
-        cy.contains('[aria-rowindex="1"] [aria-colindex="4"]', '2').should(
-          'exist'
-        );
-
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('[aria-controls="visit-samples-panel"]').click();
-        cy.get('#visit-samples-panel').should('not.have.attr', 'hidden');
-        cy.get('#details-panel').contains('SAMPLE 21').should('be.visible');
-
-        cy.get('[aria-controls="visit-users-panel"]').click();
-        cy.get('#visit-users-panel').should('not.have.attr', 'hidden');
-        cy.get('#details-panel')
-          .contains('Thomas Chambers')
-          .should('be.visible');
-
-        cy.get('[aria-controls="visit-publications-panel"]').click();
-        cy.get('#visit-publications-panel').should('not.have.attr', 'hidden');
-        cy.get('#details-panel').contains(
-          'From central effort glass evidence life.'
-        );
-      });
-
-      it('when another row is showing details', () => {
-        cy.get('[aria-label="Show details"]').eq(1).click();
-        cy.get('#details-panel')
-          .contains('Star enter wide nearly off.')
-          .should('be.visible');
-
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('#details-panel')
-          .contains('Across prepare why go.')
-          .should('be.visible');
-        cy.get('#details-panel')
-          .contains('Star enter wide nearly off.')
-          .should('not.exist');
-        cy.get('[aria-label="Hide details"]').should('have.length', 1);
-      });
-
-      it('and then not view details anymore', () => {
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('[aria-label="Hide details"]').first().click();
-
-        cy.get('#details-panel').should('not.exist');
-        cy.get('[aria-label="Hide details"]').should('not.exist');
-      });
+      cy.get('#details-panel').should('not.exist');
+      cy.get('[aria-label="Hide details"]').should('not.exist');
     });
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/proposals.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/proposals.cy.ts
@@ -23,111 +23,24 @@ describe('DLS - Proposals Table', () => {
   it('should be able to scroll down and load more rows', () => {
     cy.get('[aria-rowcount="50"]').should('exist');
     cy.get('[aria-label="grid"]').scrollTo('bottom');
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(3000);
-    cy.get('[aria-label="grid"]').scrollTo('bottom');
     cy.get('[aria-rowcount="59"]').should('exist');
   });
 
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="dls-proposals-table-title"]')
-      .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+  it('should be able to filter', () => {
+    cy.wait(['@investigations', '@investigationsCount'], { timeout: 10000 });
 
-    cy.get('body').type('{esc}');
+    cy.get('[aria-label="Filter by Name"]').first().type('2');
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="dls-proposals-table-title"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
-      .should('not.exist');
-  });
+    cy.get('[aria-rowcount="15"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+      'INVESTIGATION 21'
+    );
 
-  it('should be able to resize a column', () => {
-    let columnWidth = 0;
+    cy.get('[aria-label="Filter by Title"]').first().type('dog');
 
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        columnWidth = windowWidth / 2;
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
-
-    cy.get('[role="columnheader"]').eq(0).as('titleColumn');
-    cy.get('[role="columnheader"]').eq(1).as('nameColumn');
-
-    cy.get('@titleColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
-
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
-
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 500 })
-      .trigger('mouseup');
-
-    cy.get('@titleColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
-
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
-
-    // table width should grow if a column grows too large
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 1000 })
-      .trigger('mouseup');
-
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
-  });
-
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      cy.wait(['@investigations', '@investigationsCount'], { timeout: 10000 });
-    });
-
-    it('text', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('dog');
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        'INVESTIGATION 52'
-      );
-    });
-
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('dog');
-
-      cy.get('[aria-label="Filter by Name"]').first().type('INVESTIGATION 36');
-
-      cy.get('[aria-rowcount="0"]').should('exist');
-    });
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+      'INVESTIGATION 52'
+    );
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
@@ -20,26 +20,6 @@ describe('Investigations Table', () => {
     cy.get('[aria-rowcount="59"]').should('exist');
   });
 
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting, cypress/unsafe-to-chain-command
-    cy.get('[data-testid="investigation-table-title"]')
-      .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
-
-    cy.get('body').type('{esc}');
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="investigation-table-title"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
-      .should('not.exist');
-  });
-
   it('should have the correct url for the DOI link', () => {
     cy.get('[data-testid="investigation-table-doi-link"]')
       .first()
@@ -54,243 +34,140 @@ describe('Investigations Table', () => {
       });
   });
 
-  it('should be able to resize a column', () => {
-    let columnWidth = 0;
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    // ascending order
+    cy.contains('[role="button"]', 'Title').as('titleSortButton').click();
 
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        // Account for select and details column widths
-        columnWidth = (windowWidth - 40 - 40) / 8;
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'A air avoid beautiful. Nature article your issue. Customer rather ' +
+        'citizen bag boy late. Maybe big act produce challenge short.'
+    );
 
-    cy.get('[role="columnheader"]').eq(2).as('titleColumn');
-    cy.get('[role="columnheader"]').eq(3).as('visitColumn');
+    // descending order
+    cy.get('@titleSortButton').click();
 
-    cy.get('@titleColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'Why news west bar sing tax. Drive up more near member article. Only ' +
+        'remember free thousand interest. Ability ok upon condition ' +
+        'ability. Hand statement despite probably song.'
+    );
 
-    cy.get('@visitColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
+    // no order
+    cy.get('@titleSortButton').click();
 
-    // eslint-disable-next-line cypress/unsafe-to-chain-command
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 200 })
-      .trigger('mouseup');
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'Analysis reflect work or hour color maybe. Much team discussion message weight.'
+    );
 
-    cy.get('@titleColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
-
-    cy.get('@visitColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
-
-    // table width should grow if a column grows too large
-    // eslint-disable-next-line cypress/unsafe-to-chain-command
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 800 })
-      .trigger('mouseup');
-
-    cy.get('@visitColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
+    // multiple columns
+    cy.contains('[role="button"]', 'Start Date').click();
+    cy.get('@titleSortButton').click();
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'Analysis reflect work or hour color maybe. Much team discussion message weight.'
+    );
   });
 
-  describe('should be able to sort by', () => {
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Title').click();
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    // test exclude text filter
+    cy.get('input[aria-label="Filter by Name"]')
+      .as('nameFilter')
+      .parent()
+      .find('[aria-label="include, exclude or exact"]')
+      .as('nameFilterOptionsButton')
+      .click();
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'A air avoid beautiful. Nature article your issue. Customer rather ' +
-          'citizen bag boy late. Maybe big act produce challenge short.'
-      );
-    });
+    cy.get('#select-filter-type-exclude').click();
 
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
+    cy.get('@nameFilter').type('INVESTIGATION 1');
 
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Why news west bar sing tax. Drive up more near member article. Only ' +
-          'remember free thousand interest. Ability ok upon condition ' +
-          'ability. Hand statement despite probably song.'
-      );
-    });
+    cy.get('[aria-rowcount="48"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('87');
 
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
+    // check that size is correct after filtering
+    cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.38 GB');
 
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Analysis reflect work or hour color maybe. Much team discussion message weight.'
-      );
-    });
+    // test exact text filter
 
-    it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Start Date').click();
-      cy.contains('[role="button"]', 'Title').click();
+    cy.get('@nameFilterOptionsButton').click();
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Analysis reflect work or hour color maybe. Much team discussion message weight.'
-      );
-    });
+    cy.get('#select-filter-type-exact').click();
+
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('70');
+
+    // check that size is correct after filtering
+    cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
+
+    // test include text filter
+    cy.get('@nameFilterOptionsButton').click();
+
+    cy.get('#select-filter-type-include').click();
+
+    cy.get('[aria-rowcount="11"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('70');
+
+    // check that size is correct after filtering
+    cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
+
+    // test date filter
+    cy.get('input[id="Start Date filter from"]').type('2004-01-01');
+
+    cy.get('input[aria-label="Start Date filter to"]')
+      .parent()
+      .find('button')
+      .click();
+
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
+
+    const date = new Date();
+    date.setDate(1);
+
+    cy.get('input[id="Start Date filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
+
+    cy.get('[aria-rowcount="4"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('96');
   });
 
-  describe('should be able to filter by', () => {
-    it('exclude', () => {
-      cy.get('input[aria-label="Filter by Name"]')
-        .parent()
-        .find('[aria-label="include, exclude or exact"]')
-        .click();
+  it('should be able to view details', () => {
+    cy.get('[aria-label="Show details"]').eq(2).click();
 
-      cy.get('#select-filter-type-exclude').click();
+    cy.get('#details-panel').should('be.visible');
+    cy.get('[aria-label="Hide details"]').should('exist');
+    const firstDetailsPanelText =
+      'Prove begin boy those always dream write inside.';
 
-      cy.get('[aria-label="Filter by Name"]').first().type('INVESTIGATION 1');
+    cy.get('[aria-label="Show details"]').first().click();
 
-      cy.get('[aria-rowcount="48"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('87');
+    cy.get('#details-panel')
+      .contains('Strategy with piece reason late model air.')
+      .should('be.visible');
+    cy.get('#details-panel')
+      .contains(firstDetailsPanelText)
+      .should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('have.length', 1);
 
-      // check that size is correct after filtering
-      cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.38 GB');
-    });
+    cy.get('[aria-label="Hide details"]').first().click();
 
-    it('include', () => {
-      cy.get('input[aria-label="Filter by Name"]')
-        .parent()
-        .find('[aria-label="include, exclude or exact"]')
-        .click();
-
-      cy.get('#select-filter-type-include').click();
-
-      cy.get('[aria-label="Filter by Name"]').first().type('INVESTIGATION 1');
-
-      cy.get('[aria-rowcount="11"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('70');
-
-      // check that size is correct after filtering
-      cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
-    });
-
-    it('exact', () => {
-      cy.get('input[aria-label="Filter by Name"]')
-        .parent()
-        .find('[aria-label="include, exclude or exact"]')
-        .click();
-
-      cy.get('#select-filter-type-exact').click();
-
-      cy.get('[aria-label="Filter by Name"]').first().type('INVESTIGATION 1');
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('70');
-
-      // check that size is correct after filtering
-      cy.get('[aria-rowindex="1"] [aria-colindex="7"]').contains('3.12 GB');
-    });
-
-    it('date between', () => {
-      cy.get('input[id="Start Date filter from"]').type('2012-01-01');
-
-      cy.get('input[aria-label="Start Date filter to"]')
-        .parent()
-        .find('button')
-        .click();
-
-      cy.get('.MuiPickersDay-root[type="button"]').first().click();
-
-      const date = new Date();
-      date.setDate(1);
-
-      cy.get('input[id="Start Date filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
-
-      cy.get('[aria-rowcount="12"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Why news west bar sing tax. Drive up more near member article.'
-      );
-    });
-
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('wide');
-
-      cy.get('[aria-label="Filter by Visit ID"]').first().type('7');
-
-      cy.get('[aria-rowcount="3"]').should('exist');
-    });
-  });
-
-  describe('should be able to view details', () => {
-    it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('#details-panel').should('be.visible');
-      cy.get('[aria-label="Hide details"]').should('exist');
-    });
-
-    it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]').eq(2).click();
-
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('#details-panel')
-        .contains(
-          'Strategy with piece reason late model air. Sound process international scene call deep answer. Teach financial vote season.'
-        )
-        .should('be.visible');
-      cy.get('#details-panel')
-        .contains(
-          'Prove begin boy those always dream write inside. Cold drop season bill treat her wife. Nearly represent fire debate fish. Skin understand risk.'
-        )
-        .should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('have.length', 1);
-    });
-
-    it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-label="Hide details"]').first().click();
-
-      cy.get('#details-panel').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('not.exist');
-    });
+    cy.get('#details-panel').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
@@ -113,7 +113,7 @@ describe('ISIS - Data Publication Table', () => {
     let toDate = '2016-01-01';
     let fromDate = '2014-01-01';
     // TODO: make this less scuffed when https://github.com/ral-facilities/datagateway-api/issues/444 is fixed
-    if (process.env.CI) {
+    if (Cypress.env('CI')) {
       // can get the below date by looking at the createTime of any datafiles on SG preprod
       const sgPreprodGenerationDate = new Date('2023-03-28');
       // get rid of any timezone offset

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
@@ -102,26 +102,49 @@ describe('ISIS - Data Publication Table', () => {
 
   it('should be able to filter with both text & date filters on multiple columns', () => {
     // test text filter
-    cy.screenshot();
     cy.get('[aria-label="Filter by Title"]').first().type('ne');
 
     cy.get('[aria-rowcount="3"]').should('exist');
-    cy.screenshot();
+
     cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
       'Church child time Congress'
     );
 
-    // test date filter
-    cy.get('input[id="Publication Date filter to"]').type('2016-01-01');
+    let toDate = '2016-01-01';
+    let fromDate = '2014-01-01';
+    // TODO: make this less scuffed when https://github.com/ral-facilities/datagateway-api/issues/444 is fixed
+    if (process.env.CI) {
+      // can get the below date by looking at the createTime of any datafiles on SG preprod
+      const sgPreprodGenerationDate = new Date('2023-03-28');
+      // get rid of any timezone offset
+      sgPreprodGenerationDate.setHours(0);
+      const today = new Date();
+      today.setHours(0);
+      today.setMinutes(0);
+      today.setSeconds(0);
+      today.setMilliseconds(0);
+      const diff = today.getTime() - sgPreprodGenerationDate.getTime();
 
-    cy.screenshot();
+      const toDateDate = new Date(toDate);
+      toDateDate.setHours(0);
+      toDateDate.setTime(toDateDate.getTime() + diff);
+      toDate = toDateDate.toLocaleDateString('sv').split(' ')[0];
+
+      const fromDateDate = new Date(fromDate);
+      fromDateDate.setHours(0);
+      fromDateDate.setTime(fromDateDate.getTime() + diff);
+      fromDate = fromDateDate.toLocaleDateString('sv').split(' ')[0];
+    }
+
+    // test date filter
+    cy.get('input[id="Publication Date filter to"]').type(toDate);
 
     cy.get('[aria-rowcount="2"]').should('exist');
     cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
       'Consider author watch'
     );
 
-    cy.get('input[id="Publication Date filter from"]').type('2014-01-01');
+    cy.get('input[id="Publication Date filter from"]').type(fromDate);
 
     cy.get('[aria-rowcount="1"]').should('exist');
   });

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
@@ -47,159 +47,78 @@ describe('ISIS - Data Publication Table', () => {
     cy.get('[aria-rowcount="75"]').should('exist');
   });
 
-  it('should be able to resize a column', () => {
-    let columnWidth = 0;
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Publication Date')
+      .as('dateSortButton')
+      .click();
 
-    // Using Math.round to solve rounding errors when calculating 1000 / 3
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        columnWidth = Math.round(windowWidth / 3);
-        columnWidth = Math.round((columnWidth * 100) / 100);
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
+    // ascending order
+    cy.contains('[role="button"]', 'Title').as('titleSortButton').click();
 
-    cy.get('[role="columnheader"]').eq(0).as('titleColumn');
-    cy.get('[role="columnheader"]').eq(1).as('doiColumn');
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
+      'Article subject amount'
+    );
 
-    cy.get('@titleColumn').should(($column) => {
-      let { width } = $column[0].getBoundingClientRect();
-      width = Math.round((width * 100) / 100);
-      expect(width).to.equal(columnWidth);
-    });
+    // descending order
+    cy.get('@titleSortButton').click();
 
-    cy.get('@doiColumn').should(($column) => {
-      let { width } = $column[0].getBoundingClientRect();
-      width = Math.round((width * 100) / 100);
-      expect(width).to.equal(columnWidth);
-    });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
+      'Daughter experience discussion'
+    );
 
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 400 })
-      .trigger('mouseup');
+    // no order
+    cy.get('@titleSortButton').click();
 
-    cy.get('@titleColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.be.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
+      'Article subject amount'
+    );
 
-    cy.get('@doiColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
+    // multiple columns
+    cy.get('@dateSortButton').click();
+    cy.get('@dateSortButton').click();
+    cy.get('@titleSortButton').click();
 
-    // table width should grow if a column grows too large
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 900 })
-      .trigger('mouseup');
-
-    cy.get('@doiColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
+      'Church child time Congress'
+    );
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Publication Date').click();
-    });
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    // test text filter
+    cy.get('[aria-label="Filter by Title"]').first().type('ne');
 
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Title').click();
+    cy.get('[aria-rowcount="3"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
+      'Church child time Congress'
+    );
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
-        'Article subject amount'
-      );
-    });
+    // test date filter
+    cy.get('input[id="Publication Date filter to"]').type('2016-01-01');
 
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
+    cy.get('[aria-rowcount="2"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
+      'Consider author watch'
+    );
 
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
-        'Daughter experience discussion'
-      );
-    });
+    cy.get('input[id="Publication Date filter from"]').type('2014-01-01');
 
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
-
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.be.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
-        'Article subject amount'
-      );
-    });
-
-    it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Publication Date').click();
-      cy.contains('[role="button"]', 'Publication Date').click();
-      cy.contains('[role="button"]', 'Title').click();
-
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
-        'Church child time Congress'
-      );
-    });
-  });
-
-  describe('should be able to filter by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Publication Date').click();
-    });
-
-    it('text', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('wat');
-
-      cy.get('[aria-rowcount="2"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
-        'Consider author watch'
-      );
-    });
-
-    it('date between', () => {
-      cy.get('input[id="Publication Date filter from"]').type('2014-04-02');
-
-      cy.get('[aria-rowcount="2"]').should('exist');
-      cy.get('[aria-rowindex="2"] [aria-colindex="1"]').contains(
-        'Church child time Congress'
-      );
-    });
-
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by DOI"]').first().type('0');
-
-      cy.get('[aria-label="Filter by Title"]').first().type('wat');
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-    });
+    cy.get('[aria-rowcount="1"]').should('exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/dataPublications.cy.ts
@@ -102,15 +102,19 @@ describe('ISIS - Data Publication Table', () => {
 
   it('should be able to filter with both text & date filters on multiple columns', () => {
     // test text filter
+    cy.screenshot();
     cy.get('[aria-label="Filter by Title"]').first().type('ne');
 
     cy.get('[aria-rowcount="3"]').should('exist');
+    cy.screenshot();
     cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
       'Church child time Congress'
     );
 
     // test date filter
     cy.get('input[id="Publication Date filter to"]').type('2016-01-01');
+
+    cy.screenshot();
 
     cy.get('[aria-rowcount="2"]').should('exist');
     cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/datafiles.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/datafiles.cy.ts
@@ -8,270 +8,152 @@ describe('ISIS - Datafiles Table', () => {
     cy.intercept('**/datafiles/count?*').as('datafilesCount');
     cy.intercept('**/datafiles?order=*').as('datafilesOrder');
     cy.login();
+
+    cy.visit(
+      '/browse/instrument/1/facilityCycle/19/investigation/19/dataset/79/datafile'
+    ).wait(
+      [
+        '@idCheck',
+        '@instrument',
+        '@facilityCycle',
+        '@investigation',
+        '@dataset',
+        '@datafilesCount',
+        '@datafilesOrder',
+      ],
+      {
+        timeout: 10000,
+      }
+    );
   });
 
-  describe('Wait for initial requests', () => {
-    beforeEach(() => {
-      cy.visit(
-        '/browse/instrument/1/facilityCycle/19/investigation/19/dataset/79/datafile'
-      ).wait(
-        [
-          '@idCheck',
-          '@instrument',
-          '@facilityCycle',
-          '@investigation',
-          '@dataset',
-          '@datafilesCount',
-          '@datafilesOrder',
-        ],
-        {
-          timeout: 10000,
-        }
-      );
-    });
+  it('should load correctly', () => {
+    cy.title().should('equal', 'DataGateway DataView');
+    cy.get('#datagateway-dataview').should('be.visible');
 
-    it('should load correctly', () => {
-      cy.title().should('equal', 'DataGateway DataView');
-      cy.get('#datagateway-dataview').should('be.visible');
-
-      //Default sort
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
-    });
-
-    it('should not load incorrect URL', () => {
-      cy.visit(
-        '/browse/instrument/2/facilityCycle/14/investigation/88/dataset/118/datafile'
-      );
-
-      cy.contains('Oops!').should('be.visible');
-      cy.get('[role="grid"]').should('not.exist');
-    });
-
-    // Unable to test lazy loading as there are only 15 files per dataset
-    it.skip('should be able to scroll down and load more rows', () => {
-      cy.get('[aria-rowcount="50"]').should('exist');
-      cy.get('[aria-label="grid"]').scrollTo('bottom');
-      cy.get('[aria-rowcount="55"]').should('exist');
-    });
-
-    describe('should be able to sort by', () => {
-      beforeEach(() => {
-        //Revert the default sort
-        cy.contains('[role="button"]', 'Modified Time')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-      });
-
-      it('ascending order', () => {
-        cy.contains('[role="button"]', 'Location')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-
-        cy.get('[aria-sort="ascending"]').should('exist');
-        cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-        cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-          '/add/go/interview.png'
-        );
-      });
-
-      it('descending order', () => {
-        cy.contains('[role="button"]', 'Location')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-        cy.contains('[role="button"]', 'Location')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-
-        cy.get('[aria-sort="descending"]').should('exist');
-        cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-          'not.have.css',
-          'opacity',
-          '0'
-        );
-        cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-          '/writer/me/expert.gif'
-        );
-      });
-
-      it('multiple columns', () => {
-        cy.contains('[role="button"]', 'Modified Time')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-        cy.contains('[role="button"]', 'Name')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-        cy.contains('[role="button"]', 'Name')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Datafile 78'
-        );
-      });
-    });
-
-    describe('should be able to filter by', () => {
-      it('text', () => {
-        cy.get('[aria-label="Filter by Location"]').first().type('action');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Datafile 1268'
-        );
-      });
-
-      it('date between', () => {
-        cy.get('input[id="Modified Time filter from"]').type('2018-08-12');
-        const date = new Date();
-        cy.get('input[aria-label="Modified Time filter to"]').type(
-          date.toISOString().slice(0, 10)
-        );
-
-        cy.get('[aria-rowcount="15"]').should('exist');
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Datafile 1744'
-        );
-      });
-
-      it('multiple columns', () => {
-        cy.get('[aria-label="Filter by Name"]')
-          .first()
-          .type('5')
-          .wait('@datafilesOrder', { timeout: 10000 });
-
-        cy.get('[aria-label="Filter by Location"]')
-          .first()
-          .type('.png')
-          .wait('@datafilesOrder', { timeout: 10000 });
-
-        cy.get('[aria-rowcount="3"]').should('exist');
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Datafile 1625'
-        );
-      });
-    });
-
-    describe('should be able to view details', () => {
-      beforeEach(() => {
-        //Revert the default sort
-        cy.contains('[role="button"]', 'Modified Time')
-          .click()
-          .wait('@datafilesOrder', { timeout: 10000 });
-      });
-
-      it('when no other row is showing details', () => {
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('#details-panel').should('be.visible');
-        cy.get('[aria-label="Hide details"]').should('exist');
-      });
-
-      it('when another other row is showing details', () => {
-        cy.get('[aria-label="Show details"]').eq(1).click();
-
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('#details-panel').contains('Datafile 78').should('be.visible');
-        cy.get('#details-panel').contains('Datafile 197').should('not.exist');
-        cy.get('[aria-label="Hide details"]').should('have.length', 1);
-      });
-
-      it('and view datafile details and parameters', () => {
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('[aria-controls="datafile-details-panel"]').should('be.visible');
-
-        cy.get('#details-panel')
-          .contains(
-            'Skill certain create left. Get onto back do door room mission. Business story growth economic.'
-          )
-          .should('be.visible');
-
-        cy.get('[aria-controls="datafile-parameters-panel"]').should(
-          'be.visible'
-        );
-        cy.get('[aria-controls="datafile-parameters-panel"]').click();
-
-        cy.get('#parameter-grid').should('be.visible');
-      });
-
-      it('and then not view details anymore', () => {
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('[aria-label="Hide details"]').first().click();
-
-        cy.get('#details-panel').should('not.exist');
-        cy.get('[aria-label="Hide details"]').should('not.exist');
-      });
-    });
+    //Default sort
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
   });
 
-  describe('Do not wait for initial requests', () => {
-    beforeEach(() => {
-      cy.visit(
-        '/browse/instrument/1/facilityCycle/19/investigation/19/dataset/79/datafile'
-      );
-    });
+  it('should not load incorrect URL', () => {
+    cy.visit(
+      '/browse/instrument/2/facilityCycle/14/investigation/88/dataset/118/datafile'
+    );
 
-    it('should be able to resize a column', () => {
-      let columnWidth = 0;
+    cy.contains('Oops!').should('be.visible');
+    cy.get('[role="grid"]').should('not.exist');
+  });
 
-      cy.window()
-        .then((window) => {
-          const windowWidth = window.innerWidth;
-          // Account for select, details and actions column widths
-          columnWidth = (windowWidth - 40 - 40 - 96) / 4;
-        })
-        .then(() => expect(columnWidth).to.not.equal(0));
+  // Unable to test lazy loading as there are only 15 files per dataset
+  it.skip('should be able to scroll down and load more rows', () => {
+    cy.get('[aria-rowcount="50"]').should('exist');
+    cy.get('[aria-label="grid"]').scrollTo('bottom');
+    cy.get('[aria-rowcount="55"]').should('exist');
+  });
 
-      cy.get('[role="columnheader"]').eq(2).as('nameColumn');
-      cy.get('[role="columnheader"]').eq(3).as('locationColumn');
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Modified Time')
+      .as('timeSortButton')
+      .click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-      cy.get('@nameColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.equal(columnWidth);
-      });
+    // ascending order
+    cy.contains('[role="button"]', 'Location').as('locationSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-      cy.get('@locationColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.equal(columnWidth);
-      });
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/add/go/interview.png'
+    );
 
-      cy.get('.react-draggable')
-        .first()
-        .trigger('mousedown')
-        .trigger('mousemove', { clientX: 400 })
-        .trigger('mouseup');
+    // descending order
+    cy.get('@locationSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-      cy.get('@nameColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.greaterThan(columnWidth);
-      });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/writer/me/expert.gif'
+    );
 
-      cy.get('@locationColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.lessThan(columnWidth);
-      });
+    // no order
+    cy.get('@locationSortButton').click();
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      '/debate/form/growth.gif'
+    );
 
-      // table width should grow if a column grows too large
-      cy.get('.react-draggable')
-        .first()
-        .trigger('mousedown')
-        .trigger('mousemove', { clientX: 800 })
-        .trigger('mouseup');
+    // multiple columns
+    cy.get('@timeSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
+    cy.get('@nameSortButton').click();
+    cy.wait('@datafilesOrder', { timeout: 10000 });
 
-      cy.get('@locationColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.equal(84);
-      });
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 78');
+  });
 
-      cy.get('[aria-label="grid"]').then(($grid) => {
-        const { width } = $grid[0].getBoundingClientRect();
-        cy.window().should(($window) => {
-          expect(width).to.be.greaterThan($window.innerWidth);
-        });
-      });
-    });
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    // test date filter
+    cy.get('input[aria-label="Modified Time filter from"]').type('2018-08-12');
+    const date = new Date();
+    cy.get('input[aria-label="Modified Time filter to"]').type(
+      date.toISOString().slice(0, 10)
+    );
+
+    cy.get('[aria-rowcount="15"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 1744');
+
+    // test text filter
+    cy.get('[aria-label="Filter by Location"]').first().type('action');
+
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 1268');
+  });
+
+  it('should be able to view details', () => {
+    cy.get('[aria-label="Show details"]').eq(1).click();
+
+    cy.get('#details-panel').should('be.visible');
+    cy.get('#details-panel').contains('Datafile 1625').should('be.visible');
+    cy.get('[aria-label="Hide details"]').should('exist');
+
+    cy.get('[aria-label="Show details"]').first().click();
+
+    cy.get('#details-panel').contains('Datafile 1744').should('be.visible');
+    cy.get('#details-panel').contains('Datafile 1625').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('have.length', 1);
+
+    cy.get('[aria-controls="datafile-details-panel"]').should('be.visible');
+
+    cy.get('#details-panel')
+      .contains('Doctor involve recently treat')
+      .should('be.visible');
+
+    cy.get('[aria-controls="datafile-parameters-panel"]').should('be.visible');
+    cy.get('[aria-controls="datafile-parameters-panel"]').click();
+
+    cy.get('#parameter-grid').should('be.visible');
+    cy.get('#details-panel').contains('PARAMETERTYPE 11').should('be.visible');
+
+    cy.get('[aria-label="Hide details"]').first().click();
+
+    cy.get('#details-panel').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/datasets.cy.ts
@@ -48,199 +48,97 @@ describe('ISIS - Datasets Table', () => {
     cy.get('[aria-rowcount="75"]').should('exist');
   });
 
-  it('should be able to resize a column', () => {
-    let columnWidth = 0;
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Create Time').as('timeSortButton').click();
+    cy.wait('@datasetsOrder', { timeout: 10000 });
 
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        // Account for select, details and actions column widths
-        columnWidth = (windowWidth - 40 - 40 - 70) / 4;
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
+    // ascending order
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.wait('@datasetsOrder', { timeout: 10000 });
 
-    cy.get('[role="columnheader"]').eq(2).as('nameColumn');
-    cy.get('[role="columnheader"]').eq(3).as('sizeColumn');
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 19');
 
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
+    // descending order
+    cy.get('@nameSortButton').click();
+    cy.wait('@datasetsOrder', { timeout: 10000 });
 
-    cy.get('@sizeColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.equal(columnWidth);
-    });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 79');
 
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 400 })
-      .trigger('mouseup');
+    // no order
+    cy.get('@nameSortButton').click();
 
-    cy.get('@nameColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 19');
 
-    cy.get('@sizeColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
+    // multiple columns
+    cy.get('@timeSortButton').click();
+    cy.wait('@datasetsOrder', { timeout: 10000 });
+    cy.get('@nameSortButton').click();
+    cy.wait('@datasetsOrder', { timeout: 10000 });
 
-    // table width should grow if a column grows too large
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 800 })
-      .trigger('mouseup');
-
-    cy.get('@sizeColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 19');
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
-    });
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    // test text filter
+    cy.get('[aria-label="Filter by Name"]').first().type('79');
 
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 79');
+    // check that size is correct after filtering
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('1.36 GB');
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 19');
-    });
+    // test date filter
+    cy.get('input[id="Create Time filter from"]').type('2005-06-12');
 
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
+    cy.get('[aria-rowcount="1"]').should('exist');
 
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 79');
-    });
+    cy.get('input[aria-label="Create Time filter to"]')
+      .parent()
+      .find('button')
+      .click();
 
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name').click();
+    const date = new Date();
+    date.setDate(1);
+    date.setFullYear(2020);
 
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 19');
-    });
+    cy.get('.MuiPickersCalendarHeader-label').click();
+    cy.contains('2020').click();
 
-    it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Create Time')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
-      cy.contains('[role="button"]', 'Name')
-        .click()
-        .wait('@datasetsOrder', { timeout: 10000 });
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 79');
-    });
-  });
-
-  describe('should be able to filter by', () => {
-    it('text', () => {
-      cy.get('[aria-label="Filter by Name"]').first().type('DATASET 79');
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 79');
-      // check that size is correct after filtering
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains('1.36 GB');
-    });
-
-    it('date between', () => {
-      cy.get('input[id="Create Time filter from"]').type('2005-06-12');
-
-      const date = new Date();
-      cy.get('input[aria-label="Create Time filter to"]').type(
-        date.toISOString().slice(0, 10)
-      );
-
-      cy.get('[aria-rowcount="2"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 79');
-    });
-
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Name"]')
-        .first()
-        .type('19')
-        .wait(['@datasetsCount', '@datasetsOrder'], { timeout: 10000 });
-
-      const date = new Date();
-      cy.get('input[id="Create Time filter to"]')
-        .type(date.toISOString().slice(0, 10))
-        .wait(['@datasetsCount', '@datasetsOrder'], { timeout: 10000 });
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 19');
-    });
+    cy.get('[aria-rowcount="0"]').should('exist');
   });
 
   describe('should be able to view details', () => {
-    it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]').first().click();
+    it('and all the details are correct & also able to hide the panel', () => {
+      cy.get('[aria-label="Show details"]').eq(1).click();
 
       cy.get('#details-panel').should('be.visible');
       cy.get('[aria-label="Hide details"]').should('exist');
-    });
-
-    it('when another other row is showing details', () => {
-      cy.get('[aria-label="Show details"]').eq(1).click();
+      cy.get('#details-panel').contains('DATASET 19').should('be.visible');
 
       cy.get('[aria-label="Show details"]').first().click();
 
       cy.get('#details-panel').contains('DATASET 79').should('be.visible');
       cy.get('#details-panel').contains('DATASET 19').should('not.exist');
       cy.get('[aria-label="Hide details"]').should('have.length', 1);
-    });
-
-    it('and view dataset details and type', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-controls="dataset-details-panel"]').should('be.visible');
 
       cy.get('#details-panel')
         .contains(
@@ -256,6 +154,11 @@ describe('ISIS - Datasets Table', () => {
           'Stop prove field onto think suffer measure. Table lose season identify professor happen third simply.'
         )
         .should('be.visible');
+
+      cy.get('[aria-label="Hide details"]').first().click();
+
+      cy.get('#details-panel').should('not.exist');
+      cy.get('[aria-label="Hide details"]').should('not.exist');
     });
 
     it('and view datafiles', () => {
@@ -266,15 +169,6 @@ describe('ISIS - Datasets Table', () => {
         'eq',
         '/browse/instrument/1/facilityCycle/19/investigation/19/dataset/79/datafile'
       );
-    });
-
-    it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-label="Hide details"]').first().click();
-
-      cy.get('#details-panel').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('not.exist');
     });
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/instruments.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/instruments.cy.ts
@@ -30,157 +30,103 @@ describe('ISIS - Instruments Table', () => {
     cy.get('[aria-rowcount="75"]').should('exist');
   });
 
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="isis-instrument-table-name"]')
-      .eq(2)
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    //Revert the default sort
+    cy.contains('[role="button"]', 'Name').as('nameSortButton').click();
+    cy.get('@nameSortButton').click();
 
-    cy.get('body').type('{esc}');
+    // ascending order
+    cy.get('@nameSortButton').click();
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="isis-instrument-table-name"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+      'Eight imagine picture tough.'
+    );
+
+    // descending order
+    cy.get('@nameSortButton').click();
+
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+      'Whether number computer economy design now serious appear.'
+    );
+
+    // no order
+    cy.get('@nameSortButton').click();
+
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+      'Stop prove field onto think suffer measure.'
+    );
+  });
+
+  it('should be able to filter with text filter on multiple columns', () => {
+    cy.get('[aria-label="Filter by Type"]').first().type('4');
+
+    cy.get('[aria-rowcount="2"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+      'Space I environmental.'
+    );
+    cy.get('[aria-rowindex="2"] [aria-colindex="2"]').contains(
+      'Up election edge his not add.'
+    );
+
+    cy.get('[aria-label="Filter by Name"]').first().type('space');
+
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
+      'Space I environmental.'
+    );
+  });
+
+  it('should be able to view details', () => {
+    cy.get('[aria-label="Show details"]').eq(1).click();
+
+    cy.get('#details-panel').should('be.visible');
+    const firstDetailsPanelText = 'General attorney city month.';
+    cy.get('#details-panel')
+      .contains(firstDetailsPanelText)
+      .should('be.visible');
+    cy.get('[aria-label="Hide details"]').should('exist');
+
+    cy.get('[aria-label="Show details"]').first().click();
+
+    cy.get('#details-panel')
+      .contains('Eight imagine picture tough')
+      .should('be.visible');
+    cy.get('#details-panel')
+      .contains(firstDetailsPanelText)
       .should('not.exist');
-  });
+    cy.get('[aria-label="Hide details"]').should('have.length', 1);
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Name').click().click();
+    cy.get('[aria-controls="instrument-details-panel').should('be.visible');
+
+    cy.get('#details-panel')
+      .contains('Skill quality beautiful.')
+      .should('be.visible');
+
+    cy.get('[aria-controls="instrument-users-panel"]').should('be.visible');
+    cy.get('[aria-controls="instrument-users-panel"]').click({
+      scrollBehavior: 'center',
     });
+    cy.get('#details-panel').contains('Kim Ramirez').should('be.visible');
 
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Name').click();
+    cy.get('[aria-label="Hide details"]').first().click();
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        'Eight imagine picture tough. Mouth participant chance including. Receive environment Democrat happy like full paper. School oil later change.'
-      );
-    });
-
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'Name').click();
-
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        'Whether number computer economy design now serious appear. Response girl middle close role American.'
-      );
-    });
-
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'Name').click();
-      cy.contains('[role="button"]', 'Name').click();
-
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        'Stop prove field onto think suffer measure. Table lose season identify professor happen third simply.'
-      );
-    });
-  });
-
-  describe('should be able to filter by', () => {
-    it('text', () => {
-      cy.get('[aria-label="Filter by Name"]').first().type('space');
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        'Space I environmental. Role again act seek. Light teacher big sing foreign meeting professor. Simply world start floor.'
-      );
-    });
-
-    it('type', () => {
-      cy.get('[aria-label="Filter by Type"]').first().type('4');
-
-      cy.get('[aria-rowcount="2"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="2"]').contains(
-        'Space I environmental. Role again act seek. Light teacher big sing foreign meeting professor. Simply world start floor.'
-      );
-      cy.get('[aria-rowindex="2"] [aria-colindex="2"]').contains(
-        'Up election edge his not add. Where difficult audience often. Cup investment the officer network hospital cultural personal.'
-      );
-    });
-  });
-
-  describe('should be able to view details', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Name').click().click();
-    });
-
-    it('when no other row is showing details', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('#details-panel').should('be.visible');
-      cy.get('[aria-label="Hide details"]').should('exist');
-    });
-
-    it('when another row is showing details', () => {
-      cy.get('[aria-label="Show details"]')
-        .eq(2)
-        .click({ scrollBehavior: 'center' });
-
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('#details-panel')
-        .contains(
-          'Suggest shake effort many last prepare small. Maintain throw hope parent.'
-        )
-        .should('be.visible');
-      cy.get('#details-panel')
-        .contains(
-          'Financial vote season indicate. Candidate night sure opportunity design. Commercial test wind region meeting her get.'
-        )
-        .should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('have.length', 1);
-    });
-
-    it('and view instrument details and scientists', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-controls="instrument-details-panel').should('be.visible');
-
-      cy.get('#details-panel')
-        .contains(
-          'Stop prove field onto think suffer measure. Table lose season identify professor happen third simply. Beat professional blue clear style have. Analysis reflect work or hour color maybe.'
-        )
-        .should('be.visible');
-
-      cy.get('[aria-controls="instrument-users-panel"]').should('be.visible');
-      cy.get('[aria-controls="instrument-users-panel"]').click({
-        scrollBehavior: 'center',
-      });
-      cy.get('#details-panel').contains('Kathryn Fox').should('be.visible');
-    });
-
-    it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-label="Hide details"]').first().click();
-
-      cy.get('#details-panel').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('not.exist');
-    });
+    cy.get('#details-panel').should('not.exist');
+    cy.get('[aria-label="Hide details"]').should('not.exist');
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/investigations.cy.ts
@@ -45,26 +45,6 @@ describe('ISIS - Investigations Table', () => {
       });
   });
 
-  it('should disable the hover tool tip by pressing escape', () => {
-    // The hover tool tip has a enter delay of 500ms.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="isis-investigations-table-title"]')
-      .first()
-      .trigger('mouseover', { force: true })
-      .wait(700)
-      .get('[role="tooltip"]')
-      .should('exist');
-
-    cy.get('body').type('{esc}');
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.get('[data-testid="isis-investigations-table-title"]')
-      .wait(700)
-      .first()
-      .get('[role="tooltip"]')
-      .should('not.exist');
-  });
-
   // Not enough investigations to test scrolling.
   it.skip('should be able to scroll down and load more rows', () => {
     cy.get('[aria-rowcount="50"]').should('exist');
@@ -72,180 +52,96 @@ describe('ISIS - Investigations Table', () => {
     cy.get('[aria-rowcount="75"]').should('exist');
   });
 
-  it('should be able to resize a column', () => {
-    let columnWidth = 0;
+  // only 1 investigation, so sort test kind of pointless
+  it.skip('should be able to sort by all sort directions on single and multiple columns', () => {
+    // Revert the default sort
+    cy.contains('[role="button"]', 'Start Date').as('dateSortButton').click();
 
-    // Using Math.floor to solve rounding errors when calculating (1000 - 40 - 40) / 7
-    cy.window()
-      .then((window) => {
-        const windowWidth = window.innerWidth;
-        // Account for select and details column widths
-        columnWidth = (windowWidth - 40 - 40 - 70) / 7;
-        columnWidth = Math.floor(columnWidth * 10) / 10;
-      })
-      .then(() => expect(columnWidth).to.not.equal(0));
+    // ascending order
+    cy.contains('[role="button"]', 'Title').as('titleSortButton').click();
 
-    cy.get('[role="columnheader"]').eq(2).as('titleColumn');
-    cy.get('[role="columnheader"]').eq(3).as('visitColumn');
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'Stop system investment'
+    );
 
-    cy.get('@titleColumn').should(($column) => {
-      let { width } = $column[0].getBoundingClientRect();
-      width = Math.floor(width * 10) / 10;
-      expect(width).to.equal(columnWidth);
-    });
+    // descending order
+    cy.get('@titleSortButton').click();
 
-    cy.get('@visitColumn').should(($column) => {
-      let { width } = $column[0].getBoundingClientRect();
-      width = Math.floor(width * 10) / 10;
-      expect(width).to.equal(columnWidth);
-    });
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'Stop system investment'
+    );
 
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 200 })
-      .trigger('mouseup');
+    // no order
+    cy.get('@titleSortButton').click();
 
-    cy.get('@titleColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.greaterThan(columnWidth);
-    });
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('[aria-sort="descending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'Stop system investment'
+    );
 
-    cy.get('@visitColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.lessThan(columnWidth);
-    });
+    cy.get('@dateSortButton').click();
+    cy.get('@titleSortButton').click();
 
-    // table width should grow if a column grows too large
-    cy.get('.react-draggable')
-      .first()
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 800 })
-      .trigger('mouseup');
-
-    cy.get('@visitColumn').should(($column) => {
-      const { width } = $column[0].getBoundingClientRect();
-      expect(width).to.be.equal(84);
-    });
-
-    cy.get('[aria-label="grid"]').then(($grid) => {
-      const { width } = $grid[0].getBoundingClientRect();
-      cy.window().should(($window) => {
-        expect(width).to.be.greaterThan($window.innerWidth);
-      });
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+      'Stop system investment'
+    );
   });
 
-  describe('should be able to sort by', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date').click();
-    });
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    // test text filter
+    cy.get('[aria-label="Filter by Title"]').first().type('stop');
 
-    it('ascending order', () => {
-      cy.contains('[role="button"]', 'Title').click();
+    cy.wait('@getInvestigationsOrder');
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Stop system investment'
-      );
-    });
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
+      'INVESTIGATION 31'
+    );
+    // check that size is correct after filtering
+    cy.get('[aria-rowindex="1"] [aria-colindex="6"]').contains('3.31 GB');
 
-    it('descending order', () => {
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
+    cy.get('input[id="Start Date filter from"]').type('2007-01-01');
 
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Stop system investment'
-      );
-    });
+    cy.wait('@getInvestigationsOrder');
 
-    it('no order', () => {
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
-      cy.contains('[role="button"]', 'Title').click();
+    cy.get('[aria-rowcount="1"]').should('exist');
 
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('[aria-sort="descending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Stop system investment'
-      );
-    });
+    cy.get('input[aria-label="Start Date filter to"]')
+      .parent()
+      .find('button')
+      .click();
 
-    it('multiple columns', () => {
-      cy.contains('[role="button"]', 'Start Date').click();
-      cy.contains('[role="button"]', 'Title').click();
+    cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-        'Stop system investment'
-      );
-    });
-  });
+    const date = new Date();
+    date.setDate(1);
 
-  describe('should be able to filter by', () => {
-    it('text', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('stop');
+    cy.get('input[id="Start Date filter to"]').should(
+      'have.value',
+      date.toISOString().slice(0, 10)
+    );
 
-      cy.get('[role="progressbar"]').should('be.visible');
-      cy.get('[role="progressbar"]').should('not.exist');
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').contains(
-        'INVESTIGATION 31'
-      );
-      // check that size is correct after filtering
-      cy.get('[aria-rowindex="1"] [aria-colindex="6"]').contains('3.31 GB');
-    });
-
-    it('date between', () => {
-      cy.get('input[id="Start Date filter from"]').type('2007-09-01');
-
-      cy.get('input[aria-label="Start Date filter to"]')
-        .parent()
-        .find('button')
-        .click();
-
-      cy.get('.MuiPickersDay-root[type="button"]').first().click();
-
-      const date = new Date();
-      date.setDate(1);
-
-      cy.get('input[id="Start Date filter to"]').should(
-        'have.value',
-        date.toISOString().slice(0, 10)
-      );
-
-      cy.get('[aria-rowcount="1"]').should('not.exist');
-      cy.contains('Stop system investment').should('not.exist');
-    });
-
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Title"]').first().type('fill');
-
-      cy.get('[aria-rowcount="1"]').should('exist');
-    });
+    cy.get('[aria-rowcount="0"]').should('exist');
+    cy.contains('Stop system investment').should('not.exist');
   });
 
   describe('should be able to view details', () => {
-    beforeEach(() => {
-      //Revert the default sort
-      cy.contains('[role="button"]', 'Start Date').click();
-    });
-
-    it('when not other row is showing details', () => {
+    it('and all the details are correct & also able to hide the panel', () => {
       cy.get('[aria-label="Show details"]').first().click();
 
       // DataPublication PID
@@ -278,37 +174,22 @@ describe('ISIS - Investigations Table', () => {
 
       cy.get('#details-panel').should('be.visible');
       cy.get('[aria-label="Hide details"]').should('exist');
-    });
-
-    // Cannot test showing details when another row is showing details
-    // as well since we are currently limited to 1 investigation to test.
-
-    it('and view investigation details, users, samples and publications', () => {
-      cy.get('[aria-label="Show details"]').first().click();
 
       cy.get('[aria-controls="investigation-details-panel"]').should(
         'be.visible'
       );
 
-      // Waits needed due to suspected race condition on fetching the panels
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.get('#details-panel')
         .contains('Stop system investment')
-        .should('be.visible')
-        .wait(200);
+        .should('be.visible');
 
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.get('[aria-controls="investigation-users-panel"]')
-        .should('be.visible')
-        .wait(200);
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.get('[aria-controls="investigation-users-panel"]').wait(200).click();
+      cy.get('[aria-controls="investigation-users-panel"]').should(
+        'be.visible'
+      );
 
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.get('#details-panel')
-        .contains('Dustin Hall')
-        .should('be.visible')
-        .wait(200);
+      cy.get('[aria-controls="investigation-users-panel"]').click();
+
+      cy.get('#details-panel').contains('Dustin Hall').should('be.visible');
 
       cy.get('[aria-controls="investigation-samples-panel"]').should(
         'be.visible'
@@ -325,6 +206,11 @@ describe('ISIS - Investigations Table', () => {
       cy.get('#details-panel')
         .contains('Pressure meeting would year but energy.')
         .should('be.visible');
+
+      cy.get('[aria-label="Hide details"]').first().click();
+
+      cy.get('#details-panel').should('not.exist');
+      cy.get('[aria-label="Hide details"]').should('not.exist');
     });
 
     it('and view datasets', () => {
@@ -335,15 +221,6 @@ describe('ISIS - Investigations Table', () => {
         'eq',
         '/browse/instrument/13/facilityCycle/12/investigation/31/dataset'
       );
-    });
-
-    it('and then not view details anymore', () => {
-      cy.get('[aria-label="Show details"]').first().click();
-
-      cy.get('[aria-label="Hide details"]').first().click();
-
-      cy.get('#details-panel').should('not.exist');
-      cy.get('[aria-label="Hide details"]').should('not.exist');
     });
   });
 });

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/myData.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/myData.cy.ts
@@ -35,26 +35,6 @@ describe('ISIS - MyData Table', () => {
       cy.get('.MuiTableSortLabel-iconDirectionDesc').should('exist');
     });
 
-    it('should disable the hover tool tip by pressing escape', () => {
-      // The hover tool tip has a enter delay of 500ms.
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.get('[data-testid="isis-mydata-table-title"]')
-        .first()
-        .trigger('mouseover', { force: true })
-        .wait(700)
-        .get('[role="tooltip"]')
-        .should('exist');
-
-      cy.get('body').type('{esc}');
-
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.get('[data-testid="isis-mydata-table-title"]')
-        .wait(700)
-        .first()
-        .get('[role="tooltip"]')
-        .should('not.exist');
-    });
-
     it('should be able to click an investigation to see its landing page', () => {
       cy.get('[role="gridcell"] a').first().click({ force: true });
       cy.location('pathname').should(
@@ -84,176 +64,112 @@ describe('ISIS - MyData Table', () => {
       cy.get('[aria-rowcount="75"]').should('exist');
     });
 
-    it('should be able to resize a column', () => {
-      let columnWidth = 0;
+    // only 1 investigation, so sort test kind of pointless
+    it.skip('should be able to sort by all sort directions on single and multiple columns', () => {
+      // Revert the default sort
+      cy.contains('[role="button"]', 'Start Date').click();
 
-      cy.window()
-        .then((window) => {
-          const windowWidth = window.innerWidth;
-          // Account for select and details column widths
-          columnWidth = (windowWidth - 40 - 40) / 8;
-        })
-        .then(() => expect(columnWidth).to.not.equal(0));
-
-      cy.get('[role="columnheader"]').eq(2).as('titleColumn');
-      cy.get('[role="columnheader"]').eq(3).as('doiColumn');
-
-      cy.get('@titleColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.equal(columnWidth);
-      });
-
-      cy.get('@doiColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.equal(columnWidth);
-      });
-
-      cy.get('.react-draggable')
+      // ascending order
+      cy.contains('[role="button"]', 'Title')
+        .as('titleSortButton')
         .first()
-        .trigger('mousedown')
-        .trigger('mousemove', { clientX: 200 })
-        .trigger('mouseup');
+        .click();
 
-      cy.get('@titleColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.greaterThan(columnWidth);
-      });
+      cy.get('[aria-sort="ascending"]').should('exist');
+      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+        'Stop system investment'
+      );
 
-      cy.get('@doiColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.lessThan(columnWidth);
-      });
+      // descending order
+      cy.get('@titleSortButton').click();
+      cy.get('[aria-sort="descending"]').should('exist');
+      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+        'not.have.css',
+        'opacity',
+        '0'
+      );
+      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+        'Stop system investment'
+      );
 
-      // table width should grow if a column grows too large
-      cy.get('.react-draggable')
-        .first()
-        .trigger('mousedown')
-        .trigger('mousemove', { clientX: 800 })
-        .trigger('mouseup');
+      // no order
+      cy.get('@titleSortButton').click();
 
-      cy.get('@doiColumn').should(($column) => {
-        const { width } = $column[0].getBoundingClientRect();
-        expect(width).to.be.equal(84);
-      });
+      cy.get('[aria-sort="ascending"]').should('not.exist');
+      cy.get('[aria-sort="descending"]').should('not.exist');
+      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+        'have.css',
+        'opacity',
+        '0'
+      );
+      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+        'Stop system investment'
+      );
 
-      cy.get('[aria-label="grid"]').then(($grid) => {
-        const { width } = $grid[0].getBoundingClientRect();
-        cy.window().should(($window) => {
-          expect(width).to.be.greaterThan($window.innerWidth);
-        });
-      });
+      // multiple columns
+      cy.get('@titleSortButton').click();
+      cy.contains('[role="button"]', 'Instrument').click();
+
+      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
+        'Stop system investment'
+      );
     });
 
-    describe('should be able to sort by', () => {
-      beforeEach(() => {
-        //Revert the default sort
-        cy.contains('[role="button"]', 'Start Date').click();
-      });
+    it('should be able to filter with role, text & date filters on multiple columns', () => {
+      // role selector
+      cy.get('[aria-rowcount="1"]').should('exist');
 
-      it('ascending order', () => {
-        cy.contains('[role="button"]', 'Title').first().click();
+      cy.get('#role-selector').click();
+      cy.get('[role="listbox"]')
+        .find('[role="option"]')
+        .should('have.length', 2);
+      cy.get('[role="option"][data-value="CI"]').click();
 
-        cy.get('[aria-sort="ascending"]').should('exist');
-        cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Stop system investment'
-        );
-      });
+      cy.get('[role="progressbar"]').should('be.visible');
+      cy.get('[role="progressbar"]').should('not.exist');
 
-      it('descending order', () => {
-        cy.contains('[role="button"]', 'Title').click();
-        cy.contains('[role="button"]', 'Title').click();
-        cy.get('[aria-sort="descending"]').should('exist');
-        cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-          'not.have.css',
-          'opacity',
-          '0'
-        );
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Stop system investment'
-        );
-      });
+      cy.get('[aria-rowcount="1"]').should('exist');
 
-      it('no order', () => {
-        cy.get('[aria-sort="ascending"]').should('not.exist');
-        cy.get('[aria-sort="descending"]').should('not.exist');
-        cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-        cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-          'have.css',
-          'opacity',
-          '0'
-        );
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Stop system investment'
-        );
-      });
+      // check that size is correct after filtering
+      cy.get('[aria-rowindex="1"] [aria-colindex="8"]').contains('3.31 GB');
 
-      it('multiple columns', () => {
-        cy.contains('[role="button"]', 'Title').click();
-        cy.contains('[role="button"]', 'Instrument').click();
+      cy.get('#role-selector').click();
+      cy.get('[role="option"]').first().click();
 
-        cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
-          'Stop system investment'
-        );
-      });
-    });
+      cy.get('[aria-rowcount="1"]').should('exist');
 
-    describe('should be able to filter by', () => {
-      it('role', () => {
-        cy.get('[aria-rowcount="1"]').should('exist');
+      // text filter
+      cy.get('[aria-label="Filter by Title"]').type('stop');
 
-        cy.get('#role-selector').click();
-        cy.get('[role="listbox"]')
-          .find('[role="option"]')
-          .should('have.length', 2);
-        cy.get('[role="option"][data-value="CI"]').click();
+      cy.get('[role="progressbar"]').should('be.visible');
+      cy.get('[role="progressbar"]').should('not.exist');
 
-        cy.get('[aria-rowcount="1"]').should('exist');
+      cy.get('[aria-rowcount="1"]').should('exist');
+      cy.get('[aria-rowindex="1"] [aria-colindex="6"]').contains(
+        'INVESTIGATION 31'
+      );
 
-        // check that size is correct after filtering
-        cy.get('[aria-rowindex="1"] [aria-colindex="8"]').contains('3.31 GB');
+      cy.get('input[aria-label="Start Date filter to"]')
+        .parent()
+        .find('button')
+        .click();
 
-        cy.get('#role-selector').click();
-        cy.get('[role="option"]').first().click();
-        cy.get('[aria-rowcount="1"]').should('exist');
-      });
+      cy.get('.MuiPickersDay-root[type="button"]').first().click();
 
-      it('text', () => {
-        cy.get('[aria-rowcount="1"]').should('exist');
-        cy.get('input[id="Title-filter"]').type('color');
+      cy.get('[role="progressbar"]').should('be.visible');
+      cy.get('[role="progressbar"]').should('not.exist');
 
-        cy.get('[aria-rowcount="1"]').should('exist');
-        cy.get('[aria-rowindex="1"] [aria-colindex="6"]').contains(
-          'INVESTIGATION 31'
-        );
-      });
+      cy.get('[aria-rowcount="1"]').should('exist');
 
-      it('date between', () => {
-        cy.get('[aria-rowcount="1"]').should('exist');
+      cy.get('input[aria-label="Start Date filter from"]').type('2008-01-01');
 
-        const date = new Date();
-
-        cy.get('input[aria-label="Start Date filter to"]').type(
-          date.toISOString().slice(0, 10)
-        );
-
-        cy.get('input[id="Start Date filter from"]').type('2007-08-01');
-        cy.get('[aria-rowcount="1"]').should('exist');
-      });
-
-      it('multiple columns', () => {
-        cy.get('[aria-label="Filter by DOI"]').first().type('76');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-
-        cy.get('[aria-label="Filter by Title"]').first().type('or');
-
-        cy.get('[aria-rowcount="1"]').should('exist');
-      });
+      cy.get('[aria-rowcount="0"]').should('exist');
     });
 
     describe('should be able to view details', () => {
-      it('when no other row is showing details', () => {
+      it('and all the details are correct & also able to hide the panel', () => {
         cy.get('[aria-label="Show details"]').first().click();
 
         // DataPublication PID
@@ -286,10 +202,6 @@ describe('ISIS - MyData Table', () => {
 
         cy.get('#details-panel').should('be.visible');
         cy.get('[aria-label="Hide details"]').should('exist');
-      });
-
-      it('and view investigation details, users, samples and publications', () => {
-        cy.get('[aria-label="Show details"]').first().click();
 
         cy.get('[aria-controls="investigation-details-panel"]').should(
           'be.visible'
@@ -321,6 +233,11 @@ describe('ISIS - MyData Table', () => {
         cy.get('#details-panel')
           .contains('Pressure meeting would year but energy.')
           .should('be.visible');
+
+        cy.get('[aria-label="Hide details"]').first().click();
+
+        cy.get('#details-panel').should('not.exist');
+        cy.get('[aria-label="Hide details"]').should('not.exist');
       });
 
       it('and view datasets', () => {
@@ -331,15 +248,6 @@ describe('ISIS - MyData Table', () => {
           'eq',
           '/browse/instrument/13/facilityCycle/12/investigation/31/dataset'
         );
-      });
-
-      it('and then not view details anymore', () => {
-        cy.get('[aria-label="Show details"]').first().click();
-
-        cy.get('[aria-label="Hide details"]').first().click();
-
-        cy.get('#details-panel').should('not.exist');
-        cy.get('[aria-label="Hide details"]').should('not.exist');
       });
     });
   });

--- a/packages/datagateway-dataview/package.json
+++ b/packages/datagateway-dataview/package.json
@@ -66,7 +66,7 @@
     "e2e": "start-server-and-test e2e:serve http://localhost:3000 cy:run",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "lint:js": "eslint --ext=tsx --ext=ts --ext=js --ext=jsx --fix ./src && yarn build",
+    "lint:js": "eslint --ext=tsx --ext=ts --ext=js --ext=jsx --fix ./src ./cypress && yarn build",
     "eject": "react-scripts eject",
     "pre-commit": "lint-staged"
   },
@@ -104,6 +104,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.22.5",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.3",
     "@testing-library/react-hooks": "8.0.1",
@@ -113,7 +114,6 @@
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
     "@welldone-software/why-did-you-render": "7.0.1",
-    "@babel/eslint-parser": "7.22.5",
     "blob-polyfill": "7.0.20220408",
     "cross-env": "7.0.3",
     "cypress": "11.2.0",

--- a/packages/datagateway-download/cypress/e2e/downloadCart.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/downloadCart.cy.ts
@@ -21,13 +21,12 @@ describe('Download Cart', () => {
     // Ensure we can move away from the table and come back to it.
     cy.get('[aria-label="Download selection panel"]').should('exist');
     // Wait for the downloads to be fetched before moving back to the cart.
-    cy.get('[aria-label="Downloads"]')
-      .should('exist')
-      .click()
-      .wait('@fetchDownloads');
+    cy.get('[aria-label="Downloads"]').should('exist').click();
+    cy.wait('@fetchDownloads');
     cy.get('[aria-label="Download status panel"]').should('exist');
 
-    cy.get('[aria-label="Selection').click().wait('@fetchCart');
+    cy.get('[aria-label="Selection').click();
+    cy.wait('@fetchCart');
     cy.get('[aria-label="Download selection panel"]').should('exist');
 
     cy.get('[aria-rowcount=59]', { timeout: 10000 }).should('exist');

--- a/packages/datagateway-download/cypress/e2e/downloadConfirmation.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/downloadConfirmation.cy.ts
@@ -27,7 +27,7 @@ describe('Download Confirmation', () => {
     cy.get('[aria-label="Download confirmation dialog"]').should('exist');
   });
 
-  it('should load correctly and display the confirmation dialog for the cart items', () => {
+  it('should load correctly and display the confirmation dialog for the cart items & let the dialog be closed', () => {
     // Show the correct download size of the cart items.
     cy.contains('Download Size: 3.12 GB').should('exist');
 
@@ -46,19 +46,12 @@ describe('Download Confirmation', () => {
     cy.contains('#download-table-hundred', '3 minutes, 57 seconds').should(
       'exist'
     );
-  });
 
-  it('should prevent download requests with an invalid email address', () => {
-    // Enter in an invalid email address.
-    cy.get('#confirm-download-email').type('email.address');
+    cy.get('[aria-label="Close download confirmation dialog"]').should('exist');
 
-    // Ensure that the download button is disabled.
-    cy.get('#download-confirmation-download').should('be.disabled');
+    cy.get('[aria-label="Close download confirmation dialog"]').click();
 
-    // Complete the remainder of the email and ensure the email is not invalid anymore
-    // as the download button is enabled.
-    cy.get('#confirm-download-email').type('@test.com');
-    cy.get('#download-confirmation-download').should('be.enabled');
+    cy.get('[aria-label="Download confirmation dialog"]').should('not.exist');
   });
 
   it('should be able to submit a download request and start immediate download with default values (HTTPS)', () => {
@@ -78,6 +71,13 @@ describe('Download Confirmation', () => {
       'exist'
     );
     cy.contains('#confirm-success-access-method', 'HTTPS').should('exist');
+
+    // Click on the download status link and expect the download
+    // status panel to have been displayed.
+    cy.contains('#download-confirmation-status-link', 'View My Downloads')
+      .should('exist')
+      .click();
+    cy.get('[aria-label="Download status panel"]').should('exist');
   });
 
   it('should not be able to submit a download request with a disabled access method (Globus)', () => {
@@ -114,7 +114,16 @@ describe('Download Confirmation', () => {
     cy.get('#confirm-download-name').type('test-file-name');
 
     // Set email address.
-    cy.get('#confirm-download-email').type('test@email.com');
+    // Enter in an invalid email address.
+    cy.get('#confirm-download-email').type('email.address');
+
+    // Ensure that the download button is disabled.
+    cy.get('#download-confirmation-download').should('be.disabled');
+
+    // Complete the remainder of the email and ensure the email is not invalid anymore
+    // as the download button is enabled.
+    cy.get('#confirm-download-email').type('@test.com');
+    cy.get('#download-confirmation-download').should('be.enabled');
 
     // Request download.
     cy.get('#download-confirmation-download').click();
@@ -129,30 +138,9 @@ describe('Download Confirmation', () => {
       'exist'
     );
     cy.contains('#confirm-success-access-method', 'HTTPS').should('exist');
-    cy.contains('#confirm-success-email-address', 'test@email.com').should(
-      'exist'
-    );
-  });
-
-  // This needs to be implemented once the tab has been included into the code.
-  it('should be able to link to the downloads status tab upon successful download confirmation', () => {
-    cy.get('#download-confirmation-download').click();
-
-    cy.get('#download-confirmation-success').should('exist');
-
-    // Click on the download status link and expect the download
-    // status panel to have been displayed.
-    cy.contains('#download-confirmation-status-link', 'View My Downloads')
-      .should('exist')
-      .click();
-    cy.get('[aria-label="Download status panel"]').should('exist');
-  });
-
-  it('should be able to close the download confirmation dialog', () => {
-    cy.get('[aria-label="Close download confirmation dialog"]').should('exist');
-
-    cy.get('[aria-label="Close download confirmation dialog"]').click();
-
-    cy.get('[aria-label="Download confirmation dialog"]').should('not.exist');
+    cy.contains(
+      '#confirm-success-email-address',
+      'email.address@test.com'
+    ).should('exist');
   });
 });

--- a/packages/datagateway-download/cypress/e2e/downloadStatus.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/downloadStatus.cy.ts
@@ -166,10 +166,22 @@ describe('Download Status', () => {
 
     cy.get('[aria-rowcount="4"]').should('exist');
 
-    cy.get('[aria-rowindex="1"] [aria-colindex="5"]').should(
-      'contain',
-      format(currDate, 'yyyy-MM-dd')
-    );
+    // account for whether the download progress feature is enabled or not
+    cy.get('[role="columnheader"]')
+      .eq(3)
+      .then(($fourthColHeader) => {
+        if ($fourthColHeader.text().includes('Progress')) {
+          cy.get('[aria-rowindex="1"] [aria-colindex="5"]').should(
+            'contain',
+            format(currDate, 'yyyy-MM-dd')
+          );
+        } else {
+          cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
+            'contain',
+            format(currDate, 'yyyy-MM-dd')
+          );
+        }
+      });
 
     cy.get('[aria-label="Filter by Access Method"]').first().type('globus');
 

--- a/packages/datagateway-download/cypress/e2e/downloadStatus.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/downloadStatus.cy.ts
@@ -10,7 +10,7 @@ describe('Download Status', () => {
   });
 
   beforeEach(() => {
-    cy.intercept('GET', '**/getPercentageComplete**');
+    cy.intercept('GET', '**/getPercentageComplete**', '100');
     cy.intercept('GET', '**/topcat/user/downloads**').as('fetchDownloads');
     cy.login();
 
@@ -21,19 +21,27 @@ describe('Download Status', () => {
       cy.visit('/download');
 
       cy.get('[aria-label="Downloads"]').should('exist');
-      cy.get('[aria-label="Downloads"]')
-        .click()
-        .then(() => {
-          cy.wait('@fetchDownloads');
-        });
+      cy.get('[aria-label="Downloads"]').click();
+      cy.wait('@fetchDownloads');
     });
   });
 
-  it('should load correctly and display download status table', () => {
+  it('should load correctly and display download status table & show correct info & links', () => {
     cy.title().should('equal', 'DataGateway Download');
     cy.get('#datagateway-download').should('be.visible');
 
     cy.get('[aria-label="Download status panel"]').should('exist');
+
+    cy.contains('[aria-colindex="1"]', 'test-file-1')
+      .should('be.visible')
+      .and('not.be.disabled');
+
+    // We are not clicking and proceeding to download the item in this test
+    // but instead checking that the link exists and it is possible to be clicked.
+    cy.get('a[aria-label="Download test-file-1"]').should('not.be.empty');
+    cy.get('a[aria-label="Download test-file-1"]')
+      .should('have.prop', 'href')
+      .and('contain', 'getData');
   });
 
   it('should refresh the table when clicking the refresh downloads button', () => {
@@ -61,155 +69,115 @@ describe('Download Status', () => {
       });
   });
 
-  describe('should be able to sort download items by', () => {
-    it('ascending order', () => {
-      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
-      cy.contains('[role="button"]', 'Requested Date').click();
+  it('should be able to sort by all sort directions on single and multiple columns', () => {
+    // remove default sort
+    cy.contains('[role="button"]', 'Requested Date').click();
 
-      cy.contains('[role="button"]', 'Download Name').click();
+    // ascending
+    cy.contains('[role="button"]', 'Download Name')
+      .as('nameSortButton')
+      .click();
 
-      cy.get('[aria-sort="ascending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
+    cy.get('[aria-sort="ascending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should('be.visible');
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
-        'have.text',
-        'test-file-1'
-      );
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
+      'have.text',
+      'test-file-1'
+    );
 
-    it('descending order', () => {
-      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
-      cy.contains('[role="button"]', 'Requested Date').click();
+    // descending
+    cy.get('@nameSortButton').click();
 
-      cy.contains('[role="button"]', 'Download Name').click();
-      cy.contains('[role="button"]', 'Download Name').click();
+    cy.get('[aria-sort="descending"]').should('exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
+      'not.have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
+      'have.text',
+      'test-file-4'
+    );
 
-      cy.get('[aria-sort="descending"]').should('exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should(
-        'not.have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
-        'have.text',
-        'test-file-4'
-      );
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').should(
+      'have.text',
+      'Expired'
+    );
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').should(
-        'have.text',
-        'Expired'
-      );
-    });
+    // no order
+    cy.get('@nameSortButton').click();
 
-    it('no order', () => {
-      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
-      cy.contains('[role="button"]', 'Requested Date').click();
+    cy.get('[aria-sort="ascending"]').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
+    cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
+      'have.css',
+      'opacity',
+      '0'
+    );
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
+      'have.text',
+      'test-file-1'
+    );
 
-      cy.contains('[role="button"]', 'Download Name').click();
-      cy.contains('[role="button"]', 'Download Name').click();
-      cy.contains('[role="button"]', 'Download Name').click();
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').should(
+      'have.text',
+      'Available'
+    );
 
-      cy.get('[aria-sort="ascending"]').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionDesc').should('not.exist');
-      cy.get('.MuiTableSortLabel-iconDirectionAsc').should(
-        'have.css',
-        'opacity',
-        '0'
-      );
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
-        'have.text',
-        'test-file-1'
-      );
+    // multiple columns
+    cy.contains('[role="button"]', 'Access Method').click();
+    cy.contains('[role="button"]', 'Availability').click();
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="3"]').should(
-        'have.text',
-        'Available'
-      );
-    });
-
-    it('multiple columns', () => {
-      // Table is sorted by Requested Date by default. To keep working test, we will remove all sorts on the table beforehand
-      cy.contains('[role="button"]', 'Requested Date').click();
-
-      cy.contains('[role="button"]', 'Access Method').click();
-      cy.contains('[role="button"]', 'Availability').click();
-
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
-        'have.text',
-        'test-file-4'
-      );
-    });
+    cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
+      'have.text',
+      'test-file-4'
+    );
   });
 
-  describe('should be able to filter download items by', () => {
-    it('text', () => {
-      cy.get('[aria-label="Filter by Download Name"]').first().type('4');
+  it('should be able to filter with both text & date filters on multiple columns', () => {
+    cy.get('input[id="Requested Date filter from"]').type(
+      '2020-01-31 00:00:00'
+    );
 
-      cy.get('[aria-rowcount="1"]').should('exist');
+    const date = new Date();
+    date.setDate(1);
+    date.setMonth(date.getMonth() - 1);
+    // MUIv5 datetime pickers don't allow for time to be graphically selected
+    // This is because the relevant elements are <span> elements with pointer-events: none
+    // Therefore, we settle for typing the date and time instead
+    cy.get('input[id="Requested Date filter to"]').type(
+      format(date, 'yyyy-MM-dd HH:mm:ss')
+    );
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="1"]').should(
-        'have.text',
-        'test-file-4'
-      );
-    });
+    // There should not be results for this time period.
+    cy.get('[aria-rowcount="0"]').should('exist');
 
-    it('date between', () => {
-      cy.get('input[id="Requested Date filter from"]').type(
-        '2020-01-31 00:00:00'
-      );
+    const currDate = new Date();
+    currDate.setHours(0, 0, 0, 0);
 
-      const date = new Date();
-      date.setDate(1);
-      date.setMonth(date.getMonth() - 1);
-      // MUIv5 datetime pickers don't allow for time to be graphically selected
-      // This is because the relevant elements are <span> elements with pointer-events: none
-      // Therefore, we settle for typing the date and time instead
-      cy.get('input[id="Requested Date filter to"]').type(
-        format(date, 'yyyy-MM-dd HH:mm:ss')
-      );
+    cy.get('input[id="Requested Date filter from"]').clear();
+    cy.get('input[id="Requested Date filter to"]').clear();
+    cy.get('[aria-rowcount="4"]').should('exist');
 
-      // There should not be results for this time period.
-      cy.get('[aria-rowcount="0"]').should('exist');
+    cy.get('input[id="Requested Date filter from"]').type(
+      format(currDate, 'yyyy-MM-dd HH:mm:ss')
+    );
 
-      const currDate = new Date();
-      currDate.setHours(0, 0, 0, 0);
+    cy.get('[aria-rowcount="4"]').should('exist');
 
-      cy.get('input[id="Requested Date filter from"]').clear();
-      cy.get('input[id="Requested Date filter to"]').clear();
-      cy.get('[aria-rowcount="4"]').should('exist');
+    cy.get('[aria-rowindex="1"] [aria-colindex="5"]').should(
+      'contain',
+      format(currDate, 'yyyy-MM-dd')
+    );
 
-      cy.get('input[id="Requested Date filter from"]').type(
-        format(currDate, 'yyyy-MM-dd HH:mm:ss')
-      );
+    cy.get('[aria-label="Filter by Access Method"]').first().type('globus');
 
-      cy.get('[aria-rowcount="4"]').should('exist');
+    cy.get('[aria-rowcount="2"]').should('exist');
 
-      cy.get('[aria-rowindex="1"] [aria-colindex="4"]').should(
-        'contain',
-        format(currDate, 'yyyy-MM-dd')
-      );
-    });
+    cy.get('[aria-label="Filter by Availability"]').first().type('restoring');
 
-    it('multiple columns', () => {
-      cy.get('[aria-label="Filter by Access Method"]').first().type('globus');
-
-      cy.get('[aria-label="Filter by Availability"]').first().type('restoring');
-
-      cy.get('[aria-rowcount="2"]').should('exist');
-    });
-  });
-
-  it('should have a download link for an item', () => {
-    cy.contains('[aria-colindex="1"]', 'test-file-1')
-      .should('be.visible')
-      .and('not.be.disabled');
-
-    // We are not clicking and proceeding to download the item in this test
-    // but instead checking that the link exists and it is possible to be clicked.
-    cy.get('a[aria-label="Download test-file-1"]').should('not.be.empty');
-    cy.get('a[aria-label="Download test-file-1"]')
-      .should('have.prop', 'href')
-      .and('contain', 'getData');
+    cy.get('[aria-rowcount="1"]').should('exist');
   });
 
   it('should be able to remove a download', () => {

--- a/packages/datagateway-download/cypress/e2e/downloadTab.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/downloadTab.cy.ts
@@ -12,17 +12,15 @@ describe('Download Cart', () => {
     cy.clearDownloadCart();
   });
 
-  it('should load correctly and display selection panel', () => {
+  it('should display the selection tab on every page reload', () => {
     cy.title().should('equal', 'DataGateway Download');
     cy.get('#datagateway-download').should('be.visible');
     cy.get('[aria-label="Selection"]').should('exist');
     cy.get('[aria-label="Downloads"]').should('exist');
     cy.get('[aria-label="Download selection panel"]').should('be.visible');
     cy.get('[aria-label="Download status panel"]').should('not.be.visible');
-  });
 
-  it('should display the selection tab on every page reload', () => {
-    cy.get('[aria-label="Downloads"]').should('exist').click();
+    cy.get('[aria-label="Downloads"]').click();
     cy.get('[aria-label="Download status panel"]').should('be.visible');
     cy.get('[aria-label="Download selection panel"]').should('not.be.visible');
 

--- a/packages/datagateway-download/cypress/tsconfig.json
+++ b/packages/datagateway-download/cypress/tsconfig.json
@@ -3,7 +3,11 @@
     "strict": true,
     "baseUrl": "../node_modules",
     "target": "es5",
-    "lib": ["es5", "dom"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "types": ["cypress"]
   },
   "include": ["**/*"]

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -44,6 +44,7 @@
     "typescript": "4.9.3"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.22.5",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "12.1.3",
     "@testing-library/react-hooks": "8.0.1",
@@ -52,7 +53,6 @@
     "@types/lodash.chunk": "4.2.6",
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
-    "@babel/eslint-parser": "7.22.5",
     "cross-env": "7.0.3",
     "cypress": "11.2.0",
     "cypress-failed-log": "2.10.0",
@@ -76,7 +76,7 @@
     "e2e": "start-server-and-test e2e:serve http://localhost:3000 cy:run",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "lint:js": "eslint --ext=tsx --ext=ts --ext=js --ext=jsx --fix ./src && yarn build",
+    "lint:js": "eslint --ext=tsx --ext=ts --ext=js --ext=jsx --fix ./src ./cypress && yarn build",
     "eject": "react-scripts eject",
     "pre-commit": "lint-staged"
   },

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -175,7 +175,7 @@ const AdminDownloadStatusTable: React.FC = () => {
       label={label}
       onChange={(value: { value?: string | number; type: string } | null) => {
         if (value) {
-          if (dataKey === 'formattedStatus') {
+          if (dataKey === 'status') {
             const downloadStatus = (
               Object.keys(downloadStatuses) as DownloadStatus[]
             ).find(
@@ -320,8 +320,10 @@ const AdminDownloadStatusTable: React.FC = () => {
                     },
                     {
                       label: t('downloadStatus.status'),
-                      dataKey: 'formattedStatus',
+                      dataKey: 'status',
                       filterComponent: textFilter,
+                      cellContentRenderer: ({ rowData }) =>
+                        (rowData as FormattedDownload).formattedStatus,
                     },
                     ...(settings.uiFeatures.downloadProgress
                       ? [
@@ -362,7 +364,9 @@ const AdminDownloadStatusTable: React.FC = () => {
                     },
                     {
                       label: t('downloadStatus.deleted'),
-                      dataKey: 'formattedIsDeleted',
+                      dataKey: 'isDeleted',
+                      cellContentRenderer: ({ rowData }) =>
+                        (rowData as FormattedDownload).formattedIsDeleted,
                     },
                   ]}
                   sort={sort}

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -361,6 +361,19 @@ describe('Download Status Table', () => {
     expect(screen.queryByText('test-file-4')).toBeNull();
     expect(screen.queryByText('test-file-5')).toBeNull();
 
+    // create an invalid range
+    await user.type(dateFromFilterInput, '2020-02-28 00:00:00');
+
+    // should display error
+    expect(await screen.findAllByText('Invalid date-time range'));
+
+    // Should show all files
+    expect(await screen.findByText('test-file-1')).toBeInTheDocument();
+    expect(await screen.findByText('test-file-2')).toBeInTheDocument();
+    expect(await screen.findByText('test-file-3')).toBeInTheDocument();
+    expect(await screen.findByText('test-file-4')).toBeInTheDocument();
+    expect(await screen.findByText('test-file-5')).toBeInTheDocument();
+
     cleanupDatePickerWorkaround();
   });
 

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.test.tsx
@@ -277,6 +277,7 @@ describe('Download Status Table', () => {
     await user.type(downloadStatusFilterBox, 'downloadStatus.complete');
 
     expect(await screen.findByText('test-file-1')).toBeInTheDocument();
+    expect(screen.queryByText('test-file-3')).toBeNull();
 
     await user.clear(downloadMethodFilterBox);
     await user.clear(downloadStatusFilterBox);

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -149,13 +149,16 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
     if (!downloads) return [];
 
     const filteredData = downloads.filter((item) => {
-      for (const [key, filter] of Object.entries(filters)) {
+      const filterEntries = Object.entries(filters);
+      const satisfiedFilters: boolean[] = [];
+      for (const [key, filter] of filterEntries) {
         const tableValue = item[key];
 
         const isTableValueAString =
           tableValue !== undefined && typeof tableValue === 'string';
         if (!isTableValueAString) {
-          return false;
+          satisfiedFilters.push(false);
+          continue;
         }
 
         const isTextFilter =
@@ -163,12 +166,17 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
           'value' in filter &&
           typeof filter.value === 'string';
         if (isTextFilter) {
-          const isInclusionFilter = filter.type === 'include';
           const filterKeyword = (filter.value as string).toLowerCase();
 
-          return isInclusionFilter
-            ? tableValue.toLowerCase().includes(filterKeyword)
-            : !tableValue.toLowerCase().includes(filterKeyword);
+          satisfiedFilters.push(
+            filter.type === 'exact'
+              ? tableValue.toLowerCase() === filterKeyword
+              : filter.type === 'exclude'
+              ? !tableValue.toLowerCase().includes(filterKeyword)
+              : tableValue.toLowerCase().includes(filterKeyword)
+          );
+
+          continue;
         }
 
         const isDateFilter =
@@ -183,27 +191,36 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
           const endDateFilter = filter.endDate ? toDate(filter.endDate) : null;
 
           if (startDateFilter && endDateFilter) {
-            return isWithinInterval(tableDate, {
-              start: startDateFilter,
-              end: endDateFilter,
-            });
+            satisfiedFilters.push(
+              isWithinInterval(tableDate, {
+                start: startDateFilter,
+                end: endDateFilter,
+              })
+            );
+
+            continue;
           }
           if (startDateFilter) {
-            return (
+            satisfiedFilters.push(
               isEqual(tableDate, startDateFilter) ||
-              isAfter(tableDate, startDateFilter)
+                isAfter(tableDate, startDateFilter)
             );
+
+            continue;
           }
           if (endDateFilter) {
-            return (
+            satisfiedFilters.push(
               isEqual(tableDate, endDateFilter) ||
-              isBefore(tableDate, endDateFilter)
+                isBefore(tableDate, endDateFilter)
             );
+
+            continue;
           }
         }
+        satisfiedFilters.push(false);
       }
 
-      return true;
+      return satisfiedFilters.every((value) => value);
     });
 
     function sortDownloadItems(

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -191,12 +191,22 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
           const endDateFilter = filter.endDate ? toDate(filter.endDate) : null;
 
           if (startDateFilter && endDateFilter) {
-            satisfiedFilters.push(
-              isWithinInterval(tableDate, {
-                start: startDateFilter,
-                end: endDateFilter,
-              })
-            );
+            try {
+              satisfiedFilters.push(
+                isWithinInterval(tableDate, {
+                  start: startDateFilter,
+                  end: endDateFilter,
+                })
+              );
+            } catch (e) {
+              if (e instanceof RangeError) {
+                // isWithinInterval throws with RangeError if startDate > endDate
+                // in the date filter we tell the user this is invalid,
+                // so handle it there and do nothing here
+              } else {
+                throw e;
+              }
+            }
 
             continue;
           }

--- a/packages/datagateway-search/cypress/e2e/search/datafileSearch.cy.ts
+++ b/packages/datagateway-search/cypress/e2e/search/datafileSearch.cy.ts
@@ -30,11 +30,10 @@ describe('Datafile search tab', () => {
     //Close drop down menu
     cy.get('body').type('{esc}');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@datafiles', '@datafiles', '@datafilesCount'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@datafiles', '@datafiles', '@datafilesCount'], {
+      timeout: 10000,
+    });
 
     cy.get('#container-search-filters').should('exist');
 
@@ -43,30 +42,31 @@ describe('Datafile search tab', () => {
 
   it('should be able to search by text', () => {
     cy.clearDownloadCart();
-    cy.get('#filled-search').type('1440');
+    cy.get('#filled-search').type('1532');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@investigations', '@investigationsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('[aria-label="Search table"]')
       .contains('Datafile')
       .contains('1')
-      .click()
-      .wait(['@datafiles', '@datafiles', '@datafilesCount'], {
-        timeout: 10000,
-      });
+      .click();
+    cy.wait(['@datafiles', '@datafiles', '@datafilesCount'], {
+      timeout: 10000,
+    });
 
     cy.get('[aria-rowcount="1"]').should('exist');
 
-    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 1440');
+    cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('Datafile 1532');
+
+    // check that it's linking to its parent dataset correctly
+    cy.get('[href="/browse/investigation/45/dataset/105/datafile"]');
 
     // Check that "select all" and individual selection are equivalent
-    cy.get(`[aria-rowindex="1"] [aria-colindex="1"]`)
-      .click()
-      .wait('@topcat', { timeout: 10000 });
+    cy.get(`[aria-rowindex="1"] [aria-colindex="1"]`).click();
+    cy.wait('@topcat', { timeout: 10000 });
     cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
       'be.checked'
     );
@@ -82,7 +82,8 @@ describe('Datafile search tab', () => {
       date.toISOString().slice(0, 10)
     );
 
-    cy.get('[aria-label="Submit search"]').click().wait('@datafilesCount', {
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait('@datafilesCount', {
       timeout: 10000,
     });
 
@@ -102,34 +103,15 @@ describe('Datafile search tab', () => {
     //Close drop down menu
     cy.get('body').type('{esc}');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@investigations', '@investigations', '@investigationsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('[aria-rowcount="50"]').should('exist');
 
     cy.get('[aria-label="Search table"]')
       .contains('Datafile')
       .should('not.exist');
-  });
-
-  it('should link to a parent dataset', () => {
-    cy.get('#filled-search').type('1532');
-
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
-    cy.get('[aria-label="Search table"]')
-      .contains('Datafile')
-      .contains('1')
-      .click()
-      .wait(['@datafiles', '@datafiles', '@datafilesCount'], {
-        timeout: 10000,
-      });
-    cy.get('[href="/browse/investigation/45/dataset/105/datafile"]');
   });
 });

--- a/packages/datagateway-search/cypress/e2e/search/datasetSearch.cy.ts
+++ b/packages/datagateway-search/cypress/e2e/search/datasetSearch.cy.ts
@@ -30,34 +30,40 @@ describe('Dataset search tab', () => {
     //Close drop down menu
     cy.get('body').type('{esc}');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@datasets', '@datasets', '@datasetsCount'], {
-        timeout: 10000,
-      });
+    cy.get('#filled-search').type('12');
+    cy.get('[aria-label="Start date input"]').type('2003-01-01');
+    cy.get('[aria-label="End date input"]').type('2004-01-01');
+
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@datasets', '@datasets', '@datasetsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('#container-search-filters').should('exist');
 
     cy.get('#container-search-table').should('exist');
+
+    // check links are being rendered correctly for datasets and investigations
+    cy.get('[href="/browse/investigation/12/dataset/12/datafile"]');
+    cy.get('[href="/browse/investigation/12/dataset"]');
   });
 
   it('should be able to search by text', () => {
     cy.clearDownloadCart();
     cy.get('#filled-search').type('police');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigations', '@investigationsCount'], {
-        timeout: 15000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@investigations', '@investigations', '@investigationsCount'], {
+      timeout: 15000,
+    });
 
     cy.get('[aria-label="Search table"]')
       .contains('Dataset')
       .contains('2')
-      .click()
-      .wait(['@datasets', '@datasets', '@datasetsCount'], {
-        timeout: 15000,
-      });
+      .click();
+    cy.wait(['@datasets', '@datasets', '@datasetsCount'], {
+      timeout: 15000,
+    });
 
     cy.get('[aria-rowcount="2"]').should('exist');
 
@@ -66,9 +72,8 @@ describe('Dataset search tab', () => {
     // Check that "select all" and individual selection are equivalent
     let i = 1;
     while (i < 3) {
-      cy.get(`[aria-rowindex="${i}"] [aria-colindex="1"]`)
-        .click()
-        .wait('@topcat', { timeout: 10000 });
+      cy.get(`[aria-rowindex="${i}"] [aria-colindex="1"]`).click();
+      cy.wait('@topcat', { timeout: 10000 });
       i++;
     }
     cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(
@@ -101,46 +106,15 @@ describe('Dataset search tab', () => {
     //Close drop down menu
     cy.get('body').type('{esc}');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@investigations', '@investigations', '@investigationsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('[aria-rowcount="50"]').should('exist');
 
     cy.get('[aria-label="Search table"]')
       .contains('Dataset')
       .should('not.exist');
-  });
-
-  it('should link to a dataset', () => {
-    cy.get('#filled-search').type('12');
-    cy.get('[aria-label="Start date input"]').type('2003-01-01');
-    cy.get('[aria-label="End date input"]').type('2004-01-01');
-
-    cy.get('[aria-label="Submit search"]').click();
-
-    cy.get('[aria-label="Search table"]')
-      .contains('Dataset')
-      .contains('1')
-      .click();
-
-    cy.get('[href="/browse/investigation/12/dataset/12/datafile"]');
-  });
-
-  it('should link to a parent investigation', () => {
-    cy.get('#filled-search').type('12');
-    cy.get('[aria-label="Start date input"]').type('2003-01-01');
-    cy.get('[aria-label="End date input"]').type('2004-01-01');
-
-    cy.get('[aria-label="Submit search"]').click();
-
-    cy.get('[aria-label="Search table"]')
-      .contains('Dataset')
-      .contains('1')
-      .click();
-
-    cy.get('[href="/browse/investigation/12/dataset"]');
   });
 });

--- a/packages/datagateway-search/cypress/e2e/search/investigationSearch.cy.ts
+++ b/packages/datagateway-search/cypress/e2e/search/investigationSearch.cy.ts
@@ -30,34 +30,34 @@ describe('Investigation search tab', () => {
     //Close drop down menu
     cy.get('body').type('{esc}');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
+    cy.get('#filled-search').type('strategy');
+
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@investigations', '@investigations', '@investigationsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('#container-search-filters').should('exist');
 
     cy.get('#container-search-table').should('exist');
+
+    // check investigations are linked correctly
+    cy.get('[href="/browse/investigation/2/dataset"]');
   });
 
   it('should be able to search by title text', () => {
     cy.clearDownloadCart();
     cy.get('#filled-search').type('strategy');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@investigations', '@investigations', '@investigationsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('[aria-rowcount="4"]').should('exist');
 
     cy.get('[aria-rowindex="1"] [aria-colindex="6"]').contains('1-903289-21-1');
 
-    // Small wait to ensure rows are selected correctly
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000);
     // Check that "select all" and individual selection are equivalent
     let i = 1;
     while (i < 5) {
@@ -77,11 +77,10 @@ describe('Investigation search tab', () => {
   it('should be able to search by instrument text', () => {
     cy.get('#filled-search').type('knowledge media');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@investigations', '@investigationsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('[aria-label="Search table"]')
       .contains('Investigation')
@@ -115,27 +114,15 @@ describe('Investigation search tab', () => {
     //Close drop down menu
     cy.get('body').type('{esc}');
 
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@datasets', '@datasets', '@datasetsCount'], {
-        timeout: 10000,
-      });
+    cy.get('[aria-label="Submit search"]').click();
+    cy.wait(['@datasets', '@datasets', '@datasetsCount'], {
+      timeout: 10000,
+    });
 
     cy.get('[aria-rowcount="50"]').should('exist');
 
     cy.get('[aria-label="Search table"]')
       .contains('Investigation')
       .should('not.exist');
-  });
-
-  it('should link to an investigation', () => {
-    cy.get('#filled-search').type('strategy');
-
-    cy.get('[aria-label="Submit search"]')
-      .click()
-      .wait(['@investigations', '@investigationsCount'], {
-        timeout: 10000,
-      });
-    cy.get('[href="/browse/investigation/2/dataset"]');
   });
 });

--- a/packages/datagateway-search/cypress/e2e/searchPageContainer.cy.ts
+++ b/packages/datagateway-search/cypress/e2e/searchPageContainer.cy.ts
@@ -238,13 +238,21 @@ describe('SearchPageContainer Component', () => {
       cy.get('@cardButtons').should('have.length', 30);
     });
 
-    it('should be able to change page in card view', () => {
+    it.only('should be able to change page in card view', () => {
       cy.get('[aria-label="Search text input"]').clear();
 
       cy.get('[aria-label="Submit search"]').click();
+
+      cy.get('[aria-rowcount=50]');
+      cy.screenshot();
       cy.get('[aria-label="page view Display as cards"]').click();
 
+      cy.get('[data-testid="card"]');
+      cy.screenshot();
+
       cy.get('[aria-label="Go to page 2"]', { timeout: 10000 }).first().click();
+      cy.get('[data-testid="card"]');
+      cy.screenshot();
       cy.get('[data-testid="card"]')
         .first()
         .contains('Quite world game over million');

--- a/packages/datagateway-search/cypress/e2e/searchPageContainer.cy.ts
+++ b/packages/datagateway-search/cypress/e2e/searchPageContainer.cy.ts
@@ -238,48 +238,39 @@ describe('SearchPageContainer Component', () => {
       cy.get('@cardButtons').should('have.length', 30);
     });
 
-    it.only('should be able to change page in card view', () => {
+    it('should be able to change page in card view', () => {
       cy.get('[aria-label="Search text input"]').clear();
 
       cy.get('[aria-label="Submit search"]').click();
 
-      cy.get('[aria-rowcount=50]');
-      cy.screenshot();
       cy.get('[aria-label="page view Display as cards"]').click();
 
-      cy.get('[data-testid="card"]');
-      cy.screenshot();
+      // we're testing cards in the middle of pages, as CI and SG-preprod can differ
+      // by around 1 result, so using first/last item per page is going to be
+      // wrong on one env or the other
 
       cy.get('[aria-label="Go to page 2"]', { timeout: 10000 }).first().click();
-      cy.get('[data-testid="card"]');
-      cy.screenshot();
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Quite world game over million');
+      cy.contains('[data-testid="card"]', 'Star enter wide nearly off');
 
       cy.get('[aria-label="Go to next page"]', { timeout: 10000 })
         .first()
         .click();
-      cy.get('[data-testid="card"]').first().contains('Across prepare why go');
+      cy.contains('[data-testid="card"]', 'Crime town perhaps');
 
       cy.get('[aria-label="Go to last page"]', { timeout: 10000 })
         .first()
         .click();
-      cy.get('[data-testid="card"]').first().contains('Father effort me');
+      cy.contains('[data-testid="card"]', 'Imagine ball old window');
 
       cy.get('[aria-label="Go to previous page"]', { timeout: 10000 })
         .first()
         .click();
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Already medical seek take');
+      cy.contains('[data-testid="card"]', 'Deep watch simple');
 
       cy.get('[aria-label="Go to first page"]', { timeout: 10000 })
         .first()
         .click();
-      cy.get('[data-testid="card"]')
-        .first()
-        .contains('Analysis reflect work or hour');
+      cy.contains('[data-testid="card"]', 'Now himself exist board space');
     });
 
     it('should display selection alert banner correctly', () => {

--- a/packages/datagateway-search/package.json
+++ b/packages/datagateway-search/package.json
@@ -66,7 +66,7 @@
     "e2e": "start-server-and-test e2e:serve http://localhost:3000 cy:run",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "lint:js": "eslint --ext=tsx --ext=ts --ext=js --ext=jsx --fix ./src && yarn build",
+    "lint:js": "eslint --ext=tsx --ext=ts --ext=js --ext=jsx --fix ./src ./cypress && yarn build",
     "eject": "react-scripts eject",
     "pre-commit": "lint-staged"
   },
@@ -105,6 +105,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.22.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "12.1.3",
     "@testing-library/user-event": "^14.4.3",
@@ -114,7 +115,6 @@
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
-    "@babel/eslint-parser": "7.22.5",
     "cross-env": "7.0.3",
     "cypress": "11.2.0",
     "cypress-failed-log": "2.10.0",


### PR DESCRIPTION
## Description

- Fix sorting bug where React Query considered two requests for columns sorted in a different order (e.g. name asc first, title desc second and title desc first, name asc second) the same request, and so would incorrectly get the data from cache rather than querying
- Fix sorting bug in that the formatted columns in the admin download table couldn't be sorted
- Fix filtering bug in download status table where only the first filter you applied was checked. Now, you need to satisfy all the applied filters to see the row
- Fix filtering bug in download status table where invalid date ranges threw exceptions and crashed the app. Now, this no longer happens
- Remove linting errors
- Delete unneeded tests
- Improve efficiency by consolidating tests into fewer, longer tests
(see https://docs.cypress.io/guides/references/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion)
  - This has significantly affected the length of the dataview tests - probably around a 33% reduction I would estimate
- lint the cypress code in the CI job
- Fixed some tests that just didn't pass locally against sg-preprod for various reasons - now all tests should pass both on CI and locally

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}
