### PR TITLE
Allow query retry setting to be configurable

### DIFF
--- a/packages/datagateway-common/src/api/cart.tsx
+++ b/packages/datagateway-common/src/api/cart.tsx
@@ -11,7 +11,7 @@ import {
   useMutation,
   UseMutationResult,
 } from 'react-query';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 export const fetchDownloadCart = (config: {
   facilityName: string;
@@ -57,6 +57,7 @@ export const useCart = (): UseQueryResult<DownloadCartItem[], AxiosError> => {
   const facilityName = useSelector(
     (state: StateType) => state.dgcommon.facilityName
   );
+  const retryICATErrors = useRetryICATErrors();
   return useQuery(
     'cart',
     () =>

--- a/packages/datagateway-common/src/api/dataPublications.tsx
+++ b/packages/datagateway-common/src/api/dataPublications.tsx
@@ -15,7 +15,7 @@ import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { getApiParams, parseSearchToQuery } from '.';
 import { StateType } from '..';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 const fetchDataPublications = (
   apiUrl: string,
@@ -61,6 +61,7 @@ export const useDataPublicationsPaginated = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort, page, results } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     DataPublication[],
@@ -118,6 +119,7 @@ export const useDataPublicationsInfinite = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useInfiniteQuery(
     [
@@ -154,6 +156,7 @@ export const useDataPublication = (
   >
 ): UseQueryResult<DataPublication, AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery(
     ['dataPublication', dataPublicationId],
@@ -203,6 +206,7 @@ export const useDataPublications = (
   additionalFilters: AdditionalFilters
 ): UseQueryResult<DataPublication[], AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     DataPublication[],
@@ -259,6 +263,7 @@ export const useDataPublicationCount = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     number,

--- a/packages/datagateway-common/src/api/datafiles.tsx
+++ b/packages/datagateway-common/src/api/datafiles.tsx
@@ -18,7 +18,7 @@ import type {
   UseQueryOptions,
 } from 'react-query';
 import { useQuery, useInfiniteQuery } from 'react-query';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 export const fetchDatafiles = (
   apiUrl: string,
@@ -62,6 +62,7 @@ export const useDatafilesPaginated = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort, page, results } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     Datafile[],
@@ -114,6 +115,7 @@ export const useDatafilesInfinite = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useInfiniteQuery(
     ['datafile', { sort: JSON.stringify(sort), filters }, additionalFilters], // need to stringify sort as property order is important!
@@ -167,6 +169,7 @@ export const useDatafileCount = (
   const location = useLocation();
 
   const filters = parseSearchToQuery(location.search).filters;
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     number,
@@ -223,6 +226,7 @@ export const useDatafileDetails = (
   >
 ): UseQueryResult<Datafile, AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     Datafile,

--- a/packages/datagateway-common/src/api/datasets.tsx
+++ b/packages/datagateway-common/src/api/datasets.tsx
@@ -18,7 +18,7 @@ import {
   useInfiniteQuery,
   UseInfiniteQueryResult,
 } from 'react-query';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 export const fetchDatasets = (
   apiUrl: string,
@@ -60,6 +60,7 @@ export const useDataset = (
   additionalFilters?: AdditionalFilters
 ): UseQueryResult<Dataset[], AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     Dataset[],
@@ -95,6 +96,7 @@ export const useDatasetsPaginated = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort, page, results } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     Dataset[],
@@ -147,6 +149,7 @@ export const useDatasetsInfinite = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useInfiniteQuery(
     ['dataset', { sort: JSON.stringify(sort), filters }, additionalFilters], // need to stringify sort as property order is important!
@@ -199,6 +202,7 @@ export const useDatasetCount = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const filters = parseSearchToQuery(location.search).filters;
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     number,
@@ -242,6 +246,7 @@ export const useDatasetDetails = (
   datasetId: number
 ): UseQueryResult<Dataset, AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<Dataset, AxiosError, Dataset, [string, number]>(
     ['datasetDetails', datasetId],

--- a/packages/datagateway-common/src/api/facilityCycles.tsx
+++ b/packages/datagateway-common/src/api/facilityCycles.tsx
@@ -13,7 +13,7 @@ import {
   useInfiniteQuery,
   UseInfiniteQueryResult,
 } from 'react-query';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 const fetchFacilityCycles = (
   apiUrl: string,
@@ -79,6 +79,7 @@ export const useAllFacilityCycles = (
   enabled?: boolean
 ): UseQueryResult<FacilityCycle[], AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<FacilityCycle[], AxiosError, FacilityCycle[], string>(
     'facilityCycle',
@@ -100,6 +101,7 @@ export const useFacilityCyclesPaginated = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort, page, results } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     FacilityCycle[],
@@ -157,6 +159,7 @@ export const useFacilityCyclesInfinite = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useInfiniteQuery(
     ['facilityCycle', instrumentId, { sort: JSON.stringify(sort), filters }],
@@ -220,6 +223,7 @@ export const useFacilityCycleCount = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     number,

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -24,7 +24,7 @@ import { useSelector } from 'react-redux';
 import { StateType } from '../state/app.types';
 import format from 'date-fns/format';
 import { isValid } from 'date-fns';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 export * from './cart';
 export * from './facilityCycles';
@@ -678,6 +678,7 @@ export const useIds = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     number[],
@@ -758,6 +759,7 @@ export const useCustomFilter = (
   }[]
 ): UseQueryResult<string[], Error> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     string[],
@@ -842,6 +844,7 @@ export const useCustomFilterCount = (
   }[]
 ): UseQueryResult<number, AxiosError>[] => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   const queryConfigs: UseQueryOptions<
     number,
@@ -891,7 +894,14 @@ export const useCustomFilterCount = (
         staleTime: Infinity,
       };
     });
-  }, [apiUrl, entityType, filterIds, filterKey, additionalFilters]);
+  }, [
+    filterIds,
+    entityType,
+    filterKey,
+    additionalFilters,
+    retryICATErrors,
+    apiUrl,
+  ]);
 
   // useQueries doesn't allow us to specify type info, so ignore this line
   // since we strongly type the queries object anyway

--- a/packages/datagateway-common/src/api/instruments.tsx
+++ b/packages/datagateway-common/src/api/instruments.tsx
@@ -18,7 +18,7 @@ import {
   useInfiniteQuery,
   UseInfiniteQueryResult,
 } from 'react-query';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 const fetchInstruments = (
   apiUrl: string,
@@ -62,6 +62,7 @@ export const useInstrumentsPaginated = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort, page, results } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     Instrument[],
@@ -112,6 +113,7 @@ export const useInstrumentsInfinite = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useInfiniteQuery(
     ['instrument', { sort: JSON.stringify(sort), filters }], // need to stringify sort as property order is important!
@@ -155,6 +157,7 @@ export const useInstrumentCount = (): UseQueryResult<number, AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     number,
@@ -198,6 +201,7 @@ export const useInstrumentDetails = (
   instrumentId: number
 ): UseQueryResult<Instrument, AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<Instrument, AxiosError, Instrument, [string, number]>(
     ['instrumentDetails', instrumentId],

--- a/packages/datagateway-common/src/api/investigations.tsx
+++ b/packages/datagateway-common/src/api/investigations.tsx
@@ -18,7 +18,7 @@ import {
   useQuery,
   UseQueryResult,
 } from 'react-query';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 export const fetchInvestigations = (
   apiUrl: string,
@@ -61,6 +61,7 @@ export const useInvestigation = (
   additionalFilters?: AdditionalFilters
 ): UseQueryResult<Investigation[], AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     Investigation[],
@@ -97,6 +98,7 @@ export const useInvestigationsPaginated = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort, page, results } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     Investigation[],
@@ -158,6 +160,7 @@ export const useInvestigationsInfinite = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const { filters, sort } = parseSearchToQuery(location.search);
+  const retryICATErrors = useRetryICATErrors();
 
   return useInfiniteQuery(
     [
@@ -216,6 +219,7 @@ export const useInvestigationCount = (
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
   const location = useLocation();
   const filters = parseSearchToQuery(location.search).filters;
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<
     number,
@@ -267,6 +271,7 @@ export const useInvestigationDetails = (
   investigationId: number
 ): UseQueryResult<Investigation, AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<Investigation, AxiosError, Investigation, [string, number]>(
     ['investigationDetails', investigationId],

--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -19,7 +19,7 @@ import {
 } from '../app.types';
 import handleICATError from '../handleICATError';
 import { readSciGatewayToken } from '../parseTokens';
-import retryICATErrors from './retryICATErrors';
+import { useRetryICATErrors } from './retryICATErrors';
 
 interface QueryParameters {
   target: string;
@@ -352,6 +352,7 @@ export const useLuceneSearchInfinite = (
       {}
     );
   }
+  const retryICATErrors = useRetryICATErrors();
 
   return useInfiniteQuery(
     ['search', datasearchType, luceneParams],

--- a/packages/datagateway-common/src/api/retryICATErrors.ts
+++ b/packages/datagateway-common/src/api/retryICATErrors.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import { useQueryClient } from 'react-query';
 
-export const createRetryICATErrors = (
+const createRetryICATErrors = (
   retries: number
 ): ((failureCount: number, error: AxiosError) => boolean) => {
   return (failureCount: number, error: AxiosError) =>
@@ -26,7 +26,7 @@ const baseRetryICATErrors = (
   return true;
 };
 
-const useRetryICATErrors = (): ((
+export const useRetryICATErrors = (): ((
   failureCount: number,
   error: AxiosError
 ) => boolean) => {
@@ -34,9 +34,12 @@ const useRetryICATErrors = (): ((
   const opts = queryClient.getDefaultOptions();
   // TODO: do we want to be more elegant in handling other types of retry...
   const retries =
-    typeof opts.queries?.retry === 'number' ? opts.queries.retry : 3;
+    typeof opts.queries?.retry === 'number'
+      ? opts.queries.retry
+      : // explicitly handle boolean case as we set this in tests
+      opts.queries?.retry === false
+      ? 0
+      : 3;
 
   return createRetryICATErrors(retries);
 };
-
-export { useRetryICATErrors };

--- a/packages/datagateway-common/src/api/retryICATErrors.ts
+++ b/packages/datagateway-common/src/api/retryICATErrors.ts
@@ -32,7 +32,7 @@ export const useRetryICATErrors = (): ((
 ) => boolean) => {
   const queryClient = useQueryClient();
   const opts = queryClient.getDefaultOptions();
-  // TODO: do we want to be more elegant in handling other types of retry...
+
   const retries =
     typeof opts.queries?.retry === 'number'
       ? opts.queries.retry

--- a/packages/datagateway-common/src/api/retryICATErrors.ts
+++ b/packages/datagateway-common/src/api/retryICATErrors.ts
@@ -1,6 +1,18 @@
 import { AxiosError } from 'axios';
+import { useQueryClient } from 'react-query';
 
-const retryICATErrors = (failureCount: number, error: AxiosError): boolean => {
+export const createRetryICATErrors = (
+  retries: number
+): ((failureCount: number, error: AxiosError) => boolean) => {
+  return (failureCount: number, error: AxiosError) =>
+    baseRetryICATErrors(failureCount, error, retries);
+};
+
+const baseRetryICATErrors = (
+  failureCount: number,
+  error: AxiosError,
+  retries: number
+): boolean => {
   const message =
     (error as AxiosError<{ message?: string }>).response?.data?.message ??
     error.message;
@@ -8,10 +20,23 @@ const retryICATErrors = (failureCount: number, error: AxiosError): boolean => {
     error.response?.status === 403 ||
     // TopCAT doesn't set 403 for session ID failure, so detect by looking at the message
     message.toUpperCase().includes('SESSION') ||
-    failureCount >= 3
+    failureCount >= retries
   )
     return false;
   return true;
 };
 
-export default retryICATErrors;
+const useRetryICATErrors = (): ((
+  failureCount: number,
+  error: AxiosError
+) => boolean) => {
+  const queryClient = useQueryClient();
+  const opts = queryClient.getDefaultOptions();
+  // TODO: do we want to be more elegant in handling other types of retry...
+  const retries =
+    typeof opts.queries?.retry === 'number' ? opts.queries.retry : 3;
+
+  return createRetryICATErrors(retries);
+};
+
+export { useRetryICATErrors };

--- a/packages/datagateway-common/src/index.tsx
+++ b/packages/datagateway-common/src/index.tsx
@@ -62,6 +62,7 @@ export {
 export { default as Sticky } from './sticky.component';
 export { default as DGThemeProvider } from './dgThemeProvider.component';
 export { default as Mark } from './mark.component';
+export * from './queryClientSettingsUpdater.component';
 
 export { default as HomePage } from './homePage/homePage.component';
 

--- a/packages/datagateway-common/src/index.tsx
+++ b/packages/datagateway-common/src/index.tsx
@@ -53,7 +53,7 @@ export type DGCommonState = StateType;
 
 export * from './parseTokens';
 export { default as handleICATError } from './handleICATError';
-export { default as retryICATErrors } from './api/retryICATErrors';
+export * from './api/retryICATErrors';
 
 export {
   default as ArrowTooltip,

--- a/packages/datagateway-common/src/queryClientSettingsUpdater.component.test.tsx
+++ b/packages/datagateway-common/src/queryClientSettingsUpdater.component.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import { initialState as dGCommonInitialState } from './state/reducers/dgcommon.reducer';
+import { StateType } from './state/app.types';
+import { createLocation } from 'history';
+import configureStore from 'redux-mock-store';
+import {
+  QueryClientSettingsUpdater,
+  QueryClientSettingsUpdaterRedux,
+} from './queryClientSettingsUpdater.component';
+
+describe('QueryClientSettingsUpdater', () => {
+  const renderComponent = (
+    queryRetries: number | undefined = undefined,
+    queryClient = new QueryClient()
+  ): RenderResult => {
+    function Wrapper({
+      children,
+    }: React.PropsWithChildren<unknown>): JSX.Element {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    }
+    return render(
+      <QueryClientSettingsUpdater
+        queryClient={queryClient}
+        queryRetries={queryRetries}
+      />,
+      {
+        wrapper: Wrapper,
+      }
+    );
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('syncs retry prop to query client when it updates', async () => {
+    const queryClient = new QueryClient({
+      // set random other option to check it doesn't get overridden
+      defaultOptions: { queries: { staleTime: 300000 } },
+    });
+    let queryRetries = 1;
+    const { rerender } = renderComponent(queryRetries, queryClient);
+
+    expect(queryClient.getDefaultOptions()).toEqual({
+      queries: { staleTime: 300000, retry: 1 },
+    });
+
+    queryRetries = 0;
+
+    rerender(
+      <QueryClientSettingsUpdater
+        queryClient={queryClient}
+        queryRetries={queryRetries}
+      />
+    );
+
+    expect(queryClient.getDefaultOptions()).toEqual({
+      queries: { staleTime: 300000, retry: 0 },
+    });
+  });
+});
+
+describe('QueryClientSettingsUpdaterRedux', () => {
+  const initialState: StateType = {
+    dgcommon: dGCommonInitialState,
+    router: {
+      action: 'POP',
+      location: { ...createLocation('/'), query: {} },
+    },
+  };
+  const renderComponent = (
+    state: StateType = initialState,
+    queryClient = new QueryClient()
+  ): RenderResult => {
+    const mockStore = configureStore([thunk]);
+    function Wrapper({
+      children,
+    }: React.PropsWithChildren<unknown>): JSX.Element {
+      return (
+        <Provider store={mockStore(state)}>
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        </Provider>
+      );
+    }
+    return render(
+      <QueryClientSettingsUpdaterRedux queryClient={queryClient} />,
+      {
+        wrapper: Wrapper,
+      }
+    );
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('syncs retry setting to query client when it updates', async () => {
+    const queryClient = new QueryClient({
+      // set random other option to check it doesn't get overridden
+      defaultOptions: { queries: { staleTime: 300000 } },
+    });
+    const { rerender } = renderComponent(initialState, queryClient);
+
+    initialState.dgcommon.queryRetries = 0;
+
+    rerender(<QueryClientSettingsUpdaterRedux queryClient={queryClient} />);
+
+    expect(queryClient.getDefaultOptions()).toEqual({
+      queries: { staleTime: 300000, retry: 0 },
+    });
+  });
+});

--- a/packages/datagateway-common/src/queryClientSettingsUpdater.component.tsx
+++ b/packages/datagateway-common/src/queryClientSettingsUpdater.component.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { QueryClient } from 'react-query';
+import { StateType } from './state/app.types';
+import { useSelector } from 'react-redux';
+
+export const QueryClientSettingsUpdater: React.FC<{
+  queryRetries: number | undefined;
+  queryClient: QueryClient;
+}> = (props) => {
+  const { queryClient, queryRetries } = props;
+
+  React.useEffect(() => {
+    if (typeof queryRetries !== 'undefined') {
+      const opts = queryClient.getDefaultOptions();
+      queryClient.setDefaultOptions({
+        ...opts,
+        queries: { ...opts.queries, retry: queryRetries },
+      });
+    }
+  }, [queryClient, queryRetries]);
+
+  return null;
+};
+
+export const QueryClientSettingsUpdaterRedux: React.FC<{
+  queryClient: QueryClient;
+}> = (props) => {
+  const { queryClient } = props;
+  const queryRetries = useSelector(
+    (state: StateType) => state.dgcommon.queryRetries
+  );
+
+  return (
+    <QueryClientSettingsUpdater
+      queryClient={queryClient}
+      queryRetries={queryRetries}
+    />
+  );
+};

--- a/packages/datagateway-common/src/setupTests.tsx
+++ b/packages/datagateway-common/src/setupTests.tsx
@@ -65,7 +65,7 @@ setLogger({
 // mock retry function to ensure it doesn't slow down query failure tests
 jest.mock('./api/retryICATErrors', () => ({
   __esModule: true,
-  default: jest.fn().mockReturnValue(false),
+  useRetryICATErrors: jest.fn(() => () => false),
 }));
 
 // Mock Date.toLocaleDateString so that it always uses en-GB as locale and UTC timezone

--- a/packages/datagateway-common/src/setupTests.tsx
+++ b/packages/datagateway-common/src/setupTests.tsx
@@ -94,9 +94,9 @@ export const createTestQueryClient = (): QueryClient =>
   });
 
 export const createReactQueryWrapper = (
-  history: History = createMemoryHistory()
+  history: History = createMemoryHistory(),
+  queryClient: QueryClient = createTestQueryClient()
 ): WrapperComponent<unknown> => {
-  const testQueryClient = createTestQueryClient();
   const state = {
     dgcommon: {
       ...initialState,
@@ -115,7 +115,7 @@ export const createReactQueryWrapper = (
   const wrapper: WrapperComponent<unknown> = ({ children }) => (
     <Provider store={mockStore(state)}>
       <Router history={history}>
-        <QueryClientProvider client={testQueryClient}>
+        <QueryClientProvider client={queryClient}>
           {children}
         </QueryClientProvider>
       </Router>

--- a/packages/datagateway-common/src/state/actions/actions.types.tsx
+++ b/packages/datagateway-common/src/state/actions/actions.types.tsx
@@ -33,6 +33,7 @@ export const BroadcastSignOutType = `${CustomFrontendMessageType}:signout`;
 export const ConfigureFacilityNameType =
   'datagateway_common:configure_facility_name';
 export const ConfigureURLsType = 'datagateway_common:configure_urls';
+export const ConfigureQueryRetriesType = 'datagateway_common:configure_retries';
 
 export const SortTableType = 'datagateway_common:sort_table';
 export const FilterTableType = 'datagateway_common:filter_table';
@@ -270,6 +271,10 @@ export interface FeatureSwitches {}
 
 export interface ConfigureUrlsPayload {
   urls: URLs;
+}
+
+export interface ConfigureQueryRetriesPayload {
+  queryRetries?: number;
 }
 
 export interface URLs {

--- a/packages/datagateway-common/src/state/actions/index.tsx
+++ b/packages/datagateway-common/src/state/actions/index.tsx
@@ -2,6 +2,8 @@ import { ActionType } from '../app.types';
 import {
   ConfigureFacilityNamePayload,
   ConfigureFacilityNameType,
+  ConfigureQueryRetriesPayload,
+  ConfigureQueryRetriesType,
   ConfigureUrlsPayload,
   ConfigureURLsType,
   URLs,
@@ -20,5 +22,14 @@ export const loadUrls = (urls: URLs): ActionType<ConfigureUrlsPayload> => ({
   type: ConfigureURLsType,
   payload: {
     urls,
+  },
+});
+
+export const loadQueryRetries = (
+  queryRetries?: number
+): ActionType<ConfigureQueryRetriesPayload> => ({
+  type: ConfigureQueryRetriesType,
+  payload: {
+    queryRetries,
   },
 });

--- a/packages/datagateway-common/src/state/app.types.tsx
+++ b/packages/datagateway-common/src/state/app.types.tsx
@@ -18,6 +18,7 @@ import type { URLs } from './actions/actions.types';
 export interface DGCommonState {
   facilityName: string;
   urls: URLs;
+  queryRetries?: number;
   isisDatafileDetailsPanel: Record<
     Datafile['id'],
     {

--- a/packages/datagateway-common/src/state/reducers/dgcommon.reducer.test.tsx
+++ b/packages/datagateway-common/src/state/reducers/dgcommon.reducer.test.tsx
@@ -1,6 +1,6 @@
 import DGCommonReducer, { initialState } from './dgcommon.reducer';
 import { DGCommonState } from '../app.types';
-import { loadFacilityName, loadUrls } from '../actions';
+import { loadFacilityName, loadQueryRetries, loadUrls } from '../actions';
 
 describe('DGCommon reducer', () => {
   let state: DGCommonState;
@@ -35,5 +35,13 @@ describe('DGCommon reducer', () => {
     );
 
     expect(updatedState.urls.apiUrl).toEqual('test');
+  });
+
+  it('should set query retry property when configure query retry action is sent', () => {
+    expect(state.queryRetries).toEqual(undefined);
+
+    const updatedState = DGCommonReducer(state, loadQueryRetries(1));
+
+    expect(updatedState.queryRetries).toEqual(1);
   });
 });

--- a/packages/datagateway-common/src/state/reducers/dgcommon.reducer.tsx
+++ b/packages/datagateway-common/src/state/reducers/dgcommon.reducer.tsx
@@ -1,6 +1,8 @@
 import {
   ConfigureFacilityNamePayload,
   ConfigureFacilityNameType,
+  ConfigureQueryRetriesPayload,
+  ConfigureQueryRetriesType,
   ConfigureUrlsPayload,
   ConfigureURLsType,
   DlsDatasetDetailsPanelChangeTabPayload,
@@ -52,6 +54,16 @@ export function handleConfigureUrls(
   return {
     ...state,
     urls: payload.urls,
+  };
+}
+
+export function handleConfigureQueryRetries(
+  state: DGCommonState,
+  payload: ConfigureQueryRetriesPayload
+): DGCommonState {
+  return {
+    ...state,
+    queryRetries: payload.queryRetries,
   };
 }
 
@@ -154,6 +166,7 @@ export function changeDlsVisitDetailsPanelTab(
 const dGCommonReducer = createReducer(initialState, {
   [ConfigureFacilityNameType]: handleConfigureFacilityName,
   [ConfigureURLsType]: handleConfigureUrls,
+  [ConfigureQueryRetriesType]: handleConfigureQueryRetries,
   [IsisDatafileDetailsPanelChangeTabType]: changeIsisDatafileDetailsPanelTab,
   [IsisDatasetDetailsPanelChangeTabType]: changeIsisDatasetDetailsPanelTab,
   [IsisInstrumentDetailsPanelChangeTabType]:

--- a/packages/datagateway-dataview/src/App.test.tsx
+++ b/packages/datagateway-dataview/src/App.test.tsx
@@ -1,9 +1,22 @@
 import * as React from 'react';
-import App from './App';
+import App, { QueryClientSettingUpdater } from './App';
 import log from 'loglevel';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+  type RenderResult,
+} from '@testing-library/react';
 import PageContainer from './page/pageContainer.component';
 import { configureApp, settingsLoaded } from './state/actions';
+import { StateType } from './state/app.types';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { dGCommonInitialState } from 'datagateway-common';
+import { initialState as dgDataViewInitialState } from './state/reducers/dgdataview.reducer';
+import { createLocation } from 'history';
 
 jest
   .mock('loglevel')
@@ -77,5 +90,56 @@ describe('App', () => {
 
     // check that fallback UI is shown
     expect(await screen.findByText('app.error')).toBeInTheDocument();
+  });
+});
+
+describe('QueryClientSettingUpdater', () => {
+  const initialState: StateType = {
+    dgcommon: dGCommonInitialState,
+    dgdataview: dgDataViewInitialState,
+    router: {
+      action: 'POP',
+      location: { ...createLocation('/'), query: {} },
+    },
+  };
+  const renderComponent = (
+    state: StateType = initialState,
+    queryClient = new QueryClient()
+  ): RenderResult => {
+    const mockStore = configureStore([thunk]);
+    function Wrapper({
+      children,
+    }: React.PropsWithChildren<unknown>): JSX.Element {
+      return (
+        <Provider store={mockStore(state)}>
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        </Provider>
+      );
+    }
+    return render(<QueryClientSettingUpdater queryClient={queryClient} />, {
+      wrapper: Wrapper,
+    });
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('syncs retry setting to query client when it updates', async () => {
+    const queryClient = new QueryClient({
+      // set random other option to check it doesn't get overridden
+      defaultOptions: { queries: { staleTime: 300000 } },
+    });
+    const { rerender } = renderComponent(initialState, queryClient);
+
+    initialState.dgcommon.queryRetries = 0;
+
+    rerender(<QueryClientSettingUpdater queryClient={queryClient} />);
+
+    expect(queryClient.getDefaultOptions()).toEqual({
+      queries: { staleTime: 300000, retry: 0 },
+    });
   });
 });

--- a/packages/datagateway-dataview/src/App.test.tsx
+++ b/packages/datagateway-dataview/src/App.test.tsx
@@ -1,22 +1,9 @@
 import * as React from 'react';
-import App, { QueryClientSettingUpdater } from './App';
+import App from './App';
 import log from 'loglevel';
-import {
-  render,
-  screen,
-  waitFor,
-  type RenderResult,
-} from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import PageContainer from './page/pageContainer.component';
 import { configureApp, settingsLoaded } from './state/actions';
-import { StateType } from './state/app.types';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-import { QueryClient, QueryClientProvider } from 'react-query';
-import { dGCommonInitialState } from 'datagateway-common';
-import { initialState as dgDataViewInitialState } from './state/reducers/dgdataview.reducer';
-import { createLocation } from 'history';
 
 jest
   .mock('loglevel')
@@ -90,56 +77,5 @@ describe('App', () => {
 
     // check that fallback UI is shown
     expect(await screen.findByText('app.error')).toBeInTheDocument();
-  });
-});
-
-describe('QueryClientSettingUpdater', () => {
-  const initialState: StateType = {
-    dgcommon: dGCommonInitialState,
-    dgdataview: dgDataViewInitialState,
-    router: {
-      action: 'POP',
-      location: { ...createLocation('/'), query: {} },
-    },
-  };
-  const renderComponent = (
-    state: StateType = initialState,
-    queryClient = new QueryClient()
-  ): RenderResult => {
-    const mockStore = configureStore([thunk]);
-    function Wrapper({
-      children,
-    }: React.PropsWithChildren<unknown>): JSX.Element {
-      return (
-        <Provider store={mockStore(state)}>
-          <QueryClientProvider client={queryClient}>
-            {children}
-          </QueryClientProvider>
-        </Provider>
-      );
-    }
-    return render(<QueryClientSettingUpdater queryClient={queryClient} />, {
-      wrapper: Wrapper,
-    });
-  };
-
-  beforeEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('syncs retry setting to query client when it updates', async () => {
-    const queryClient = new QueryClient({
-      // set random other option to check it doesn't get overridden
-      defaultOptions: { queries: { staleTime: 300000 } },
-    });
-    const { rerender } = renderComponent(initialState, queryClient);
-
-    initialState.dgcommon.queryRetries = 0;
-
-    rerender(<QueryClientSettingUpdater queryClient={queryClient} />);
-
-    expect(queryClient.getDefaultOptions()).toEqual({
-      queries: { staleTime: 300000, retry: 0 },
-    });
   });
 });

--- a/packages/datagateway-dataview/src/App.tsx
+++ b/packages/datagateway-dataview/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Preloader,
   BroadcastSignOutType,
   RequestPluginRerenderType,
+  QueryClientSettingsUpdaterRedux,
 } from 'datagateway-common';
 import {
   createBrowserHistory,
@@ -17,7 +18,7 @@ import {
 import log from 'loglevel';
 import React from 'react';
 import { Translation } from 'react-i18next';
-import { batch, connect, Provider, useSelector } from 'react-redux';
+import { batch, connect, Provider } from 'react-redux';
 import { AnyAction, applyMiddleware, compose, createStore, Store } from 'redux';
 import { createLogger } from 'redux-logger';
 import thunk, { ThunkDispatch } from 'redux-thunk';
@@ -106,27 +107,6 @@ const queryClient = new QueryClient({
   },
 });
 
-export const QueryClientSettingUpdater: React.FC<{
-  queryClient: QueryClient;
-}> = (props) => {
-  const { queryClient } = props;
-  const queryRetries = useSelector(
-    (state: StateType) => state.dgcommon.queryRetries
-  );
-
-  React.useEffect(() => {
-    if (typeof queryRetries !== 'undefined') {
-      const opts = queryClient.getDefaultOptions();
-      queryClient.setDefaultOptions({
-        ...opts,
-        queries: { ...opts.queries, retry: queryRetries },
-      });
-    }
-  }, [queryClient, queryRetries]);
-
-  return null;
-};
-
 document.addEventListener(MicroFrontendId, (e) => {
   const action = (e as CustomEvent).detail;
   if (action.type === BroadcastSignOutType) {
@@ -205,7 +185,7 @@ class App extends React.Component<unknown, { hasError: boolean }> {
           <Provider store={this.store}>
             <ConnectedRouter history={history}>
               <QueryClientProvider client={queryClient}>
-                <QueryClientSettingUpdater queryClient={queryClient} />
+                <QueryClientSettingsUpdaterRedux queryClient={queryClient} />
                 <DGThemeProvider>
                   <ConnectedPreloader>
                     <React.Suspense

--- a/packages/datagateway-dataview/src/App.tsx
+++ b/packages/datagateway-dataview/src/App.tsx
@@ -17,7 +17,7 @@ import {
 import log from 'loglevel';
 import React from 'react';
 import { Translation } from 'react-i18next';
-import { batch, connect, Provider } from 'react-redux';
+import { batch, connect, Provider, useSelector } from 'react-redux';
 import { AnyAction, applyMiddleware, compose, createStore, Store } from 'redux';
 import { createLogger } from 'redux-logger';
 import thunk, { ThunkDispatch } from 'redux-thunk';
@@ -106,6 +106,27 @@ const queryClient = new QueryClient({
   },
 });
 
+export const QueryClientSettingUpdater: React.FC<{
+  queryClient: QueryClient;
+}> = (props) => {
+  const { queryClient } = props;
+  const queryRetries = useSelector(
+    (state: StateType) => state.dgcommon.queryRetries
+  );
+
+  React.useEffect(() => {
+    if (typeof queryRetries !== 'undefined') {
+      const opts = queryClient.getDefaultOptions();
+      queryClient.setDefaultOptions({
+        ...opts,
+        queries: { ...opts.queries, retry: queryRetries },
+      });
+    }
+  }, [queryClient, queryRetries]);
+
+  return null;
+};
+
 document.addEventListener(MicroFrontendId, (e) => {
   const action = (e as CustomEvent).detail;
   if (action.type === BroadcastSignOutType) {
@@ -184,6 +205,7 @@ class App extends React.Component<unknown, { hasError: boolean }> {
           <Provider store={this.store}>
             <ConnectedRouter history={history}>
               <QueryClientProvider client={queryClient}>
+                <QueryClientSettingUpdater queryClient={queryClient} />
                 <DGThemeProvider>
                   <ConnectedPreloader>
                     <React.Suspense

--- a/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
+++ b/packages/datagateway-dataview/src/page/breadcrumbs.component.tsx
@@ -13,7 +13,7 @@ import {
   handleICATError,
   parseSearchToQuery,
   readSciGatewayToken,
-  retryICATErrors,
+  useRetryICATErrors,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -81,6 +81,7 @@ const useEntityInformation = (
   const breadcrumbSettings = useSelector(
     (state: StateType) => state.dgdataview.breadcrumbSettings
   );
+  const retryICATErrors = useRetryICATErrors();
 
   const queryConfigs = React.useMemo(() => {
     const queryConfigs: UseQueryOptions<
@@ -187,7 +188,13 @@ const useEntityInformation = (
     }
 
     return queryConfigs;
-  }, [currentPathnames, landingPageEntities, breadcrumbSettings, apiUrl]);
+  }, [
+    currentPathnames,
+    landingPageEntities,
+    breadcrumbSettings,
+    retryICATErrors,
+    apiUrl,
+  ]);
 
   // useQueries doesn't allow us to specify type info, so ignore this line
   // since we strongly type the queries object anyway

--- a/packages/datagateway-dataview/src/settings.ts
+++ b/packages/datagateway-dataview/src/settings.ts
@@ -7,6 +7,7 @@ export interface DataviewSettings {
   downloadApiUrl: string;
   idsUrl: string;
   icatUrl: string;
+  queryRetries?: number;
   selectAllSetting?: boolean;
   facilityImageURL?: string;
   features?: never;

--- a/packages/datagateway-dataview/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-dataview/src/state/actions/actions.test.tsx
@@ -102,7 +102,7 @@ describe('Actions', () => {
       features: {},
       idsUrl: 'ids',
       apiUrl: 'api',
-      retries: 1,
+      queryRetries: 1,
       breadcrumbs: [
         {
           matchEntity: 'test',

--- a/packages/datagateway-dataview/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-dataview/src/state/actions/actions.test.tsx
@@ -16,7 +16,12 @@ import {
   ConfigureFacilityImageSettingType,
 } from './actions.types';
 import { actions, resetActions, dispatch, getState } from '../../setupTests';
-import { loadUrls, loadFacilityName } from 'datagateway-common';
+import {
+  loadUrls,
+  loadFacilityName,
+  loadQueryRetries,
+  ConfigureQueryRetriesType,
+} from 'datagateway-common';
 
 jest.mock('loglevel');
 
@@ -90,13 +95,14 @@ describe('Actions', () => {
     });
   });
 
-  it('settings are loaded and facilityName, loadFeatureSwitches, loadUrls, loadBreadcrumbSettings, loadSelectAllSetting and settingsLoaded actions are sent', async () => {
+  it('settings are loaded and facilityName, loadFeatureSwitches, loadUrls, loadQueryRetries, loadBreadcrumbSettings, loadSelectAllSetting and settingsLoaded actions are sent', async () => {
     mockSettingsGetter.mockReturnValue({
       facilityName: 'Generic',
       facilityImageURL: 'test-image.jpg',
       features: {},
       idsUrl: 'ids',
       apiUrl: 'api',
+      retries: 1,
       breadcrumbs: [
         {
           matchEntity: 'test',
@@ -117,7 +123,7 @@ describe('Actions', () => {
     const asyncAction = configureApp();
     await asyncAction(dispatch, getState, null);
 
-    expect(actions.length).toEqual(8);
+    expect(actions.length).toEqual(9);
     expect(actions).toContainEqual(loadFacilityName('Generic'));
     expect(actions).toContainEqual(loadFacilityImageSetting('test-image.jpg'));
     expect(actions).toContainEqual(loadFeatureSwitches({}));
@@ -142,9 +148,10 @@ describe('Actions', () => {
     expect(actions).toContainEqual(
       loadPluginHostSetting('http://localhost:3000/')
     );
+    expect(actions).toContainEqual(loadQueryRetries(1));
   });
 
-  it("doesn't send loadSelectAllSetting, loadBreadcrumbSettings, loadPluginHostSetting, loadFacilityImageSetting and loadFeatureSwitches actions when they're not defined", async () => {
+  it("doesn't send loadQueryRetries, loadSelectAllSetting, loadBreadcrumbSettings, loadPluginHostSetting, loadFacilityImageSetting and loadFeatureSwitches actions when they're not defined", async () => {
     mockSettingsGetter.mockReturnValue({
       facilityName: 'Generic',
       idsUrl: 'ids',
@@ -170,6 +177,9 @@ describe('Actions', () => {
     ).toBe(true);
     expect(
       actions.every(({ type }) => type !== ConfigureFacilityImageSettingType)
+    ).toBe(true);
+    expect(
+      actions.every(({ type }) => type !== ConfigureQueryRetriesType)
     ).toBe(true);
 
     expect(actions).toContainEqual(settingsLoaded());

--- a/packages/datagateway-dataview/src/state/actions/index.tsx
+++ b/packages/datagateway-dataview/src/state/actions/index.tsx
@@ -14,7 +14,11 @@ import {
   ConfigureFacilityImageSettingPayload,
   ConfigureFacilityImageSettingType,
 } from './actions.types';
-import { loadUrls, loadFacilityName } from 'datagateway-common';
+import {
+  loadUrls,
+  loadFacilityName,
+  loadQueryRetries,
+} from 'datagateway-common';
 import { Action } from 'redux';
 import { settings } from '../../settings';
 
@@ -86,6 +90,10 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
           icatUrl: '', // we currently don't need icatUrl in dataview so just pass empty string for now
         })
       );
+
+      if (settingsResult?.['queryRetries'] !== undefined) {
+        dispatch(loadQueryRetries(settingsResult['queryRetries']));
+      }
 
       // Dispatch the action to load the breadcrumb settings (optional settings).
       if (settingsResult?.['breadcrumbs'] !== undefined) {

--- a/packages/datagateway-dataview/src/views/roleSelector.component.tsx
+++ b/packages/datagateway-dataview/src/views/roleSelector.component.tsx
@@ -11,7 +11,7 @@ import {
   InvestigationUser,
   parseSearchToQuery,
   readSciGatewayToken,
-  retryICATErrors,
+  useRetryICATErrors,
   StateType,
   usePushFilter,
 } from 'datagateway-common';
@@ -48,6 +48,7 @@ export const useRoles = (
   username: string
 ): UseQueryResult<string[], AxiosError> => {
   const apiUrl = useSelector((state: StateType) => state.dgcommon.urls.apiUrl);
+  const retryICATErrors = useRetryICATErrors();
 
   return useQuery<string[], AxiosError, string[], [string, string]>(
     ['roles', username],

--- a/packages/datagateway-download/src/App.test.tsx
+++ b/packages/datagateway-download/src/App.test.tsx
@@ -2,7 +2,7 @@ import { RenderResult, render } from '@testing-library/react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import App, { ErrorFallback, QueryClientSettingUpdater } from './App';
+import App, { ErrorFallback, QueryClientSettingsUpdaterContext } from './App';
 import { flushPromises } from './setupTests';
 import { mockedSettings } from './testData';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -32,7 +32,7 @@ describe('ErrorFallback', () => {
   });
 });
 
-describe('QueryClientSettingUpdater', () => {
+describe('QueryClientSettingUpdaterContext', () => {
   let settings = mockedSettings;
   const renderComponent = (queryClient = new QueryClient()): RenderResult => {
     function Wrapper({
@@ -46,9 +46,12 @@ describe('QueryClientSettingUpdater', () => {
         </DownloadSettingsContext.Provider>
       );
     }
-    return render(<QueryClientSettingUpdater queryClient={queryClient} />, {
-      wrapper: Wrapper,
-    });
+    return render(
+      <QueryClientSettingsUpdaterContext queryClient={queryClient} />,
+      {
+        wrapper: Wrapper,
+      }
+    );
   };
 
   beforeEach(() => {
@@ -65,7 +68,7 @@ describe('QueryClientSettingUpdater', () => {
 
     settings.queryRetries = 0;
 
-    rerender(<QueryClientSettingUpdater queryClient={queryClient} />);
+    rerender(<QueryClientSettingsUpdaterContext queryClient={queryClient} />);
 
     expect(queryClient.getDefaultOptions()).toEqual({
       queries: { staleTime: 300000, retry: 0 },

--- a/packages/datagateway-download/src/App.tsx
+++ b/packages/datagateway-download/src/App.tsx
@@ -14,6 +14,7 @@ import DOIGenerationForm from './DOIGenerationForm/DOIGenerationForm.component';
 import AdminDownloadStatusTable from './downloadStatus/adminDownloadStatusTable.component';
 
 import DownloadTabs from './downloadTab/downloadTab.component';
+import { QueryClientSettingsUpdater } from 'datagateway-common';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -24,23 +25,18 @@ const queryClient = new QueryClient({
   },
 });
 
-export const QueryClientSettingUpdater: React.FC<{
+export const QueryClientSettingsUpdaterContext: React.FC<{
   queryClient: QueryClient;
 }> = (props) => {
   const { queryClient } = props;
   const { queryRetries } = React.useContext(DownloadSettingsContext);
 
-  React.useEffect(() => {
-    if (typeof queryRetries !== 'undefined') {
-      const opts = queryClient.getDefaultOptions();
-      queryClient.setDefaultOptions({
-        ...opts,
-        queries: { ...opts.queries, retry: queryRetries },
-      });
-    }
-  }, [queryClient, queryRetries]);
-
-  return null;
+  return (
+    <QueryClientSettingsUpdater
+      queryClient={queryClient}
+      queryRetries={queryRetries}
+    />
+  );
 };
 
 /**
@@ -99,7 +95,7 @@ class App extends Component<unknown, { hasError: boolean }> {
         <DGThemeProvider>
           <ConfigProvider>
             <QueryClientProvider client={queryClient}>
-              <QueryClientSettingUpdater queryClient={queryClient} />
+              <QueryClientSettingsUpdaterContext queryClient={queryClient} />
               <React.Suspense
                 fallback={
                   <Preloader loading={true}>Finished loading</Preloader>

--- a/packages/datagateway-download/src/App.tsx
+++ b/packages/datagateway-download/src/App.tsx
@@ -9,7 +9,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter as Router, Link, Route, Switch } from 'react-router-dom';
 
-import ConfigProvider from './ConfigProvider';
+import ConfigProvider, { DownloadSettingsContext } from './ConfigProvider';
 import DOIGenerationForm from './DOIGenerationForm/DOIGenerationForm.component';
 import AdminDownloadStatusTable from './downloadStatus/adminDownloadStatusTable.component';
 
@@ -23,6 +23,25 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+export const QueryClientSettingUpdater: React.FC<{
+  queryClient: QueryClient;
+}> = (props) => {
+  const { queryClient } = props;
+  const { queryRetries } = React.useContext(DownloadSettingsContext);
+
+  React.useEffect(() => {
+    if (typeof queryRetries !== 'undefined') {
+      const opts = queryClient.getDefaultOptions();
+      queryClient.setDefaultOptions({
+        ...opts,
+        queries: { ...opts.queries, retry: queryRetries },
+      });
+    }
+  }, [queryClient, queryRetries]);
+
+  return null;
+};
 
 /**
  * A fallback component when the app fails to render.
@@ -80,6 +99,7 @@ class App extends Component<unknown, { hasError: boolean }> {
         <DGThemeProvider>
           <ConfigProvider>
             <QueryClientProvider client={queryClient}>
+              <QueryClientSettingUpdater queryClient={queryClient} />
               <React.Suspense
                 fallback={
                   <Preloader loading={true}>Finished loading</Preloader>

--- a/packages/datagateway-download/src/ConfigProvider.tsx
+++ b/packages/datagateway-download/src/ConfigProvider.tsx
@@ -17,6 +17,7 @@ export interface DownloadSettings {
   idsUrl: string;
   doiMinterUrl?: string;
   dataCiteUrl?: string;
+  queryRetries?: number;
 
   fileCountMax?: number;
   totalSizeMax?: number;

--- a/packages/datagateway-search/src/App.test.tsx
+++ b/packages/datagateway-search/src/App.test.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App, { QueryClientSettingUpdater } from './App';
+import App from './App';
 import log from 'loglevel';
-import { RenderResult, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { configureApp, settingsLoaded } from './state/actions';
-import { dGCommonInitialState } from 'datagateway-common';
-import { createLocation } from 'history';
-import { QueryClient, QueryClientProvider } from 'react-query';
-import { Provider } from 'react-redux';
-import thunk from 'redux-thunk';
-import configureStore from 'redux-mock-store';
-import { initialState as dgSearchInitialState } from './state/reducers/dgsearch.reducer';
-import { StateType } from './state/app.types';
 
 jest.mock('loglevel').mock('./state/actions', () => ({
   ...jest.requireActual('./state/actions'),
@@ -76,56 +68,5 @@ describe('App', () => {
 
     // check that fallback UI is shown
     expect(await screen.findByText('app.error')).toBeInTheDocument();
-  });
-});
-
-describe('QueryClientSettingUpdater', () => {
-  const initialState: StateType = {
-    dgcommon: dGCommonInitialState,
-    dgsearch: dgSearchInitialState,
-    router: {
-      action: 'POP',
-      location: { ...createLocation('/'), query: {} },
-    },
-  };
-  const renderComponent = (
-    state: StateType = initialState,
-    queryClient = new QueryClient()
-  ): RenderResult => {
-    const mockStore = configureStore([thunk]);
-    function Wrapper({
-      children,
-    }: React.PropsWithChildren<unknown>): JSX.Element {
-      return (
-        <Provider store={mockStore(state)}>
-          <QueryClientProvider client={queryClient}>
-            {children}
-          </QueryClientProvider>
-        </Provider>
-      );
-    }
-    return render(<QueryClientSettingUpdater queryClient={queryClient} />, {
-      wrapper: Wrapper,
-    });
-  };
-
-  beforeEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('syncs retry setting to query client when it updates', async () => {
-    const queryClient = new QueryClient({
-      // set random other option to check it doesn't get overridden
-      defaultOptions: { queries: { staleTime: 300000 } },
-    });
-    const { rerender } = renderComponent(initialState, queryClient);
-
-    initialState.dgcommon.queryRetries = 0;
-
-    rerender(<QueryClientSettingUpdater queryClient={queryClient} />);
-
-    expect(queryClient.getDefaultOptions()).toEqual({
-      queries: { staleTime: 300000, retry: 0 },
-    });
   });
 });

--- a/packages/datagateway-search/src/App.test.tsx
+++ b/packages/datagateway-search/src/App.test.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import App, { QueryClientSettingUpdater } from './App';
 import log from 'loglevel';
-import { render, screen, waitFor } from '@testing-library/react';
+import { RenderResult, render, screen, waitFor } from '@testing-library/react';
 import { configureApp, settingsLoaded } from './state/actions';
+import { dGCommonInitialState } from 'datagateway-common';
+import { createLocation } from 'history';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { initialState as dgSearchInitialState } from './state/reducers/dgsearch.reducer';
+import { StateType } from './state/app.types';
 
 jest.mock('loglevel').mock('./state/actions', () => ({
   ...jest.requireActual('./state/actions'),
@@ -68,5 +76,56 @@ describe('App', () => {
 
     // check that fallback UI is shown
     expect(await screen.findByText('app.error')).toBeInTheDocument();
+  });
+});
+
+describe('QueryClientSettingUpdater', () => {
+  const initialState: StateType = {
+    dgcommon: dGCommonInitialState,
+    dgsearch: dgSearchInitialState,
+    router: {
+      action: 'POP',
+      location: { ...createLocation('/'), query: {} },
+    },
+  };
+  const renderComponent = (
+    state: StateType = initialState,
+    queryClient = new QueryClient()
+  ): RenderResult => {
+    const mockStore = configureStore([thunk]);
+    function Wrapper({
+      children,
+    }: React.PropsWithChildren<unknown>): JSX.Element {
+      return (
+        <Provider store={mockStore(state)}>
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        </Provider>
+      );
+    }
+    return render(<QueryClientSettingUpdater queryClient={queryClient} />, {
+      wrapper: Wrapper,
+    });
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('syncs retry setting to query client when it updates', async () => {
+    const queryClient = new QueryClient({
+      // set random other option to check it doesn't get overridden
+      defaultOptions: { queries: { staleTime: 300000 } },
+    });
+    const { rerender } = renderComponent(initialState, queryClient);
+
+    initialState.dgcommon.queryRetries = 0;
+
+    rerender(<QueryClientSettingUpdater queryClient={queryClient} />);
+
+    expect(queryClient.getDefaultOptions()).toEqual({
+      queries: { staleTime: 300000, retry: 0 },
+    });
   });
 });

--- a/packages/datagateway-search/src/App.tsx
+++ b/packages/datagateway-search/src/App.tsx
@@ -16,7 +16,7 @@ import {
 } from 'history';
 import log from 'loglevel';
 import React from 'react';
-import { batch, connect, Provider } from 'react-redux';
+import { batch, connect, Provider, useSelector } from 'react-redux';
 import { AnyAction, applyMiddleware, compose, createStore, Store } from 'redux';
 import { createLogger } from 'redux-logger';
 import thunk, { ThunkDispatch } from 'redux-thunk';
@@ -99,6 +99,27 @@ const queryClient = new QueryClient({
   },
 });
 
+export const QueryClientSettingUpdater: React.FC<{
+  queryClient: QueryClient;
+}> = (props) => {
+  const { queryClient } = props;
+  const queryRetries = useSelector(
+    (state: StateType) => state.dgcommon.queryRetries
+  );
+
+  React.useEffect(() => {
+    if (typeof queryRetries !== 'undefined') {
+      const opts = queryClient.getDefaultOptions();
+      queryClient.setDefaultOptions({
+        ...opts,
+        queries: { ...opts.queries, retry: queryRetries },
+      });
+    }
+  }, [queryClient, queryRetries]);
+
+  return null;
+};
+
 document.addEventListener(MicroFrontendId, (e) => {
   const action = (e as CustomEvent).detail;
   if (action.type === BroadcastSignOutType) {
@@ -175,6 +196,7 @@ class App extends React.Component<unknown, { hasError: boolean }> {
           <Provider store={this.store}>
             <ConnectedRouter history={history}>
               <QueryClientProvider client={queryClient}>
+                <QueryClientSettingUpdater queryClient={queryClient} />
                 <DGThemeProvider>
                   <ConnectedPreloader>
                     <React.Suspense

--- a/packages/datagateway-search/src/App.tsx
+++ b/packages/datagateway-search/src/App.tsx
@@ -6,6 +6,7 @@ import {
   Preloader,
   BroadcastSignOutType,
   RequestPluginRerenderType,
+  QueryClientSettingsUpdaterRedux,
 } from 'datagateway-common';
 import {
   createBrowserHistory,
@@ -16,7 +17,7 @@ import {
 } from 'history';
 import log from 'loglevel';
 import React from 'react';
-import { batch, connect, Provider, useSelector } from 'react-redux';
+import { batch, connect, Provider } from 'react-redux';
 import { AnyAction, applyMiddleware, compose, createStore, Store } from 'redux';
 import { createLogger } from 'redux-logger';
 import thunk, { ThunkDispatch } from 'redux-thunk';
@@ -99,27 +100,6 @@ const queryClient = new QueryClient({
   },
 });
 
-export const QueryClientSettingUpdater: React.FC<{
-  queryClient: QueryClient;
-}> = (props) => {
-  const { queryClient } = props;
-  const queryRetries = useSelector(
-    (state: StateType) => state.dgcommon.queryRetries
-  );
-
-  React.useEffect(() => {
-    if (typeof queryRetries !== 'undefined') {
-      const opts = queryClient.getDefaultOptions();
-      queryClient.setDefaultOptions({
-        ...opts,
-        queries: { ...opts.queries, retry: queryRetries },
-      });
-    }
-  }, [queryClient, queryRetries]);
-
-  return null;
-};
-
 document.addEventListener(MicroFrontendId, (e) => {
   const action = (e as CustomEvent).detail;
   if (action.type === BroadcastSignOutType) {
@@ -196,7 +176,7 @@ class App extends React.Component<unknown, { hasError: boolean }> {
           <Provider store={this.store}>
             <ConnectedRouter history={history}>
               <QueryClientProvider client={queryClient}>
-                <QueryClientSettingUpdater queryClient={queryClient} />
+                <QueryClientSettingsUpdaterRedux queryClient={queryClient} />
                 <DGThemeProvider>
                   <ConnectedPreloader>
                     <React.Suspense

--- a/packages/datagateway-search/src/settings.ts
+++ b/packages/datagateway-search/src/settings.ts
@@ -6,6 +6,7 @@ export interface SearchSettings {
   downloadApiUrl: string;
   idsUrl: string;
   icatUrl: string;
+  queryRetries?: number;
   selectAllSetting?: boolean;
   searchableEntities?: string[];
   minNumResults?: number;

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -14,7 +14,12 @@ import {
   SettingsLoadedType,
 } from './actions.types';
 import { actions, resetActions, dispatch, getState } from '../../setupTests';
-import { loadUrls, loadFacilityName } from 'datagateway-common';
+import {
+  loadUrls,
+  loadFacilityName,
+  loadQueryRetries,
+  ConfigureQueryRetriesType,
+} from 'datagateway-common';
 
 const mockSettingsGetter = jest.fn();
 jest.mock('../../settings', () => ({
@@ -50,13 +55,14 @@ describe('Actions', () => {
     });
   });
 
-  it('settings are loaded and facilityName, loadUrls, loadSelectAllSetting, loadSearchableEntitites, loadMaxNumResults and settingsLoaded actions are sent', async () => {
+  it('settings are loaded and facilityName, loadUrls, loadQueryRetries, loadSelectAllSetting, loadSearchableEntitites, loadMaxNumResults and settingsLoaded actions are sent', async () => {
     mockSettingsGetter.mockReturnValue({
       facilityName: 'Generic',
       idsUrl: 'ids',
       apiUrl: 'api',
       downloadApiUrl: 'download-api',
       icatUrl: 'icat',
+      retries: 0,
       selectAllSetting: false,
       searchableEntities: ['investigation', 'dataset', 'datafile'],
       maxNumResults: 150,
@@ -64,7 +70,7 @@ describe('Actions', () => {
     const asyncAction = configureApp();
     await asyncAction(dispatch, getState, null);
 
-    expect(actions.length).toEqual(6);
+    expect(actions.length).toEqual(7);
     expect(actions).toContainEqual(loadFacilityName('Generic'));
     expect(actions).toContainEqual(
       loadUrls({
@@ -79,11 +85,12 @@ describe('Actions', () => {
       loadSearchableEntitites(['investigation', 'dataset', 'datafile'])
     );
     expect(actions).toContainEqual(loadMaxNumResults(150));
+    expect(actions).toContainEqual(loadQueryRetries(0));
 
     expect(actions).toContainEqual(settingsLoaded());
   });
 
-  it("doesn't send loadSelectAllSetting, loadSearchableEntitites and loadMaxNumResults actions when they're not defined", async () => {
+  it("doesn't send loadQueryRetries, loadSelectAllSetting, loadSearchableEntitites and loadMaxNumResults actions when they're not defined", async () => {
     mockSettingsGetter.mockReturnValue({
       facilityName: 'Generic',
       idsUrl: 'ids',
@@ -103,6 +110,9 @@ describe('Actions', () => {
     ).toBe(true);
     expect(
       actions.every(({ type }) => type !== ConfigureMaxNumResultsType)
+    ).toBe(true);
+    expect(
+      actions.every(({ type }) => type !== ConfigureQueryRetriesType)
     ).toBe(true);
 
     expect(actions).toContainEqual(settingsLoaded());

--- a/packages/datagateway-search/src/state/actions/actions.test.tsx
+++ b/packages/datagateway-search/src/state/actions/actions.test.tsx
@@ -62,7 +62,7 @@ describe('Actions', () => {
       apiUrl: 'api',
       downloadApiUrl: 'download-api',
       icatUrl: 'icat',
-      retries: 0,
+      queryRetries: 0,
       selectAllSetting: false,
       searchableEntities: ['investigation', 'dataset', 'datafile'],
       maxNumResults: 150,

--- a/packages/datagateway-search/src/state/actions/index.tsx
+++ b/packages/datagateway-search/src/state/actions/index.tsx
@@ -10,7 +10,11 @@ import {
   ConfigureMinNumResultsPayload,
   ConfigureMinNumResultsType,
 } from './actions.types';
-import { loadUrls, loadFacilityName } from 'datagateway-common';
+import {
+  loadUrls,
+  loadFacilityName,
+  loadQueryRetries,
+} from 'datagateway-common';
 import { Action } from 'redux';
 import { settings } from '../../settings';
 
@@ -68,6 +72,10 @@ export const configureApp = (): ThunkResult<Promise<void>> => {
           icatUrl: settingsResult['icatUrl'],
         })
       );
+
+      if (settingsResult?.['queryRetries'] !== undefined) {
+        dispatch(loadQueryRetries(settingsResult['queryRetries']));
+      }
 
       if (settingsResult?.['selectAllSetting'] !== undefined) {
         dispatch(loadSelectAllSetting(settingsResult['selectAllSetting']));


### PR DESCRIPTION
## Description
Adds a setting to all plugins that allows the sysadmin to set the react query query retry behaviour to whatever they want. I just let them set any number, including 0 to effectively disable retries even though setting false would have the same effect as keeping it as a number made typing easier.

This was requested by DLS as they have problems with queries timing out and they generally don't want to retry them, at the very least not 3 times like the current default. I opted away from limiting it to just problematic queries or from trying to figure out error messages indicating a query timeout and just made it a global config option.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage