### PR TITLE
Improve unit tests & fix text previewer styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "yarn workspaces foreach --interlaced --verbose --parallel --jobs 3 run lint:js --max-warnings=0",
     "tsc": "yarn workspace datagateway-common tsc",
     "test": "yarn test:unit && yarn test:e2e",
-    "test:unit": "yarn workspaces foreach --interlaced --verbose --parallel --jobs 3 --exclude datagateway run test",
+    "test:unit": "yarn workspaces foreach --interlaced --verbose --parallel --jobs 4 --exclude datagateway run test --runInBand",
     "test:e2e": "yarn workspaces foreach --interlaced --verbose --parallel --jobs 3 run e2e",
     "datagateway-dataview": "yarn workspace datagateway-dataview start",
     "datagateway-download": "yarn workspace datagateway-download start",

--- a/packages/datagateway-common/package.json
+++ b/packages/datagateway-common/package.json
@@ -62,6 +62,7 @@
     "eslint-config-react-app": "7.0.0",
     "eslint-plugin-cypress": "2.13.3",
     "eslint-plugin-prettier": "4.2.1",
+    "jest-fail-on-console": "3.1.1",
     "lint-staged": "13.2.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -434,8 +434,6 @@ describe('generic api functions', () => {
           result.current('title', 'asc', 'push', true);
         });
 
-        console.log(history.location.search);
-
         expect(pushSpy).toHaveBeenCalledWith({
           search: `?sort=${encodeURIComponent('{"name":"asc","title":"asc"}')}`,
         });

--- a/packages/datagateway-common/src/setupTests.tsx
+++ b/packages/datagateway-common/src/setupTests.tsx
@@ -12,6 +12,9 @@ import { Router } from 'react-router-dom';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { createMemoryHistory, History } from 'history';
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole();
 
 jest.setTimeout(15000);
 

--- a/packages/datagateway-common/src/views/addToCartButton.component.test.tsx
+++ b/packages/datagateway-common/src/views/addToCartButton.component.test.tsx
@@ -20,6 +20,8 @@ import userEvent from '@testing-library/user-event';
 import { UserEvent } from '@testing-library/user-event/setup/setup';
 import { DownloadCartItem } from '../app.types';
 
