### PR TITLE
Feature/download type status cache #1519

### DIFF
--- a/packages/datagateway-download/src/downloadApiHooks.ts
+++ b/packages/datagateway-download/src/downloadApiHooks.ts
@@ -543,6 +543,7 @@ export const useDownloadTypeStatuses = <TData = DownloadTypeStatus>({
     },
     ...queryOptions,
     cacheTime: 0,
+    staleTime: 0,
   }));
 
   // I have spent hours on this trying to make the type work,

--- a/packages/datagateway-download/src/downloadApiHooks.ts
+++ b/packages/datagateway-download/src/downloadApiHooks.ts
@@ -542,6 +542,7 @@ export const useDownloadTypeStatuses = <TData = DownloadTypeStatus>({
       if (error) handleQueryError(type);
     },
     ...queryOptions,
+    cacheTime: 0,
   }));
 
   // I have spent hours on this trying to make the type work,


### PR DESCRIPTION
## Description
This PR changes staleTime and cacheTime of Download Type Status requests to 0, to ensure they are not being cached.

- Changed staleTime and cacheTime of requests sent by `useDownloadTypeStatuses` hook to 0.
- Added a unit test to check if requests are being sent every time the hook is called. Also checking if request is stale. 

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1519 
