### PR TITLE
Fix double requests on default sort

### DIFF
--- a/packages/datagateway-common/src/api/dataPublications.tsx
+++ b/packages/datagateway-common/src/api/dataPublications.tsx
@@ -102,6 +102,7 @@ export const useDataPublicationsPaginated = (
         handleICATError(error);
       },
       retry: retryICATErrors,
+      cacheTime: isMounted ? 300000 : 0,
     }
   );
 };

--- a/packages/datagateway-common/src/api/dataPublications.tsx
+++ b/packages/datagateway-common/src/api/dataPublications.tsx
@@ -90,19 +90,22 @@ export const useDataPublicationsPaginated = (
       const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchDataPublications(apiUrl, { sort, filters }, additionalFilters, {
-            startIndex,
-            stopIndex,
-          })
-        : [];
+      return fetchDataPublications(
+        apiUrl,
+        { sort, filters },
+        additionalFilters,
+        {
+          startIndex,
+          stopIndex,
+        }
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
-      cacheTime: isMounted ? 300000 : 0,
+      enabled: isMounted ?? true,
     }
   );
 };
@@ -123,20 +126,19 @@ export const useDataPublicationsInfinite = (
     ],
     (params) => {
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchDataPublications(
-            apiUrl,
-            { sort, filters },
-            additionalFilters,
-            offsetParams
-          )
-        : [];
+      return fetchDataPublications(
+        apiUrl,
+        { sort, filters },
+        additionalFilters,
+        offsetParams
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
+      enabled: isMounted ?? true,
     }
   );
 };

--- a/packages/datagateway-common/src/api/datafiles.tsx
+++ b/packages/datagateway-common/src/api/datafiles.tsx
@@ -104,6 +104,7 @@ export const useDatafilesPaginated = (
         handleICATError(error);
       },
       retry: retryICATErrors,
+      cacheTime: isMounted ? 300000 : 0,
     }
   );
 };

--- a/packages/datagateway-common/src/api/datafiles.tsx
+++ b/packages/datagateway-common/src/api/datafiles.tsx
@@ -92,19 +92,17 @@ export const useDatafilesPaginated = (
       const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchDatafiles(apiUrl, { sort, filters }, additionalFilters, {
-            startIndex,
-            stopIndex,
-          })
-        : [];
+      return fetchDatafiles(apiUrl, { sort, filters }, additionalFilters, {
+        startIndex,
+        stopIndex,
+      });
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
-      cacheTime: isMounted ? 300000 : 0,
+      enabled: isMounted ?? true,
     }
   );
 };
@@ -121,20 +119,19 @@ export const useDatafilesInfinite = (
     ['datafile', { sort: JSON.stringify(sort), filters }, additionalFilters], // need to stringify sort as property order is important!
     (params) => {
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchDatafiles(
-            apiUrl,
-            { sort, filters },
-            additionalFilters,
-            offsetParams
-          )
-        : [];
+      return fetchDatafiles(
+        apiUrl,
+        { sort, filters },
+        additionalFilters,
+        offsetParams
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
+      enabled: isMounted ?? true,
     }
   );
 };

--- a/packages/datagateway-common/src/api/datasets.tsx
+++ b/packages/datagateway-common/src/api/datasets.tsx
@@ -131,19 +131,17 @@ export const useDatasetsPaginated = (
       const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchDatasets(apiUrl, { sort, filters }, additionalFilters, {
-            startIndex,
-            stopIndex,
-          })
-        : [];
+      return fetchDatasets(apiUrl, { sort, filters }, additionalFilters, {
+        startIndex,
+        stopIndex,
+      });
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
-      cacheTime: isMounted ? 300000 : 0,
+      enabled: isMounted ?? true,
     }
   );
 };
@@ -160,20 +158,19 @@ export const useDatasetsInfinite = (
     ['dataset', { sort: JSON.stringify(sort), filters }, additionalFilters], // need to stringify sort as property order is important!
     (params) => {
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchDatasets(
-            apiUrl,
-            { sort, filters },
-            additionalFilters,
-            offsetParams
-          )
-        : [];
+      return fetchDatasets(
+        apiUrl,
+        { sort, filters },
+        additionalFilters,
+        offsetParams
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
+      enabled: isMounted ?? true,
     }
   );
 };

--- a/packages/datagateway-common/src/api/datasets.tsx
+++ b/packages/datagateway-common/src/api/datasets.tsx
@@ -143,6 +143,7 @@ export const useDatasetsPaginated = (
         handleICATError(error);
       },
       retry: retryICATErrors,
+      cacheTime: isMounted ? 300000 : 0,
     }
   );
 };

--- a/packages/datagateway-common/src/api/facilityCycles.tsx
+++ b/packages/datagateway-common/src/api/facilityCycles.tsx
@@ -128,24 +128,22 @@ export const useFacilityCyclesPaginated = (
       const { page, results } = params.queryKey[2];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchFacilityCycles(
-            apiUrl,
-            instrumentId,
-            { sort, filters },
-            {
-              startIndex,
-              stopIndex,
-            }
-          )
-        : [];
+      return fetchFacilityCycles(
+        apiUrl,
+        instrumentId,
+        { sort, filters },
+        {
+          startIndex,
+          stopIndex,
+        }
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
-      cacheTime: isMounted ? 300000 : 0,
+      enabled: isMounted ?? true,
     }
   );
 };
@@ -162,20 +160,19 @@ export const useFacilityCyclesInfinite = (
     ['facilityCycle', instrumentId, { sort: JSON.stringify(sort), filters }],
     (params) => {
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchFacilityCycles(
-            apiUrl,
-            instrumentId,
-            { sort, filters },
-            offsetParams
-          )
-        : [];
+      return fetchFacilityCycles(
+        apiUrl,
+        instrumentId,
+        { sort, filters },
+        offsetParams
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
+      enabled: isMounted ?? true,
     }
   );
 };

--- a/packages/datagateway-common/src/api/facilityCycles.tsx
+++ b/packages/datagateway-common/src/api/facilityCycles.tsx
@@ -145,6 +145,7 @@ export const useFacilityCyclesPaginated = (
         handleICATError(error);
       },
       retry: retryICATErrors,
+      cacheTime: isMounted ? 300000 : 0,
     }
   );
 };

--- a/packages/datagateway-common/src/api/instruments.tsx
+++ b/packages/datagateway-common/src/api/instruments.tsx
@@ -102,6 +102,7 @@ export const useInstrumentsPaginated = (
         handleICATError(error);
       },
       retry: retryICATErrors,
+      cacheTime: isMounted ? 300000 : 0,
     }
   );
 };

--- a/packages/datagateway-common/src/api/instruments.tsx
+++ b/packages/datagateway-common/src/api/instruments.tsx
@@ -90,19 +90,17 @@ export const useInstrumentsPaginated = (
       const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchInstruments(apiUrl, { sort, filters }, additionalFilters, {
-            startIndex,
-            stopIndex,
-          })
-        : [];
+      return fetchInstruments(apiUrl, { sort, filters }, additionalFilters, {
+        startIndex,
+        stopIndex,
+      });
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
-      cacheTime: isMounted ? 300000 : 0,
+      enabled: isMounted ?? true,
     }
   );
 };
@@ -119,20 +117,19 @@ export const useInstrumentsInfinite = (
     ['instrument', { sort: JSON.stringify(sort), filters }], // need to stringify sort as property order is important!
     (params) => {
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchInstruments(
-            apiUrl,
-            { sort, filters },
-            additionalFilters,
-            offsetParams
-          )
-        : [];
+      return fetchInstruments(
+        apiUrl,
+        { sort, filters },
+        additionalFilters,
+        offsetParams
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
+      enabled: isMounted ?? true,
     }
   );
 };

--- a/packages/datagateway-common/src/api/investigations.tsx
+++ b/packages/datagateway-common/src/api/investigations.tsx
@@ -153,6 +153,7 @@ export const useInvestigationsPaginated = (
         handleICATError(error);
       },
       retry: retryICATErrors,
+      cacheTime: isMounted ? 300000 : 0,
     }
   );
 };

--- a/packages/datagateway-common/src/api/investigations.tsx
+++ b/packages/datagateway-common/src/api/investigations.tsx
@@ -135,25 +135,23 @@ export const useInvestigationsPaginated = (
       const { page, results } = params.queryKey[1];
       const startIndex = (page - 1) * results;
       const stopIndex = startIndex + results - 1;
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchInvestigations(
-            apiUrl,
-            { sort, filters },
-            additionalFilters,
-            {
-              startIndex,
-              stopIndex,
-            },
-            ignoreIDSort
-          )
-        : [];
+      return fetchInvestigations(
+        apiUrl,
+        { sort, filters },
+        additionalFilters,
+        {
+          startIndex,
+          stopIndex,
+        },
+        ignoreIDSort
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
-      cacheTime: isMounted ? 300000 : 0,
+      enabled: isMounted ?? true,
     }
   );
 };
