### PR TITLE
Fix missing investigation parameter labels

### DIFF
--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -130,6 +130,10 @@
         "name_other": "Samples",
         "no_samples": "No samples"
       },
+      "parameters": {
+        "label": "Investigation Parameters",
+        "no_parameters": "No parameters"
+      },
       "publications": {
         "label": "Publications",
         "reference_one": "Reference",

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -98,7 +98,8 @@
         "no_samples": "No samples"
       },
       "parameters": {
-        "label": "Investigation Parameters"
+        "label": "Investigation Parameters",
+        "no_parameters": "No parameters"
       },
       "publications": {
         "label": "Publications",


### PR DESCRIPTION
## Description
See title. When testing DLS preprod with v2 he raised that there was a missing `investigations.details.parameters.no_parameters` label. So filling in that missing label and a related label I noticed was missing.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
