### PR TITLE
Remove libgconf install step on CI jobs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,10 +22,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
-        run: |
-          sudo apt-get install libgconf-2-4
-          yarn --immutable
+        run: yarn --immutable
 
       # Linting and unit testing
       - name: Run linting
@@ -174,10 +171,7 @@ jobs:
           cache: 'yarn'
      
       - name: Install dependencies
-        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
-        run: |
-          sudo apt-get install libgconf-2-4
-          yarn --immutable
+        run: yarn --immutable
 
       - name: Run datagateway-dataview e2e tests
         run: yarn workspace datagateway-dataview run e2e
@@ -342,10 +336,7 @@ jobs:
           cache: 'yarn'
       
       - name: Install dependencies
-        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
-        run: |
-          sudo apt-get install libgconf-2-4
-          yarn --immutable
+        run: yarn --immutable
 
       - name: Run datagateway-download e2e tests
         run: yarn workspace datagateway-download run e2e
@@ -475,10 +466,7 @@ jobs:
           cache: 'yarn'
      
       - name: Install dependencies
-        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
-        run: |
-          sudo apt-get install libgconf-2-4
-          yarn --immutable
+        run: yarn --immutable
 
       - name: Run datagateway-search e2e tests
         run: yarn workspace datagateway-search run e2e

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,10 +23,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
-        run: |
-          sudo apt-get install libgconf-2-4
-          yarn --immutable
+        run: yarn --immutable
 
       - name: Determine tag name
         run: |


### PR DESCRIPTION
## Description
Github changed the default machine from Ubuntu 22 to Ubuntu 24, which doesn't have libgconf-2-4. Equally, Cypress no longer needs this dependency so it can just be removed

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

