### PR TITLE
Fix datagateway-download e2e tests broken by minting api update

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -332,7 +332,7 @@ jobs:
         run: echo DATACITE_PASSWORD=${{ secrets.DATACITE_PASSWORD }} >> ./.github/config.env
 
       - name: Run minting api
-        run: docker run --env-file ./.github/config.env -p 8000:8000 --add-host host.docker.internal:host-gateway -d harbor.stfc.ac.uk/icat/doi-mint-api      
+        run: docker run --env-file ./.github/config.env -p 8000:8000 --add-host host.docker.internal:host-gateway -d harbor.stfc.ac.uk/icat/doi-mint-api:v0.3.0      
 
       # E2E tests
       - name: Setup Node.js

--- a/packages/datagateway-download/cypress/e2e/DOIGenerationForm.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/DOIGenerationForm.cy.ts
@@ -159,9 +159,9 @@ describe('DOI Generation form', () => {
         'have.length',
         1
       );
-      cy.contains("No record found: name='invalid' in User").should(
-        'be.visible'
-      );
+      cy.contains(
+        'No record found: No ICAT User found with name invalid'
+      ).should('be.visible');
 
       cy.contains('button', 'Generate DOI').should('not.be.disabled');
     });


### PR DESCRIPTION
## Description
The minting api wasn't pinned in the CI (due to it only having tagged containers later in development than the original CI script) and so the release of v0.3.0 a couple of weeks ago broke the CI. I've now pinned the api to v0.3.0 and updated the broken test (just the format of an error message had changed)

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