@@ -176,21 +174,20 @@ export const useInvestigationsInfinite = (
     ],
     (params) => {
       const offsetParams = params.pageParam ?? { startIndex: 0, stopIndex: 49 };
-      return (isMounted ?? true) || Object.keys(sort).length
-        ? fetchInvestigations(
-            apiUrl,
-            { sort, filters },
-            additionalFilters,
-            offsetParams,
-            ignoreIDSort
-          )
-        : [];
+      return fetchInvestigations(
+        apiUrl,
+        { sort, filters },
+        additionalFilters,
+        offsetParams,
+        ignoreIDSort
+      );
     },
     {
       onError: (error) => {
         handleICATError(error);
       },
       retry: retryICATErrors,
+      enabled: isMounted ?? true,
     }
   );
 };

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -24,7 +24,7 @@ const DataHeader = (
     labelString: string;
     icon?: React.ComponentType<unknown>;
     filterComponent?: (label: string, dataKey: string) => React.ReactElement;
-    // defaultSort?: Order;
+    defaultSort?: Order;
   }
 ): React.ReactElement => {
   const {
@@ -35,7 +35,7 @@ const DataHeader = (
     label,
     labelString,
     disableSort,
-    // defaultSort,
+    defaultSort,
     resizeColumn,
     icon: Icon,
     filterComponent,
@@ -45,11 +45,11 @@ const DataHeader = (
 
   //Apply default sort on page load (but only if not already defined in URL params)
   //This will apply them in the order of the column definitions given to a table
-  // React.useEffect(() => {
-  //   if (defaultSort !== undefined && currSortDirection === undefined)
-  //     onSort(dataKey, defaultSort, 'replace');
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
+  React.useEffect(() => {
+    if (defaultSort !== undefined && currSortDirection === undefined)
+      onSort(dataKey, defaultSort, 'replace');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   let nextSortDirection: Order | null = null;
   switch (currSortDirection) {

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -24,7 +24,7 @@ const DataHeader = (
     labelString: string;
     icon?: React.ComponentType<unknown>;
     filterComponent?: (label: string, dataKey: string) => React.ReactElement;
-    defaultSort?: Order;
+    // defaultSort?: Order;
   }
 ): React.ReactElement => {
   const {
@@ -35,7 +35,7 @@ const DataHeader = (
     label,
     labelString,
     disableSort,
-    defaultSort,
+    // defaultSort,
     resizeColumn,
     icon: Icon,
     filterComponent,
@@ -45,11 +45,11 @@ const DataHeader = (
 
   //Apply default sort on page load (but only if not already defined in URL params)
   //This will apply them in the order of the column definitions given to a table
-  React.useEffect(() => {
-    if (defaultSort !== undefined && currSortDirection === undefined)
-      onSort(dataKey, defaultSort, 'replace');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // React.useEffect(() => {
+  //   if (defaultSort !== undefined && currSortDirection === undefined)
+  //     onSort(dataKey, defaultSort, 'replace');
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
 
   let nextSortDirection: Order | null = null;
   switch (currSortDirection) {

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -451,7 +451,7 @@ const VirtualizedTable = React.memo(
                               labelString={label}
                               filterComponent={filterComponent}
                               resizeColumn={resizeColumn}
-                              defaultSort={defaultSort}
+                              // defaultSort={defaultSort}
                             />
                           )}
                           className={className}

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -451,7 +451,7 @@ const VirtualizedTable = React.memo(
                               labelString={label}
                               filterComponent={filterComponent}
                               resizeColumn={resizeColumn}
-                              // defaultSort={defaultSort}
+                              defaultSort={defaultSort}
                             />
                           )}
                           className={className}

--- a/packages/datagateway-dataview/cypress/e2e/cartSelection.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/cartSelection.cy.ts
@@ -434,7 +434,7 @@ describe('Add/remove from cart functionality', () => {
 
       it('by all items in a filtered table', () => {
         cy.get('[aria-label="Filter by Location"]').first().type('g');
-        cy.wait(['@getDatafiles', '@getDatafiles']);
+        cy.wait('@getDatafiles');
 
         cy.get('[aria-label="select all rows"]').check();
         cy.get('[aria-label="select all rows"]', { timeout: 10000 }).should(

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.test.tsx
@@ -150,6 +150,14 @@ describe('DLS Datasets - Card View', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useDatasetsPaginated).toHaveBeenCalledTimes(2);
+    expect(useDatasetsPaginated).toHaveBeenCalledWith(expect.anything(), false);
+    expect(useDatasetsPaginated).toHaveBeenLastCalledWith(
+      expect.anything(),
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsDatasetsCardView.component.tsx
@@ -46,6 +46,9 @@ const DLSDatasetsCardView = (props: DLSDatasetsCVProps): React.ReactElement => {
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.test.tsx
@@ -116,6 +116,19 @@ describe('DLS Proposals - Card View', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"title":"asc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useInvestigationsPaginated).toHaveBeenCalledTimes(2);
+    expect(useInvestigationsPaginated).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      false
+    );
+    expect(useInvestigationsPaginated).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      true
+    );
   });
 
   it('renders fine with incomplete data', () => {

--- a/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsProposalsCardView.component.tsx
@@ -31,6 +31,9 @@ const DLSProposalsCardView = (): React.ReactElement => {
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.test.tsx
@@ -153,6 +153,19 @@ describe('DLS Visits - Card View', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"startDate":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useInvestigationsPaginated).toHaveBeenCalledTimes(2);
+    expect(useInvestigationsPaginated).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      false
+    );
+    expect(useInvestigationsPaginated).toHaveBeenLastCalledWith(
+      expect.anything(),
+      undefined,
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/dls/dlsVisitsCardView.component.tsx
@@ -51,6 +51,9 @@ const DLSVisitsCardView = (props: DLSVisitsCVProps): React.ReactElement => {
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/card/isis/isisDataPublicationsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDataPublicationsCardView.component.test.tsx
@@ -131,6 +131,12 @@ describe('ISIS Data Publication - Card View', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"publicationDate":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    const datafilesCalls = (axios.get as jest.Mock).mock.calls.filter(
+      (call) => call[0] === '/datapublications'
+    );
+    expect(datafilesCalls).toHaveLength(1);
   });
 
   it('updates filter query params on text filter', async () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisDataPublicationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDataPublicationsCardView.component.tsx
@@ -43,6 +43,9 @@ const ISISDataPublicationsCardView = (
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
@@ -185,6 +185,14 @@ describe('ISIS Datasets - Card View', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useDatasetsPaginated).toHaveBeenCalledTimes(2);
+    expect(useDatasetsPaginated).toHaveBeenCalledWith(expect.anything(), false);
+    expect(useDatasetsPaginated).toHaveBeenLastCalledWith(
+      expect.anything(),
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
@@ -62,6 +62,9 @@ const ISISDatasetsCardView = (
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.test.tsx
@@ -150,6 +150,17 @@ describe('ISIS Facility Cycles - Card View', () => {
     expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
+
+    // check that the data request is sent only once after mounting
+    expect(useFacilityCyclesPaginated).toHaveBeenCalledTimes(2);
+    expect(useFacilityCyclesPaginated).toHaveBeenCalledWith(
+      expect.anything(),
+      false
+    );
+    expect(useFacilityCyclesPaginated).toHaveBeenLastCalledWith(
+      expect.anything(),
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisFacilityCyclesCardView.component.tsx
@@ -41,6 +41,9 @@ const ISISFacilityCyclesCardView = (
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.test.tsx
@@ -138,6 +138,11 @@ describe('ISIS Instruments - Card View', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"fullName":"asc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useInstrumentsPaginated).toHaveBeenCalledTimes(2);
+    expect(useInstrumentsPaginated).toHaveBeenCalledWith(undefined, false);
+    expect(useInstrumentsPaginated).toHaveBeenLastCalledWith(undefined, true);
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInstrumentsCardView.component.tsx
@@ -41,6 +41,9 @@ const ISISInstrumentsCardView = (
   const pushPage = usePushPage();
   const pushResults = usePushResults();
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.test.tsx
@@ -307,6 +307,12 @@ describe('ISIS Investigations - Card View', () => {
     expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
+
+    // check that the data request is sent only once after mounting
+    const datafilesCalls = (axios.get as jest.Mock).mock.calls.filter(
+      (call) => call[0] === '/investigations'
+    );
+    expect(datafilesCalls).toHaveLength(1);
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -91,6 +91,9 @@ const ISISInvestigationsCardView = (
     },
   ];
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
@@ -231,6 +231,14 @@ describe('DLS datafiles table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useDatafilesInfinite).toHaveBeenCalledTimes(2);
+    expect(useDatafilesInfinite).toHaveBeenCalledWith(expect.anything(), false);
+    expect(useDatafilesInfinite).toHaveBeenLastCalledWith(
+      expect.anything(),
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -7,8 +7,6 @@ import {
   useDatafileCount,
   useDatafilesInfinite,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -36,28 +34,8 @@ const DLSDatafilesTable = (
   const { datasetId, investigationId } = props;
 
   const [t] = useTranslation();
-  const handleSort = useSort();
-  const location = useLocation();
 
-  // set default sort
-  const defaultSort: SortType = {
-    createTime: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const location = useLocation();
 
   const selectAllSetting = useSelector(
     (state: StateType) => state.dgdataview.selectAllSetting
@@ -70,6 +48,7 @@ const DLSDatafilesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'datafile',
@@ -165,7 +144,7 @@ const DLSDatafilesTable = (
         label: t('datafiles.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
     ],
     [t, dateFilter, textFilter]

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -7,6 +7,8 @@ import {
   useDatafileCount,
   useDatafilesInfinite,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -34,8 +36,28 @@ const DLSDatafilesTable = (
   const { datasetId, investigationId } = props;
 
   const [t] = useTranslation();
-
+  const handleSort = useSort();
   const location = useLocation();
+
+  // set default sort
+  const defaultSort: SortType = {
+    createTime: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const selectAllSetting = useSelector(
     (state: StateType) => state.dgdataview.selectAllSetting
@@ -48,7 +70,6 @@ const DLSDatafilesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'datafile',
@@ -144,7 +165,7 @@ const DLSDatafilesTable = (
         label: t('datafiles.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
     ],
     [t, dateFilter, textFilter]

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.tsx
@@ -85,6 +85,9 @@ const DLSDatafilesTable = (
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
@@ -234,6 +234,14 @@ describe('DLS Dataset table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useDatasetsInfinite).toHaveBeenCalledTimes(2);
+    expect(useDatasetsInfinite).toHaveBeenCalledWith(expect.anything(), false);
+    expect(useDatasetsInfinite).toHaveBeenLastCalledWith(
+      expect.anything(),
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -12,6 +12,8 @@ import {
   useDatasetCount,
   useDatasetsInfinite,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -38,8 +40,28 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
   const { investigationId, proposalName } = props;
 
   const [t] = useTranslation();
-
+  const handleSort = useSort();
   const location = useLocation();
+
+  // set default sort
+  const defaultSort: SortType = {
+    createTime: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const selectAllSetting = useSelector(
     (state: StateType) => state.dgdataview.selectAllSetting
@@ -52,7 +74,6 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'dataset',
@@ -138,7 +159,7 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -81,6 +81,9 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.tsx
@@ -12,8 +12,6 @@ import {
   useDatasetCount,
   useDatasetsInfinite,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -40,28 +38,8 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
   const { investigationId, proposalName } = props;
 
   const [t] = useTranslation();
-  const handleSort = useSort();
-  const location = useLocation();
 
-  // set default sort
-  const defaultSort: SortType = {
-    createTime: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const location = useLocation();
 
   const selectAllSetting = useSelector(
     (state: StateType) => state.dgdataview.selectAllSetting
@@ -74,6 +52,7 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'dataset',
@@ -159,7 +138,7 @@ const DLSDatasetsTable = (props: DLSDatasetsTableProps): React.ReactElement => {
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -3,8 +3,6 @@ import {
   formatCountOrSize,
   Investigation,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   readSciGatewayToken,
   Table,
   tableLink,
@@ -34,27 +32,6 @@ const DLSMyDataTable = (): React.ReactElement => {
   const [t] = useTranslation();
   const location = useLocation();
   const username = readSciGatewayToken().username || '';
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    startDate: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -103,6 +80,7 @@ const DLSMyDataTable = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
   const pushFilter = usePushFilter();
 
   const loadMoreRows = React.useCallback(
@@ -170,7 +148,7 @@ const DLSMyDataTable = (): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -47,6 +47,9 @@ const DLSMyDataTable = (): React.ReactElement => {
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -3,6 +3,8 @@ import {
   formatCountOrSize,
   Investigation,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   readSciGatewayToken,
   Table,
   tableLink,
@@ -32,6 +34,27 @@ const DLSMyDataTable = (): React.ReactElement => {
   const [t] = useTranslation();
   const location = useLocation();
   const username = readSciGatewayToken().username || '';
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    startDate: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -80,7 +103,6 @@ const DLSMyDataTable = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
   const pushFilter = usePushFilter();
 
   const loadMoreRows = React.useCallback(
@@ -148,7 +170,7 @@ const DLSMyDataTable = (): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
@@ -172,6 +172,19 @@ describe('DLS Proposals table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"title":"asc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useInvestigationsInfinite).toHaveBeenCalledTimes(2);
+    expect(useInvestigationsInfinite).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      false
+    );
+    expect(useInvestigationsInfinite).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      true
+    );
   });
 
   it('renders title and name as links', async () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -31,6 +31,9 @@ const DLSProposalsTable = (): React.ReactElement => {
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -6,6 +6,8 @@ import {
   useInvestigationsInfinite,
   useInvestigationCount,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   useSort,
   useTextFilter,
 } from 'datagateway-common';
@@ -18,6 +20,27 @@ import SubjectIcon from '@mui/icons-material/Subject';
 const DLSProposalsTable = (): React.ReactElement => {
   const location = useLocation();
   const [t] = useTranslation();
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    title: 'asc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -56,7 +79,6 @@ const DLSProposalsTable = (): React.ReactElement => {
   }, [data]);
 
   const textFilter = useTextFilter(filters);
-  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -81,7 +103,7 @@ const DLSProposalsTable = (): React.ReactElement => {
         filterComponent: textFilter,
         // Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
         // used above in useInvestigationsInfinite)
-        defaultSort: 'asc',
+        // defaultSort: 'asc',
         disableSort: true,
       },
       {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.tsx
@@ -6,8 +6,6 @@ import {
   useInvestigationsInfinite,
   useInvestigationCount,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   useSort,
   useTextFilter,
 } from 'datagateway-common';
@@ -20,27 +18,6 @@ import SubjectIcon from '@mui/icons-material/Subject';
 const DLSProposalsTable = (): React.ReactElement => {
   const location = useLocation();
   const [t] = useTranslation();
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    title: 'asc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -79,6 +56,7 @@ const DLSProposalsTable = (): React.ReactElement => {
   }, [data]);
 
   const textFilter = useTextFilter(filters);
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -103,7 +81,7 @@ const DLSProposalsTable = (): React.ReactElement => {
         filterComponent: textFilter,
         // Sort to ensure a deterministic order for pagination (ignoreIDSort: true is
         // used above in useInvestigationsInfinite)
-        // defaultSort: 'asc',
+        defaultSort: 'asc',
         disableSort: true,
       },
       {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.test.tsx
@@ -241,6 +241,19 @@ describe('DLS Visits table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"startDate":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useInvestigationsInfinite).toHaveBeenCalledTimes(2);
+    expect(useInvestigationsInfinite).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      false
+    );
+    expect(useInvestigationsInfinite).toHaveBeenLastCalledWith(
+      expect.anything(),
+      undefined,
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
@@ -5,6 +5,8 @@ import {
   ColumnType,
   formatCountOrSize,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   useDateFilter,
   useInvestigationCount,
   useInvestigationsInfinite,
@@ -33,6 +35,27 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
 
   const [t] = useTranslation();
   const location = useLocation();
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    startDate: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -75,7 +98,6 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -127,7 +149,7 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
@@ -46,6 +46,9 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.tsx
@@ -5,8 +5,6 @@ import {
   ColumnType,
   formatCountOrSize,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   useDateFilter,
   useInvestigationCount,
   useInvestigationsInfinite,
@@ -35,27 +33,6 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
 
   const [t] = useTranslation();
   const location = useLocation();
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    startDate: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -98,6 +75,7 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -149,7 +127,7 @@ const DLSVisitsTable = (props: DLSVisitsTableProps): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.test.tsx
@@ -216,6 +216,12 @@ describe('ISIS Data Publication table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"publicationDate":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    const datafilesCalls = (axios.get as jest.Mock).mock.calls.filter(
+      (call) => call[0] === '/datapublications'
+    );
+    expect(datafilesCalls).toHaveLength(1);
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.tsx
@@ -47,6 +47,9 @@ const ISISDataPublicationsTable = (
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.tsx
@@ -2,8 +2,6 @@ import {
   ColumnType,
   externalSiteLink,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   DataPublication,
   Table,
   tableLink,
@@ -31,27 +29,6 @@ const ISISDataPublicationsTable = (
 
   const location = useLocation();
   const [t] = useTranslation();
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    publicationDate: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -97,6 +74,7 @@ const ISISDataPublicationsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -146,7 +124,7 @@ const ISISDataPublicationsTable = (
             10
           ) ?? '',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
     ];
   }, [t, textFilter, dateFilter, instrumentId, view]);

--- a/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDataPublicationsTable.component.tsx
@@ -2,6 +2,8 @@ import {
   ColumnType,
   externalSiteLink,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   DataPublication,
   Table,
   tableLink,
@@ -29,6 +31,27 @@ const ISISDataPublicationsTable = (
 
   const location = useLocation();
   const [t] = useTranslation();
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    publicationDate: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -74,7 +97,6 @@ const ISISDataPublicationsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -124,7 +146,7 @@ const ISISDataPublicationsTable = (
             10
           ) ?? '',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
     ];
   }, [t, textFilter, dateFilter, instrumentId, view]);

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
@@ -265,6 +265,13 @@ describe('ISIS datafiles table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"modTime":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    const datafilesCalls = (axios.get as jest.Mock).mock.calls.filter(
+      (call) => call[0] === '/datafiles'
+    );
+    // 2 becasue there is also a call for ids
+    expect(datafilesCalls).toHaveLength(2);
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -11,8 +11,6 @@ import {
   useDatafileCount,
   useDatafilesInfinite,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -42,28 +40,8 @@ const ISISDatafilesTable = (
   const { datasetId, investigationId } = props;
 
   const [t] = useTranslation();
-  const handleSort = useSort();
-  const location = useLocation();
 
-  // set default sort
-  const defaultSort: SortType = {
-    modTime: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const location = useLocation();
 
   const selectAllSetting = useSelector(
     (state: StateType) => state.dgdataview.selectAllSetting
@@ -76,6 +54,7 @@ const ISISDatafilesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'datafile',
@@ -180,7 +159,7 @@ const ISISDatafilesTable = (
         label: t('datafiles.modified_time'),
         dataKey: 'modTime',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
     ],
     [t, dateFilter, textFilter]

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -91,6 +91,9 @@ const ISISDatafilesTable = (
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.tsx
@@ -11,6 +11,8 @@ import {
   useDatafileCount,
   useDatafilesInfinite,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -40,8 +42,28 @@ const ISISDatafilesTable = (
   const { datasetId, investigationId } = props;
 
   const [t] = useTranslation();
-
+  const handleSort = useSort();
   const location = useLocation();
+
+  // set default sort
+  const defaultSort: SortType = {
+    modTime: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const selectAllSetting = useSelector(
     (state: StateType) => state.dgdataview.selectAllSetting
@@ -54,7 +76,6 @@ const ISISDatafilesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'datafile',
@@ -159,7 +180,7 @@ const ISISDatafilesTable = (
         label: t('datafiles.modified_time'),
         dataKey: 'modTime',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
     ],
     [t, dateFilter, textFilter]

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
@@ -179,6 +179,14 @@ describe('ISIS Dataset table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"createTime":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useDatasetsInfinite).toHaveBeenCalledTimes(2);
+    expect(useDatasetsInfinite).toHaveBeenCalledWith(expect.anything(), false);
+    expect(useDatasetsInfinite).toHaveBeenLastCalledWith(
+      expect.anything(),
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -92,6 +92,9 @@ const ISISDatasetsTable = (
     },
   ]);
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -11,6 +11,8 @@ import {
   useDatasetCount,
   useDatasetsInfinite,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -49,6 +51,27 @@ const ISISDatasetsTable = (
   const [t] = useTranslation();
 
   const location = useLocation();
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    createTime: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { push } = useHistory();
 
@@ -63,7 +86,6 @@ const ISISDatasetsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'dataset',
@@ -156,7 +178,7 @@ const ISISDatasetsTable = (
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -11,8 +11,6 @@ import {
   useDatasetCount,
   useDatasetsInfinite,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   useTextFilter,
   useDateFilter,
   ColumnType,
@@ -51,27 +49,6 @@ const ISISDatasetsTable = (
   const [t] = useTranslation();
 
   const location = useLocation();
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    createTime: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { push } = useHistory();
 
@@ -86,6 +63,7 @@ const ISISDatasetsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
 
   const { data: allIds, isLoading: allIdsLoading } = useIds(
     'dataset',
@@ -178,7 +156,7 @@ const ISISDatasetsTable = (
         label: t('datasets.create_time'),
         dataKey: 'createTime',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.test.tsx
@@ -202,6 +202,17 @@ describe('ISIS FacilityCycles table component', () => {
     expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
+
+    // check that the data request is sent only once after mounting
+    expect(useFacilityCyclesInfinite).toHaveBeenCalledTimes(2);
+    expect(useFacilityCyclesInfinite).toHaveBeenCalledWith(
+      expect.anything(),
+      false
+    );
+    expect(useFacilityCyclesInfinite).toHaveBeenLastCalledWith(
+      expect.anything(),
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -2,8 +2,6 @@ import {
   ColumnType,
   FacilityCycle,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   useFacilityCycleCount,
   useFacilityCyclesInfinite,
   useSort,
@@ -29,27 +27,6 @@ const ISISFacilityCyclesTable = (
 
   const location = useLocation();
   const [t] = useTranslation();
-  const pushSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    startDate: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        pushSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -78,6 +55,7 @@ const ISISFacilityCyclesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const pushSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -103,7 +81,7 @@ const ISISFacilityCyclesTable = (
         label: t('facilitycycles.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -2,6 +2,8 @@ import {
   ColumnType,
   FacilityCycle,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   useFacilityCycleCount,
   useFacilityCyclesInfinite,
   useSort,
@@ -27,6 +29,27 @@ const ISISFacilityCyclesTable = (
 
   const location = useLocation();
   const [t] = useTranslation();
+  const pushSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    startDate: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        pushSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -55,7 +78,6 @@ const ISISFacilityCyclesTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const pushSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -81,7 +103,7 @@ const ISISFacilityCyclesTable = (
         label: t('facilitycycles.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisFacilityCyclesTable.component.tsx
@@ -33,6 +33,9 @@ const ISISFacilityCyclesTable = (
     [location.search]
   );
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.test.tsx
@@ -184,6 +184,11 @@ describe('ISIS Instruments table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"fullName":"asc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useInstrumentsInfinite).toHaveBeenCalledTimes(2);
+    expect(useInstrumentsInfinite).toHaveBeenCalledWith(undefined, false);
+    expect(useInstrumentsInfinite).toHaveBeenLastCalledWith(undefined, true);
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
@@ -33,6 +33,9 @@ const ISISInstrumentsTable = (
     [location.search]
   );
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
@@ -2,6 +2,7 @@ import {
   ColumnType,
   Instrument,
   parseSearchToQuery,
+  parseQueryToSearch,
   Table,
   tableLink,
   useInstrumentCount,
@@ -9,6 +10,7 @@ import {
   useSort,
   useTextFilter,
   ISISInstrumentDetailsPanel,
+  SortType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +29,28 @@ const ISISInstrumentsTable = (
 
   const location = useLocation();
   const [t] = useTranslation();
+
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    fullName: 'asc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -50,7 +74,6 @@ const ISISInstrumentsTable = (
   }, [data]);
 
   const textFilter = useTextFilter(filters);
-  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -77,7 +100,7 @@ const ISISInstrumentsTable = (
           );
         },
         filterComponent: textFilter,
-        defaultSort: 'asc',
+        // defaultSort: 'asc',
       },
       {
         icon: SubjectIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInstrumentsTable.component.tsx
@@ -2,7 +2,6 @@ import {
   ColumnType,
   Instrument,
   parseSearchToQuery,
-  parseQueryToSearch,
   Table,
   tableLink,
   useInstrumentCount,
@@ -10,7 +9,6 @@ import {
   useSort,
   useTextFilter,
   ISISInstrumentDetailsPanel,
-  SortType,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -29,28 +27,6 @@ const ISISInstrumentsTable = (
 
   const location = useLocation();
   const [t] = useTranslation();
-
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    fullName: 'asc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -74,6 +50,7 @@ const ISISInstrumentsTable = (
   }, [data]);
 
   const textFilter = useTextFilter(filters);
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -100,7 +77,7 @@ const ISISInstrumentsTable = (
           );
         },
         filterComponent: textFilter,
-        // defaultSort: 'asc',
+        defaultSort: 'asc',
       },
       {
         icon: SubjectIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -362,6 +362,13 @@ describe('ISIS Investigations table component', () => {
     expect(replaceSpy).toHaveBeenCalledWith({
       search: `?sort=${encodeURIComponent('{"startDate":"desc"}')}`,
     });
+
+    // check that the data request is sent only once after mounting
+    const datafilesCalls = (axios.get as jest.Mock).mock.calls.filter(
+      (call) => call[0] === '/investigations'
+    );
+    // 2 becasue there is also a call for ids
+    expect(datafilesCalls).toHaveLength(2);
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -15,8 +15,6 @@ import {
   Investigation,
   ISISInvestigationDetailsPanel,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   Table,
   TableActionProps,
   tableLink,
@@ -55,27 +53,6 @@ const ISISInvestigationsTable = (
   const location = useLocation();
   const { push } = useHistory();
   const [t] = useTranslation();
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    startDate: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -163,6 +140,7 @@ const ISISInvestigationsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
   const principalExperimenterFilter = usePrincipalExperimenterFilter(filters);
 
   const loadMoreRows = React.useCallback(
@@ -268,7 +246,7 @@ const ISISInvestigationsTable = (
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -15,6 +15,8 @@ import {
   Investigation,
   ISISInvestigationDetailsPanel,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   Table,
   TableActionProps,
   tableLink,
@@ -53,6 +55,27 @@ const ISISInvestigationsTable = (
   const location = useLocation();
   const { push } = useHistory();
   const [t] = useTranslation();
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    startDate: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -140,7 +163,6 @@ const ISISInvestigationsTable = (
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
   const principalExperimenterFilter = usePrincipalExperimenterFilter(filters);
 
   const loadMoreRows = React.useCallback(
@@ -246,7 +268,7 @@ const ISISInvestigationsTable = (
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -80,6 +80,9 @@ const ISISInvestigationsTable = (
     },
   ];
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.test.tsx
@@ -351,6 +351,19 @@ describe('ISIS MyData table component', () => {
     expect(history.location.search).toBe(
       `?sort=${encodeURIComponent('{"startDate":"desc"}')}`
     );
+
+    // check that the data request is sent only once after mounting
+    expect(useInvestigationsInfinite).toHaveBeenCalledTimes(2);
+    expect(useInvestigationsInfinite).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      false
+    );
+    expect(useInvestigationsInfinite).toHaveBeenLastCalledWith(
+      expect.anything(),
+      undefined,
+      true
+    );
   });
 
   it('updates sort query params on sort', async () => {

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -53,6 +53,9 @@ const ISISMyDataTable = (): React.ReactElement => {
     [location.search]
   );
 
+  // isMounted is used to disable queries when the component isn't fully mounted.
+  // It prevents the request being sent twice if default sort is set.
+  // It is not needed for cards/tables that don't have default sort.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -14,6 +14,8 @@ import {
   Investigation,
   ISISInvestigationDetailsPanel,
   parseSearchToQuery,
+  parseQueryToSearch,
+  SortType,
   readSciGatewayToken,
   Table,
   tableLink,
@@ -47,6 +49,27 @@ const ISISMyDataTable = (): React.ReactElement => {
   const { push } = useHistory();
   const [t] = useTranslation();
   const username = readSciGatewayToken().username || '';
+  const handleSort = useSort();
+
+  // set default sort
+  const defaultSort: SortType = {
+    startDate: 'desc',
+  };
+  // apply default sort
+  // had to use useMemo because useEffect doesn't run until the component is mounted
+  React.useMemo(() => {
+    if (location.search === '') {
+      location.search = parseQueryToSearch({
+        ...parseSearchToQuery(location.search),
+        sort: defaultSort,
+      }).toString();
+      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
+      for (const [column, order] of Object.entries(defaultSort)) {
+        handleSort(column, order, 'replace');
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -128,7 +151,6 @@ const ISISMyDataTable = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
-  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -245,7 +267,7 @@ const ISISMyDataTable = (): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        defaultSort: 'desc',
+        // defaultSort: 'desc',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -14,8 +14,6 @@ import {
   Investigation,
   ISISInvestigationDetailsPanel,
   parseSearchToQuery,
-  parseQueryToSearch,
-  SortType,
   readSciGatewayToken,
   Table,
   tableLink,
@@ -49,27 +47,6 @@ const ISISMyDataTable = (): React.ReactElement => {
   const { push } = useHistory();
   const [t] = useTranslation();
   const username = readSciGatewayToken().username || '';
-  const handleSort = useSort();
-
-  // set default sort
-  const defaultSort: SortType = {
-    startDate: 'desc',
-  };
-  // apply default sort
-  // had to use useMemo because useEffect doesn't run until the component is mounted
-  React.useMemo(() => {
-    if (location.search === '') {
-      location.search = parseQueryToSearch({
-        ...parseSearchToQuery(location.search),
-        sort: defaultSort,
-      }).toString();
-      // TODO: will have to add shiftDown=true to append sort after improved sort ux pr is merged
-      for (const [column, order] of Object.entries(defaultSort)) {
-        handleSort(column, order, 'replace');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { filters, view, sort } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -151,6 +128,7 @@ const ISISMyDataTable = (): React.ReactElement => {
 
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
+  const handleSort = useSort();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -267,7 +245,7 @@ const ISISMyDataTable = (): React.ReactElement => {
         label: t('investigations.start_date'),
         dataKey: 'startDate',
         filterComponent: dateFilter,
-        // defaultSort: 'desc',
+        defaultSort: 'desc',
       },
       {
         icon: CalendarToday,


### PR DESCRIPTION
## Fixed double requests bug on default sort
Any table/card view that uses default sorting now checks whether it has been mounted to prevent data requests being sent twice.
The `isMounted` variable is used to disable or enable queries in datagateway-common/api.

## Testing instructions
Updated unit tests to check for double requests when default sort is specified.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1582 
