### PR TITLE
Update release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
       - develop
-    tags: '*'
+    tags: 
+      - '*'
 
 jobs:
   build:
@@ -72,11 +73,15 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
 
       - name: Create/update release
-        uses: johnwbyrd/update-release@1d5ec4791e40507e5eca3b4dbf90f0b27e7e4979 # v1.0.0
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: ./datagateway-dataview-${{ env.TAG_NAME }}.tar.gz ./datagateway-download-${{ env.TAG_NAME }}.tar.gz ./datagateway-search-${{ env.TAG_NAME }}.tar.gz
-          release: Release ${{ env.TAG_NAME }}
-          tag: ${{ env.TAG_NAME }}
+          files: |
+            ./datagateway-dataview-${{ env.TAG_NAME }}.tar.gz
+            ./datagateway-download-${{ env.TAG_NAME }}.tar.gz
+            ./datagateway-search-${{ env.TAG_NAME }}.tar.gz
+          name: ${{ env.TAG_NAME }}
+          tag_name: ${{ env.TAG_NAME }}
           prerelease: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
           draft: false
+          generate_release_notes: true


### PR DESCRIPTION
## Description
The old release action is a) unmaintained and b) always failed to upload the assets when the release was first created and thus the job needed to be reran. This fixes both those issues.

I tested this on my fork so feel free to verify it works: https://github.com/louise-davies/datagateway

This will also auto-trigger github to fill in it's generated release notes - it also adds a tiny bit of config to that to separate out dependency updates

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