+jest.mock('../handleICATError');
+
 describe('Generic add to cart button', () => {
   const mockStore = configureStore([thunk]);
   let state: StateType;
@@ -202,7 +204,7 @@ describe('Generic add to cart button', () => {
       },
     });
 
-    user.click(
+    await user.click(
       await screen.findByRole('button', { name: 'buttons.add_to_cart' })
     );
 

--- a/packages/datagateway-dataview/package.json
+++ b/packages/datagateway-dataview/package.json
@@ -121,6 +121,7 @@
     "eslint": "8.44.0",
     "eslint-config-react-app": "7.0.0",
     "express": "4.18.1",
+    "jest-fail-on-console": "3.1.1",
     "lint-staged": "13.2.3",
     "serve": "14.2.0",
     "start-server-and-test": "2.0.0"

--- a/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
+++ b/packages/datagateway-dataview/src/page/pageContainer.component.test.tsx
@@ -349,6 +349,9 @@ describe('PageContainer - Tests', () => {
 
     renderComponent();
 
+    expect(
+      await screen.findByTestId('isis-dataPublication-landing')
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('styled-routing')).toBeNull();
   });
 

--- a/packages/datagateway-dataview/src/setupTests.ts
+++ b/packages/datagateway-dataview/src/setupTests.ts
@@ -8,6 +8,9 @@ import { StateType } from './state/app.types';
 import { initialState as dgDataViewInitialState } from './state/reducers/dgdataview.reducer';
 import { dGCommonInitialState } from 'datagateway-common';
 import { screen, within } from '@testing-library/react';
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole();
 
 jest.setTimeout(15000);
 

--- a/packages/datagateway-dataview/src/views/citationFormatter.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/citationFormatter.component.test.tsx
@@ -225,6 +225,8 @@ describe('Citation formatter component tests', () => {
   });
 
   it('displays loading spinner while waiting for a response from DataCite', async () => {
+    console.error = jest.fn();
+
     let reject: () => void;
     (axios.get as jest.Mock).mockReturnValueOnce(
       new Promise((_, _reject) => {

--- a/packages/datagateway-dataview/src/views/datafilePreview/datafilePreviewer.component.tsx
+++ b/packages/datagateway-dataview/src/views/datafilePreview/datafilePreviewer.component.tsx
@@ -144,6 +144,8 @@ function DatafilePreviewer({
   const [isDetailsPaneIn, setIsDetailsPaneIn] =
     React.useState(isDetailsPaneShown);
 
+  const animationTimeoutRef = React.useRef<NodeJS.Timeout | undefined>();
+
   React.useEffect(() => {
     // This effect controls the appearance of details panel
     //
@@ -166,12 +168,12 @@ function DatafilePreviewer({
 
     if (isDetailsPaneShown && !isDetailsPaneGridVisible) {
       setIsDetailsPaneGridVisible(true);
-      setTimeout(() => {
+      animationTimeoutRef.current = setTimeout(() => {
         setIsDetailsPaneIn(true);
       }, theme.transitions.duration.standard);
     } else if (!isDetailsPaneShown && isDetailsPaneGridVisible) {
       setIsDetailsPaneIn(false);
-      setTimeout(() => {
+      animationTimeoutRef.current = setTimeout(() => {
         setIsDetailsPaneGridVisible(false);
       }, theme.transitions.duration.standard);
     }
@@ -180,6 +182,13 @@ function DatafilePreviewer({
     isDetailsPaneGridVisible,
     theme.transitions.duration.standard,
   ]);
+
+  // ensure we clean up the timeout on component unmount
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(animationTimeoutRef.current);
+    };
+  }, []);
 
   React.useEffect(() => {
     if (loadDatafileMetaError) {

--- a/packages/datagateway-dataview/src/views/datafilePreview/previewComponents/__snapshots__/textPreview.component.test.tsx.snap
+++ b/packages/datagateway-dataview/src/views/datafilePreview/previewComponents/__snapshots__/textPreview.component.test.tsx.snap
@@ -4,53 +4,69 @@ exports[`TextPreview should render given text file 1`] = `
 <DocumentFragment>
   <pre
     aria-label="datafiles.preview.txt.file_content_label"
-    class="css-h4y87t"
+    class="css-1pxm7zh"
     font-size="12"
   >
     <span
-      class="css-ppgvqg"
+      style="display: flex;"
     >
-      1
-    </span>
-    <code
-      class="css-a948ge"
-    >
-      First line
+      <span
+        class="css-xzflaj"
+      >
+        1
+      </span>
+      <code
+        class="css-jfzx4e"
+      >
+        First line
 
-    </code>
+      </code>
+    </span>
     <span
-      class="css-ppgvqg"
+      style="display: flex;"
     >
-      2
-    </span>
-    <code
-      class="css-a948ge"
-    >
-      Second line
+      <span
+        class="css-xzflaj"
+      >
+        2
+      </span>
+      <code
+        class="css-jfzx4e"
+      >
+        Second line
 
-    </code>
+      </code>
+    </span>
     <span
-      class="css-ppgvqg"
+      style="display: flex;"
     >
-      3
-    </span>
-    <code
-      class="css-a948ge"
-    >
-      Third line
+      <span
+        class="css-xzflaj"
+      >
+        3
+      </span>
+      <code
+        class="css-jfzx4e"
+      >
+        Third line
 
-    </code>
+      </code>
+    </span>
     <span
-      class="css-ppgvqg"
+      style="display: flex;"
     >
-      4
-    </span>
-    <code
-      class="css-a948ge"
-    >
-      
+      <span
+        class="css-xzflaj"
+      >
+        4
+      </span>
+      <code
+        class="css-jfzx4e"
+      >
+        
 
-    </code>
+      </code>
+    </span>
   </pre>
 </DocumentFragment>
 `;

--- a/packages/datagateway-dataview/src/views/datafilePreview/previewComponents/textPreview.component.tsx
+++ b/packages/datagateway-dataview/src/views/datafilePreview/previewComponents/textPreview.component.tsx
@@ -9,19 +9,17 @@ import type { PreviewComponentProps } from './previewComponents';
 const TextContainer = styled('pre')<{ fontSize: number }>(({ fontSize }) => ({
   margin: 0,
   fontSize,
-  counterReset: 'line',
-  display: 'grid',
-  gridTemplateColumns: 'min-content 1fr',
-  gridAutoRows: 'min-content',
   flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
 }));
 
 const LineNumber = styled('span')(({ theme }) => ({
   textAlign: 'right',
-  paddingLeft: theme.spacing(2),
-  paddingRight: theme.spacing(3),
-  paddingTop: theme.spacing(0.5),
-  paddingBottom: theme.spacing(0.5),
+  paddingLeft: theme.spacing(1),
+  paddingRight: theme.spacing(1),
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
   opacity: 0.8,
   borderRight: `1px solid ${theme.palette.text.disabled}`,
   // disable text select for line numbers, it makes text selection a lot easier
@@ -31,9 +29,9 @@ const LineNumber = styled('span')(({ theme }) => ({
 
 const TextLine = styled('code')(({ theme }) => ({
   paddingLeft: theme.spacing(2),
-  paddingTop: theme.spacing(0.5),
-  paddingBottom: theme.spacing(0.5),
-  counterIncrement: 'line',
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
+  flexGrow: 1,
   // highlight the current line when hovered over.
   '&:hover': {
     backgroundColor: theme.palette.action.hover,
@@ -90,6 +88,8 @@ function TextPreview({
     );
   }
 
+  const lines = textContent.split('\n');
+
   return (
     <TextContainer
       fontSize={fontSize}
@@ -97,11 +97,13 @@ function TextPreview({
         fileName: datafile.name,
       })}
     >
-      {textContent.split('\n').map((line, i) => (
-        <React.Fragment key={i}>
-          <LineNumber>{i + 1}</LineNumber>
+      {lines.map((line, i) => (
+        <span style={{ display: 'flex' }} key={i}>
+          <LineNumber>
+            {`${i + 1}`.padStart(`${lines.length}`.length)}
+          </LineNumber>
           <TextLine>{`${line}\n`}</TextLine>
-        </React.Fragment>
+        </span>
       ))}
     </TextContainer>
   );

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
@@ -140,7 +140,7 @@ describe('Investigation table component', () => {
 
               return Promise.resolve({
                 data: {
-                  cardItems: [],
+                  cartItems: [],
                 },
               });
             }
@@ -171,7 +171,7 @@ describe('Investigation table component', () => {
     jest.clearAllMocks();
   });
 
-  it('renders correctly', async () => {
+  it.skip('renders correctly', async () => {
     renderComponent();
 
     let rows: HTMLElement[] = [];
@@ -268,7 +268,7 @@ describe('Investigation table component', () => {
     ).toBeInTheDocument();
   });
 
-  it('updates filter query params on text filter', async () => {
+  it.skip('updates filter query params on text filter', async () => {
     renderComponent();
 
     const filterInput = await screen.findByRole('textbox', {
@@ -291,7 +291,7 @@ describe('Investigation table component', () => {
     expect(history.location.search).toBe('?');
   });
 
-  it('updates filter query params on date filter', async () => {
+  it.skip('updates filter query params on date filter', async () => {
     applyDatePickerWorkaround();
 
     renderComponent();
@@ -320,7 +320,7 @@ describe('Investigation table component', () => {
     cleanupDatePickerWorkaround();
   });
 
-  it('updates sort query params on sort', async () => {
+  it.skip('updates sort query params on sort', async () => {
     renderComponent();
 
     await user.click(screen.getByText('investigations.title'));

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.test.tsx
@@ -171,7 +171,7 @@ describe('Investigation table component', () => {
     jest.clearAllMocks();
   });
 
-  it.skip('renders correctly', async () => {
+  it('renders correctly', async () => {
     renderComponent();
 
     let rows: HTMLElement[] = [];
@@ -268,7 +268,7 @@ describe('Investigation table component', () => {
     ).toBeInTheDocument();
   });
 
-  it.skip('updates filter query params on text filter', async () => {
+  it('updates filter query params on text filter', async () => {
     renderComponent();
 
     const filterInput = await screen.findByRole('textbox', {
@@ -291,7 +291,7 @@ describe('Investigation table component', () => {
     expect(history.location.search).toBe('?');
   });
 
-  it.skip('updates filter query params on date filter', async () => {
+  it('updates filter query params on date filter', async () => {
     applyDatePickerWorkaround();
 
     renderComponent();
@@ -320,7 +320,7 @@ describe('Investigation table component', () => {
     cleanupDatePickerWorkaround();
   });
 
-  it.skip('updates sort query params on sort', async () => {
+  it('updates sort query params on sort', async () => {
     renderComponent();
 
     await user.click(screen.getByText('investigations.title'));

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -60,6 +60,7 @@
     "enzyme-to-json": "3.6.1",
     "eslint": "8.44.0",
     "eslint-config-react-app": "7.0.0",
+    "jest-fail-on-console": "3.1.1",
     "lint-staged": "13.2.3",
     "serve": "14.2.0",
     "start-server-and-test": "2.0.0"

--- a/packages/datagateway-download/src/downloadApiHooks.test.tsx
+++ b/packages/datagateway-download/src/downloadApiHooks.test.tsx
@@ -1,4 +1,8 @@
-import { renderHook, WrapperComponent } from '@testing-library/react-hooks';
+import {
+  act,
+  renderHook,
+  WrapperComponent,
+} from '@testing-library/react-hooks';
 import axios from 'axios';
 import type { Download } from 'datagateway-common';
 import {
@@ -1252,18 +1256,22 @@ describe('Download Cart API react-query hooks test', () => {
       expect(result.current[0].isStale).toBe(true);
       expect(axios.get).toHaveBeenCalledTimes(1);
 
-      const { result: newResult } = renderHook(
-        () =>
-          useDownloadTypeStatuses({
-            downloadTypes: ['https'],
-          }),
-        { wrapper }
-      );
+      await act(async () => {
+        const { result: newResult } = renderHook(
+          () =>
+            useDownloadTypeStatuses({
+              downloadTypes: ['https'],
+            }),
+          { wrapper }
+        );
 
-      await waitFor(() => newResult.current.every((query) => query.isSuccess));
+        await waitFor(() =>
+          newResult.current.every((query) => query.isSuccess)
+        );
 
-      expect(newResult.current[0].isStale).toBe(true);
-      expect(axios.get).toHaveBeenCalledTimes(2);
+        expect(newResult.current[0].isStale).toBe(true);
+        expect(axios.get).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/packages/datagateway-download/src/setupTests.ts
+++ b/packages/datagateway-download/src/setupTests.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import '@testing-library/jest-dom';
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole();
 
 jest.setTimeout(15000);
 

--- a/packages/datagateway-search/package.json
+++ b/packages/datagateway-search/package.json
@@ -123,6 +123,7 @@
     "eslint": "8.44.0",
     "eslint-config-react-app": "7.0.0",
     "express": "4.18.1",
+    "jest-fail-on-console": "3.1.1",
     "lint-staged": "13.2.3",
     "serve": "14.2.0",
     "start-server-and-test": "2.0.0"

--- a/packages/datagateway-search/src/setupTests.ts
+++ b/packages/datagateway-search/src/setupTests.ts
@@ -7,6 +7,9 @@ import { StateType } from './state/app.types';
 import { dGCommonInitialState } from 'datagateway-common';
 import { initialState as dgSearchInitialState } from './state/reducers/dgsearch.reducer';
 import { screen, within } from '@testing-library/react';
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole();
 
 jest.setTimeout(15000);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6583,6 +6583,7 @@ __metadata:
     hex-to-rgba: 2.0.1
     history: 4.10.1
     i18next: 22.0.3
+    jest-fail-on-console: 3.1.1
     lint-staged: 13.2.3
     lodash.debounce: 4.0.8
     loglevel: 1.8.0
@@ -6662,6 +6663,7 @@ __metadata:
     i18next: 22.0.3
     i18next-browser-languagedetector: 7.1.0
     i18next-http-backend: 2.2.1
+    jest-fail-on-console: 3.1.1
     jsrsasign: 10.8.6
     lint-staged: 13.2.3
     lodash.debounce: 4.0.8
@@ -6732,6 +6734,7 @@ __metadata:
     i18next: 22.0.3
     i18next-browser-languagedetector: 7.1.0
     i18next-http-backend: 2.2.1
+    jest-fail-on-console: 3.1.1
     jsrsasign: 10.8.6
     lint-staged: 13.2.3
     lodash.chunk: 4.2.0
@@ -6803,6 +6806,7 @@ __metadata:
     i18next: 22.0.3
     i18next-browser-languagedetector: 7.1.0
     i18next-http-backend: 2.2.1
+    jest-fail-on-console: 3.1.1
     jsrsasign: 10.8.6
     lint-staged: 13.2.3
     loglevel: 1.8.0
@@ -10315,6 +10319,15 @@ __metadata:
     jest-mock: ^27.5.1
     jest-util: ^27.5.1
   checksum: 0f988330c4f3eec092e3fb37ea753b0c6f702e83cd8f4d770af9c2bf964a70bc45fbd34ec6fdb6d71ce98a778d9f54afd673e63f222e4667fff289e8069dba39
+  languageName: node
+  linkType: hard
+
+"jest-fail-on-console@npm:3.1.1":
+  version: 3.1.1
+  resolution: "jest-fail-on-console@npm:3.1.1"
+  dependencies:
+    chalk: ^4.1.0
+  checksum: dbc244766fb78525b2d4a7e879678b91032acefa04694e17edb5917e325abf8ee356bdf728bc1c89058d67b9c8b3da4cd45515232eb9ab1b973a6b4f57bfb7af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
See title

The top level test:unit command now runs all packages in band in Jest (i.e. Jest runs tests serially not in parallel) - this is recommended on CI and may reduce failure rates. Also increased jobs from 3 to 4 to run all suites in parallel.

Also, I got annoyed with console errors again so I fixed those and added a library that will fail a test if it generates logging.

Also, in fixing some logging in datafilePreviewer, I noticed that the styling for the text previewer was messed up. Line numbers took up half the view. I refactored so that the line numbers take up only the space they need, with the rest going to the actual text content.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
