### PR TITLE
Fix default filter on my data DLS table

### DIFF
--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -364,10 +364,11 @@ export const useSingleSort = (): ((
   );
 };
 
-export const usePushFilter = (
+const useFilter = (
+  updateMethod: UpdateMethod,
   filterPrefix?: string
 ): ((filterKey: string, filter: Filter | null) => void) => {
-  const { push } = useHistory();
+  const { push, replace } = useHistory();
 
   return React.useCallback(
     (filterKey: string, filter: Filter | null) => {
@@ -394,10 +395,24 @@ export const usePushFilter = (
           },
         };
       }
-      push({ search: `?${parseQueryToSearch(query).toString()}` });
+      (updateMethod === 'push' ? push : replace)({
+        search: `?${parseQueryToSearch(query).toString()}`,
+      });
     },
-    [filterPrefix, push]
+    [filterPrefix, push, replace, updateMethod]
   );
+};
+
+export const usePushFilter = (
+  filterPrefix?: string
+): ((filterKey: string, filter: Filter | null) => void) => {
+  return useFilter('push', filterPrefix);
+};
+
+export const useReplaceFilter = (
+  filterPrefix?: string
+): ((filterKey: string, filter: Filter | null) => void) => {
+  return useFilter('replace', filterPrefix);
 };
 
 export const usePushInvestigationFilter = (): ((

--- a/packages/datagateway-common/src/table/columnFilters/__snapshots__/dateColumnFilter.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/columnFilters/__snapshots__/dateColumnFilter.component.test.tsx.snap
@@ -189,3 +189,98 @@ exports[`Date filter component renders correctly 1`] = `
   </form>
 </DocumentFragment>
 `;
+
+exports[`Date filter component renders correctly with default values 1`] = `
+<DocumentFragment>
+  <form>
+    <div
+      class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+    >
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd css-1ptx2yq-MuiInputBase-root-MuiInput-root"
+      >
+        <input
+          aria-invalid="false"
+          aria-label="test filter from"
+          autocomplete="off"
+          class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1x51dt5-MuiInputBase-input-MuiInput-input"
+          id="test filter from"
+          inputmode="text"
+          placeholder="From..."
+          type="text"
+          value="1999-01-01"
+        />
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+        >
+          <button
+            aria-label="test filter from, date picker"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-1bkxqye-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CalendarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+    >
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd css-1ptx2yq-MuiInputBase-root-MuiInput-root"
+      >
+        <input
+          aria-invalid="false"
+          aria-label="test filter to"
+          autocomplete="off"
+          class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1x51dt5-MuiInputBase-input-MuiInput-input"
+          id="test filter to"
+          inputmode="text"
+          placeholder="To..."
+          type="text"
+          value="2000-01-01"
+        />
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+        >
+          <button
+            aria-label="test filter to, date picker"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-1bkxqye-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CalendarIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </form>
+</DocumentFragment>
+`;

--- a/packages/datagateway-common/src/table/columnFilters/__snapshots__/textColumnFilter.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/columnFilters/__snapshots__/textColumnFilter.component.test.tsx.snap
@@ -73,6 +73,79 @@ exports[`Text filter component renders correctly 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Text filter component renders correctly with default value 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
+      id="test-filter"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorSecondary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1o0voyd-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="true"
+        id="test-filter"
+      >
+        Include
+      </label>
+      <div
+        aria-hidden="true"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
+      >
+        <input
+          aria-invalid="false"
+          aria-label="Filter by test"
+          class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1x51dt5-MuiInputBase-input-MuiInput-input"
+          id="test-filter"
+          type="text"
+          value="test default value"
+        />
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary  css-4u4t8f-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="include, exclude or exact"
+              aria-labelledby="test-select-filter-type"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              id="test-select-filter-type"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="include"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="SettingsIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Text filter component usePrincipalExperimenterFilter hook returns a function which can generate a working PI filter 1`] = `
 <DocumentFragment>
   <div>

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.test.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.test.tsx
@@ -5,13 +5,12 @@ import DateColumnFilter, {
   useDateFilter,
 } from './dateColumnFilter.component';
 import { renderHook } from '@testing-library/react-hooks';
-import { act } from 'react-test-renderer';
 import { usePushFilter } from '../../api';
 import {
   applyDatePickerWorkaround,
   cleanupDatePickerWorkaround,
 } from '../../setupTests';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event/setup/setup';
 import userEvent from '@testing-library/user-event';
 
@@ -31,6 +30,21 @@ describe('Date filter component', () => {
     const { asFragment } = render(
       <DateColumnFilter
         value={{
+          startDate: '1999-01-01T00:00:00.000Z',
+          endDate: '2000-01-01T00:00:00.000Z',
+        }}
+        label="test"
+        onChange={jest.fn()}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders correctly with default values', () => {
+    const { asFragment } = render(
+      <DateColumnFilter
+        value={{}}
+        defaultFilter={{
           startDate: '1999-01-01T00:00:00.000Z',
           endDate: '2000-01-01T00:00:00.000Z',
         }}

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { format, isValid, isEqual, isBefore } from 'date-fns';
-import { FiltersType, DateFilter } from '../../app.types';
+import { FiltersType, DateFilter, Filter } from '../../app.types';
 import { usePushFilter } from '../../api';
 import { TextField, TextFieldProps } from '@mui/material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
@@ -69,6 +69,7 @@ interface DateColumnFilterProps {
   onChange: (value: { startDate?: string; endDate?: string } | null) => void;
   value: { startDate?: string; endDate?: string } | undefined;
   filterByTime?: boolean;
+  defaultFilter?: DateFilter;
 }
 
 const CustomTextField: React.FC<TextFieldProps> = (renderProps) => {
@@ -103,10 +104,18 @@ const CustomTextField: React.FC<TextFieldProps> = (renderProps) => {
 const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
   //Need state to change otherwise wont update error messages for an invalid date
   const [startDate, setStartDate] = useState(
-    props.value?.startDate ? new Date(props.value.startDate) : null
+    props.defaultFilter?.startDate
+      ? new Date(props.defaultFilter.startDate)
+      : props.value?.startDate
+      ? new Date(props.value.startDate)
+      : null
   );
   const [endDate, setEndDate] = useState(
-    props.value?.endDate ? new Date(props.value.endDate) : null
+    props.defaultFilter?.endDate
+      ? new Date(props.defaultFilter.endDate)
+      : props.value?.endDate
+      ? new Date(props.value.endDate)
+      : null
   );
 
   const invalidDateRange = startDate && endDate && isBefore(endDate, startDate);
@@ -292,16 +301,25 @@ export default DateColumnFilter;
 
 export const useDateFilter = (
   filters: FiltersType
-): ((label: string, dataKey: string) => React.ReactElement) => {
+): ((
+  label: string,
+  dataKey: string,
+  defaultFilter?: Filter
+) => React.ReactElement) => {
   const pushFilter = usePushFilter();
   return React.useMemo(() => {
-    const dateFilter = (label: string, dataKey: string): React.ReactElement => (
+    const dateFilter = (
+      label: string,
+      dataKey: string,
+      defaultFilter?: Filter
+    ): React.ReactElement => (
       <DateColumnFilter
         label={label}
         value={filters[dataKey] as DateFilter}
         onChange={(value: { startDate?: string; endDate?: string } | null) =>
           pushFilter(dataKey, value ? value : null)
         }
+        defaultFilter={defaultFilter as DateFilter}
       />
     );
     return dateFilter;

--- a/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.test.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.test.tsx
@@ -4,15 +4,14 @@ import TextColumnFilter, {
   useTextFilter,
   DEBOUNCE_DELAY,
 } from './textColumnFilter.component';
-import { act } from 'react-dom/test-utils';
 import { usePushFilter, usePushFilters } from '../../api';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { UserEvent } from '@testing-library/user-event/setup/setup';
 import userEvent from '@testing-library/user-event';
 
 jest.mock('../../api');
-jest.useFakeTimers('modern');
+jest.useFakeTimers();
 
 describe('Text filter component', () => {
   let user: UserEvent;
@@ -25,6 +24,18 @@ describe('Text filter component', () => {
     const { asFragment } = render(
       <TextColumnFilter
         value={{ value: 'test value', type: 'include' }}
+        label="test"
+        onChange={jest.fn()}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders correctly with default value', () => {
+    const { asFragment } = render(
+      <TextColumnFilter
+        value={{ value: undefined, type: 'include' }}
+        defaultFilter={{ value: 'test default value', type: 'include' }}
         label="test"
         onChange={jest.fn()}
       />

--- a/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
@@ -9,21 +9,24 @@ import {
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import debounce from 'lodash.debounce';
-import { FiltersType, TextFilter } from '../../app.types';
+import { Filter, FiltersType, TextFilter } from '../../app.types';
 import { usePushFilter, usePushFilters } from '../../api';
 
 const TextColumnFilter = (props: {
   label: string;
   onChange: (value: { value?: string | number; type: string } | null) => void;
   value: { value?: string | number; type: string } | undefined;
+  defaultFilter?: TextFilter;
 }): React.ReactElement => {
-  const { onChange, label } = props;
+  const { onChange, label, defaultFilter } = props;
   const { value: propValue, type: propType } = props.value ?? {};
 
   const [inputValue, setInputValue] = React.useState(
-    propValue ? propValue : ''
+    defaultFilter ? defaultFilter.value : propValue ? propValue : ''
   );
-  const [type, setType] = React.useState(propType ? propType : 'include');
+  const [type, setType] = React.useState(
+    defaultFilter ? defaultFilter.type : propType ? propType : 'include'
+  );
   // Debounce the updating of the column filter by 500 milliseconds.
   const updateValue = React.useMemo(
     () =>
@@ -134,16 +137,25 @@ export default TextColumnFilter;
 
 export const useTextFilter = (
   filters: FiltersType
-): ((label: string, dataKey: string) => React.ReactElement) => {
+): ((
+  label: string,
+  dataKey: string,
+  defaultFilter?: Filter
+) => React.ReactElement) => {
   const pushFilter = usePushFilter();
   return React.useMemo(() => {
-    const textFilter = (label: string, dataKey: string): React.ReactElement => (
+    const textFilter = (
+      label: string,
+      dataKey: string,
+      defaultFilter?: Filter
+    ): React.ReactElement => (
       <TextColumnFilter
         label={label}
         value={filters[dataKey] as TextFilter}
         onChange={(value: { value?: string | number; type: string } | null) =>
           pushFilter(dataKey, value ? value : null)
         }
+        defaultFilter={defaultFilter as TextFilter}
       />
     );
     return textFilter;

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
@@ -39,6 +39,7 @@ describe('Data column header component', () => {
   afterEach(() => {
     onSort.mockClear();
     resizeColumn.mockClear();
+    filterComponent.mockClear();
   });
 
   it('renders correctly without sort or filter', async () => {
@@ -117,7 +118,18 @@ describe('Data column header component', () => {
     });
   });
 
-  it('calls the onDefaultFilter method  and supplies default filter to filter component when default filter is specified', () => {
+  it('does not call the onSort method when default sort is specified but sort is not empty', () => {
+    render(
+      <DataHeader
+        {...dataHeaderProps}
+        defaultSort="asc"
+        sort={{ test: 'desc' }}
+      />
+    );
+    expect(onSort).not.toHaveBeenCalled();
+  });
+
+  it('calls the onDefaultFilter method and supplies default filter to filter component when default filter is specified', () => {
     const onDefaultFilter = jest.fn();
     render(
       <DataHeader
@@ -125,6 +137,7 @@ describe('Data column header component', () => {
         filterComponent={filterComponent}
         onDefaultFilter={onDefaultFilter}
         defaultFilter={{ type: 'include', value: 'x' }}
+        filters={{}}
       />
     );
     expect(onDefaultFilter).toHaveBeenCalledWith('test', {
@@ -135,6 +148,21 @@ describe('Data column header component', () => {
       type: 'include',
       value: 'x',
     });
+  });
+
+  it('does not call the onDefaultFilter method and not supply default filter to filter component when default filter is specified but filters is not empty', () => {
+    const onDefaultFilter = jest.fn();
+    render(
+      <DataHeader
+        {...dataHeaderProps}
+        filterComponent={filterComponent}
+        onDefaultFilter={onDefaultFilter}
+        defaultFilter={{ type: 'include', value: 'x' }}
+        filters={{ test: { type: 'exclude', value: 'y' } }}
+      />
+    );
+    expect(onDefaultFilter).not.toHaveBeenCalled();
+    expect(filterComponent).toHaveBeenCalledWith('Test', 'test', undefined);
   });
 
   describe('changes icons in the label', () => {

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.test.tsx
@@ -4,6 +4,7 @@ import type { UserEvent } from '@testing-library/user-event/setup/setup';
 import * as React from 'react';
 import DataHeader from './dataHeader.component';
 import TextColumnFilter from '../columnFilters/textColumnFilter.component';
+import { Filter } from '../../app.types';
 
 describe('Data column header component', () => {
   let user: UserEvent;
@@ -21,11 +22,14 @@ describe('Data column header component', () => {
     },
   };
 
-  const filterComponent = (
-    label: string,
-    dataKey: string
-  ): React.ReactElement => (
-    <TextColumnFilter label={label} onChange={jest.fn()} value={undefined} />
+  const filterComponent = jest.fn(
+    (
+      label: string,
+      dataKey: string,
+      defaultValue?: Filter
+    ): React.ReactElement => (
+      <TextColumnFilter label={label} onChange={jest.fn()} value={undefined} />
+    )
   );
 
   beforeEach(() => {
@@ -110,6 +114,26 @@ describe('Data column header component', () => {
     it('sets desc order', () => {
       render(<DataHeader {...dataHeaderProps} defaultSort="desc" />);
       expect(onSort).toHaveBeenCalledWith('test', 'desc', 'replace', false);
+    });
+  });
+
+  it('calls the onDefaultFilter method  and supplies default filter to filter component when default filter is specified', () => {
+    const onDefaultFilter = jest.fn();
+    render(
+      <DataHeader
+        {...dataHeaderProps}
+        filterComponent={filterComponent}
+        onDefaultFilter={onDefaultFilter}
+        defaultFilter={{ type: 'include', value: 'x' }}
+      />
+    );
+    expect(onDefaultFilter).toHaveBeenCalledWith('test', {
+      type: 'include',
+      value: 'x',
+    });
+    expect(filterComponent).toHaveBeenCalledWith('Test', 'test', {
+      type: 'include',
+      value: 'x',
     });
   });
 

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Filter, Order, UpdateMethod } from '../../app.types';
+import {
+  Filter,
+  FiltersType,
+  Order,
+  SortType,
+  UpdateMethod,
+} from '../../app.types';
 import { TableHeaderProps } from 'react-virtualized';
 import {
   TableCell,
@@ -18,7 +24,7 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 const DataHeader = (
   props: TableHeaderProps & {
     sx: SxProps;
-    sort: { [column: string]: Order };
+    sort: SortType;
     onSort: (
       column: string,
       order: Order | null,
@@ -37,6 +43,7 @@ const DataHeader = (
     shiftDown?: boolean;
     defaultFilter?: Filter;
     onDefaultFilter?: (column: string, filter: Filter | null) => void;
+    filters?: FiltersType;
   }
 ): React.ReactElement => {
   const {
@@ -54,25 +61,25 @@ const DataHeader = (
     shiftDown,
     defaultFilter,
     onDefaultFilter,
+    filters,
   } = props;
 
   const currSortDirection = sort[dataKey];
 
   const [hover, setHover] = React.useState(false);
 
+  const shouldApplyDefaultFilter =
+    typeof defaultFilter !== 'undefined' &&
+    typeof onDefaultFilter !== 'undefined' &&
+    typeof filters !== 'undefined' &&
+    Object.keys(filters).length === 0;
+
   //Apply default sort & filter on page load (but only if not already defined in URL params)
   //This will apply them in the order of the column definitions given to a table
   React.useEffect(() => {
-    if (
-      typeof defaultSort !== 'undefined' &&
-      typeof currSortDirection === 'undefined'
-    )
+    if (typeof defaultSort !== 'undefined' && Object.keys(sort).length === 0)
       onSort(dataKey, defaultSort, 'replace', false);
-    if (
-      typeof defaultFilter !== 'undefined' &&
-      typeof onDefaultFilter !== 'undefined'
-    )
-      onDefaultFilter(dataKey, defaultFilter);
+    if (shouldApplyDefaultFilter) onDefaultFilter(dataKey, defaultFilter);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -146,7 +153,11 @@ const DataHeader = (
           <Box marginRight={1}>{Icon && <Icon />}</Box>
           <Box>{inner}</Box>
         </Box>
-        {filterComponent?.(labelString, dataKey, defaultFilter)}
+        {filterComponent?.(
+          labelString,
+          dataKey,
+          shouldApplyDefaultFilter ? defaultFilter : undefined
+        )}
       </div>
       <Draggable
         axis="none"

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Order, UpdateMethod } from '../../app.types';
+import { Filter, Order, UpdateMethod } from '../../app.types';
 import { TableHeaderProps } from 'react-virtualized';
 import {
   TableCell,
@@ -28,9 +28,15 @@ const DataHeader = (
     resizeColumn: (dataKey: string, deltaX: number) => void;
     labelString: string;
     icon?: React.ComponentType<unknown>;
-    filterComponent?: (label: string, dataKey: string) => React.ReactElement;
+    filterComponent?: (
+      label: string,
+      dataKey: string,
+      defaultFilter?: Filter
+    ) => React.ReactElement;
     defaultSort?: Order;
     shiftDown?: boolean;
+    defaultFilter?: Filter;
+    onDefaultFilter?: (column: string, filter: Filter | null) => void;
   }
 ): React.ReactElement => {
   const {
@@ -46,17 +52,27 @@ const DataHeader = (
     icon: Icon,
     filterComponent,
     shiftDown,
+    defaultFilter,
+    onDefaultFilter,
   } = props;
 
   const currSortDirection = sort[dataKey];
 
   const [hover, setHover] = React.useState(false);
 
-  //Apply default sort on page load (but only if not already defined in URL params)
+  //Apply default sort & filter on page load (but only if not already defined in URL params)
   //This will apply them in the order of the column definitions given to a table
   React.useEffect(() => {
-    if (defaultSort !== undefined && currSortDirection === undefined)
+    if (
+      typeof defaultSort !== 'undefined' &&
+      typeof currSortDirection === 'undefined'
+    )
       onSort(dataKey, defaultSort, 'replace', false);
+    if (
+      typeof defaultFilter !== 'undefined' &&
+      typeof onDefaultFilter !== 'undefined'
+    )
+      onDefaultFilter(dataKey, defaultFilter);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -130,7 +146,7 @@ const DataHeader = (
           <Box marginRight={1}>{Icon && <Icon />}</Box>
           <Box>{inner}</Box>
         </Box>
-        {filterComponent?.(labelString, dataKey)}
+        {filterComponent?.(labelString, dataKey, defaultFilter)}
       </div>
       <Draggable
         axis="none"

--- a/packages/datagateway-common/src/table/table.component.test.tsx
+++ b/packages/datagateway-common/src/table/table.component.test.tsx
@@ -108,6 +108,34 @@ describe('Table component', () => {
     expect(onSort).toHaveBeenCalledWith('TEST2', 'asc', 'push', false);
   });
 
+  it('calls onDefaultFilter function when defaultFilter has been specified', () => {
+    const onDefaultFilter = jest.fn();
+    const sortedTableProps = {
+      ...tableProps,
+      columns: [
+        {
+          ...tableProps.columns[0],
+          defaultFilter: { value: 'x', type: 'include' },
+        },
+        {
+          ...tableProps.columns[1],
+          defaultFilter: { startDate: '2025-01-01', endDate: '2025-01-02' },
+        },
+      ],
+      onDefaultFilter,
+    };
+    render(<Table {...sortedTableProps} />);
+
+    expect(onDefaultFilter).toHaveBeenCalledWith('TEST1', {
+      value: 'x',
+      type: 'include',
+    });
+    expect(onDefaultFilter).toHaveBeenCalledWith('TEST2', {
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+    });
+  });
+
   it('renders select column correctly', async () => {
     render(
       <Table
@@ -226,6 +254,30 @@ describe('Table component', () => {
       render(<Table {...tableProps} loadMoreRows={undefined} />)
     ).toThrowError(
       'Only one of loadMoreRows and totalRowCount was defined - either define both for infinite loading functionality or neither for no infinite loading'
+    );
+
+    spy.mockRestore();
+  });
+
+  it('throws error when a default sort has been defined without passing onDefaultFilter', () => {
+    const spy = jest.spyOn(console, 'error');
+    spy.mockImplementation(() => {
+      // suppress react uncaught error warning as we're deliberately triggering an error!
+    });
+
+    const newTableProps = {
+      ...tableProps,
+      columns: [
+        {
+          ...tableProps.columns[0],
+          defaultFilter: { value: 'x', type: 'include' },
+        },
+      ],
+      onDefaultFilter: undefined,
+    };
+
+    expect(() => render(<Table {...newTableProps} />)).toThrowError(
+      'Column has a default filter prop but onDefaultFilter was not passed to Table - either pass onDefaultFilter function or remove defaultFilter from the column definition'
     );
 
     spy.mockRestore();

--- a/packages/datagateway-common/src/table/table.component.test.tsx
+++ b/packages/datagateway-common/src/table/table.component.test.tsx
@@ -123,6 +123,7 @@ describe('Table component', () => {
         },
       ],
       onDefaultFilter,
+      filters: {},
     };
     render(<Table {...sortedTableProps} />);
 
@@ -274,10 +275,36 @@ describe('Table component', () => {
         },
       ],
       onDefaultFilter: undefined,
+      filters: {},
     };
 
     expect(() => render(<Table {...newTableProps} />)).toThrowError(
-      'Column has a default filter prop but onDefaultFilter was not passed to Table - either pass onDefaultFilter function or remove defaultFilter from the column definition'
+      'Column has a default filter prop but onDefaultFilter or filters was not passed to Table - either pass onDefaultFilter function & filters or remove defaultFilter from the column definition'
+    );
+
+    spy.mockRestore();
+  });
+
+  it('throws error when a default sort has been defined without passing filters', () => {
+    const spy = jest.spyOn(console, 'error');
+    spy.mockImplementation(() => {
+      // suppress react uncaught error warning as we're deliberately triggering an error!
+    });
+
+    const newTableProps = {
+      ...tableProps,
+      columns: [
+        {
+          ...tableProps.columns[0],
+          defaultFilter: { value: 'x', type: 'include' },
+        },
+      ],
+      onDefaultFilter: jest.fn(),
+      filters: undefined,
+    };
+
+    expect(() => render(<Table {...newTableProps} />)).toThrowError(
+      'Column has a default filter prop but onDefaultFilter or filters was not passed to Table - either pass onDefaultFilter function & filters or remove defaultFilter from the column definition'
     );
 
     spy.mockRestore();

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -12,7 +12,15 @@ import {
   Index,
   TableRowRenderer,
 } from 'react-virtualized';
-import { Entity, Order, ICATEntity, UpdateMethod, Filter } from '../app.types';
+import {
+  Entity,
+  Order,
+  ICATEntity,
+  UpdateMethod,
+  Filter,
+  FiltersType,
+  SortType,
+} from '../app.types';
 import ExpandCell from './cellRenderers/expandCell.component';
 import DataCell from './cellRenderers/dataCell.component';
 import ActionCell from './cellRenderers/actionCell.component';
@@ -136,13 +144,14 @@ interface VirtualizedTableProps {
   columns: ColumnType[];
   loadMoreRows?: (offsetParams: IndexRange) => Promise<unknown>;
   totalRowCount?: number;
-  sort: { [column: string]: Order };
+  sort: SortType;
   onSort: (
     column: string,
     order: Order | null,
     updateMethod: UpdateMethod
   ) => void;
   onDefaultFilter?: (filterKey: string, filterValue: Filter | null) => void;
+  filters?: FiltersType;
   detailsPanel?: React.ComponentType<DetailsPanelProps>;
   actions?: React.ComponentType<TableActionProps>[];
   actionsWidth?: number;
@@ -181,6 +190,7 @@ const VirtualizedTable = React.memo(
       disableSelectAll,
       shortHeader,
       onDefaultFilter,
+      filters,
     } = props;
 
     // Format dates to be more readable
@@ -233,10 +243,10 @@ const VirtualizedTable = React.memo(
 
     if (
       columns.some((column) => column.defaultFilter) &&
-      typeof onDefaultFilter === 'undefined'
+      (typeof onDefaultFilter === 'undefined' || typeof filters === 'undefined')
     )
       throw new Error(
-        'Column has a default filter prop but onDefaultFilter was not passed to Table - either pass onDefaultFilter function or remove defaultFilter from the column definition'
+        'Column has a default filter prop but onDefaultFilter or filters was not passed to Table - either pass onDefaultFilter function & filters or remove defaultFilter from the column definition'
       );
 
     const [widthProps, setWidthProps] = React.useState<{
@@ -526,6 +536,7 @@ const VirtualizedTable = React.memo(
                               shiftDown={shiftDown}
                               defaultFilter={defaultFilter}
                               onDefaultFilter={onDefaultFilter}
+                              filters={filters}
                             />
                           )}
                           className={className}

--- a/packages/datagateway-common/src/table/table.component.tsx
+++ b/packages/datagateway-common/src/table/table.component.tsx
@@ -12,7 +12,7 @@ import {
   Index,
   TableRowRenderer,
 } from 'react-virtualized';
-import { Entity, Order, ICATEntity, UpdateMethod } from '../app.types';
+import { Entity, Order, ICATEntity, UpdateMethod, Filter } from '../app.types';
 import ExpandCell from './cellRenderers/expandCell.component';
 import DataCell from './cellRenderers/dataCell.component';
 import ActionCell from './cellRenderers/actionCell.component';
@@ -112,7 +112,12 @@ export interface ColumnType {
   className?: string;
   disableSort?: boolean;
   defaultSort?: Order;
-  filterComponent?: (label: string, dataKey: string) => React.ReactElement;
+  defaultFilter?: Filter;
+  filterComponent?: (
+    label: string,
+    dataKey: string,
+    defaultFilter?: Filter
+  ) => React.ReactElement;
 }
 
 export interface DetailsPanelProps {
@@ -137,6 +142,7 @@ interface VirtualizedTableProps {
     order: Order | null,
     updateMethod: UpdateMethod
   ) => void;
+  onDefaultFilter?: (filterKey: string, filterValue: Filter | null) => void;
   detailsPanel?: React.ComponentType<DetailsPanelProps>;
   actions?: React.ComponentType<TableActionProps>[];
   actionsWidth?: number;
@@ -174,6 +180,7 @@ const VirtualizedTable = React.memo(
       onSort,
       disableSelectAll,
       shortHeader,
+      onDefaultFilter,
     } = props;
 
     // Format dates to be more readable
@@ -222,6 +229,14 @@ const VirtualizedTable = React.memo(
     )
       throw new Error(
         'Only one of loadMoreRows and totalRowCount was defined - either define both for infinite loading functionality or neither for no infinite loading'
+      );
+
+    if (
+      columns.some((column) => column.defaultFilter) &&
+      typeof onDefaultFilter === 'undefined'
+    )
+      throw new Error(
+        'Column has a default filter prop but onDefaultFilter was not passed to Table - either pass onDefaultFilter function or remove defaultFilter from the column definition'
       );
 
     const [widthProps, setWidthProps] = React.useState<{
@@ -483,6 +498,7 @@ const VirtualizedTable = React.memo(
                         filterComponent,
                         disableSort,
                         defaultSort,
+                        defaultFilter,
                       },
                       index
                     ) => {
@@ -508,6 +524,8 @@ const VirtualizedTable = React.memo(
                               resizeColumn={resizeColumn}
                               defaultSort={defaultSort}
                               shiftDown={shiftDown}
+                              defaultFilter={defaultFilter}
+                              onDefaultFilter={onDefaultFilter}
                             />
                           )}
                           className={className}

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/myData.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/myData.cy.ts
@@ -27,6 +27,12 @@ describe('DLS - MyData Table', () => {
       //Default sort
       cy.get('[aria-sort="descending"]').should('exist');
       cy.get('.MuiTableSortLabel-iconDirectionDesc').should('be.visible');
+
+      // default filter
+      cy.get('input[id="Start Date filter to"]').should(
+        'have.value',
+        new Date().toISOString().split('T')[0]
+      );
     });
 
     it('should be able to click an investigation to see its datasets', () => {

--- a/packages/datagateway-dataview/public/datagateway-dataview-settings.example.json
+++ b/packages/datagateway-dataview/public/datagateway-dataview-settings.example.json
@@ -142,7 +142,7 @@
     },
     {
       "section": "Browse",
-      "link": "/my-data/DLS?filters={\"startDate\":{\"endDate\":\"2022-04-01\"}}&sort={\"startDate\":\"desc\"}",
+      "link": "/my-data/DLS?sort={\"startDate\":\"desc\"}",
       "displayName": "My Data DLS",
       "order": 5
     },

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.test.tsx
@@ -189,18 +189,27 @@ describe('DLS MyData table component', () => {
     ).toBeInTheDocument();
   });
 
-  it('sorts by startDate desc and filters startDate to be before the current date on load', () => {
+  it('sorts by startDate desc and filters startDate to be before the current date on load', async () => {
+    const replaceSpy = jest.spyOn(history, 'replace');
     renderComponent();
 
-    expect(history.length).toBe(2);
-    expect(history.entries[0].search).toBe(
-      `?sort=${encodeURIComponent(JSON.stringify({ startDate: 'desc' }))}`
-    );
-    expect(history.location.search).toBe(
-      `?filters=${encodeURIComponent(
+    expect(
+      screen.getByRole('textbox', {
+        name: 'investigations.start_date filter to',
+      })
+    ).toHaveValue('1970-01-01');
+
+    expect(replaceSpy).toHaveBeenCalledTimes(2);
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?filters=${encodeURIComponent(
         JSON.stringify({ startDate: { endDate: '1970-01-01' } })
-      )}`
-    );
+      )}`,
+    });
+    expect(replaceSpy).toHaveBeenCalledWith({
+      search: `?sort=${encodeURIComponent(
+        JSON.stringify({ startDate: 'desc' })
+      )}`,
+    });
   });
 
   it('updates filter query params on text filter', async () => {

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -8,11 +8,11 @@ import {
   useDateFilter,
   useInvestigationCount,
   useInvestigationsInfinite,
-  usePushFilter,
   useSort,
   useTextFilter,
   DLSVisitDetailsPanel,
   formatBytes,
+  useReplaceFilter,
 } from 'datagateway-common';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -47,8 +47,8 @@ const DLSMyDataTable = (): React.ReactElement => {
   ]);
 
   // isMounted is used to disable queries when the component isn't fully mounted.
-  // It prevents the request being sent twice if default sort is set.
-  // It is not needed for cards/tables that don't have default sort.
+  // It prevents the request being sent twice if default sort/filter is set.
+  // It is not needed for cards/tables that don't have default sort/filter.
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
     setIsMounted(true);
@@ -91,7 +91,7 @@ const DLSMyDataTable = (): React.ReactElement => {
   const textFilter = useTextFilter(filters);
   const dateFilter = useDateFilter(filters);
   const handleSort = useSort();
-  const pushFilter = usePushFilter();
+  const handleDefaultFilter = useReplaceFilter();
 
   const loadMoreRows = React.useCallback(
     (offsetParams: IndexRange) => fetchNextPage({ pageParam: offsetParams }),
@@ -158,6 +158,9 @@ const DLSMyDataTable = (): React.ReactElement => {
         dataKey: 'startDate',
         filterComponent: dateFilter,
         defaultSort: 'desc',
+        defaultFilter: {
+          endDate: `${new Date(Date.now()).toISOString().split('T')[0]}`,
+        },
       },
       {
         icon: CalendarToday,
@@ -170,16 +173,6 @@ const DLSMyDataTable = (): React.ReactElement => {
     [t, dateFilter, textFilter, view]
   );
 
-  React.useEffect(() => {
-    // Sort and filter by startDate upon load.
-    if (!('startDate' in filters))
-      pushFilter('startDate', {
-        endDate: `${new Date(Date.now()).toISOString().split('T')[0]}`,
-      });
-    // we only want this to run on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <Table
       data={aggregatedData}
@@ -187,6 +180,7 @@ const DLSMyDataTable = (): React.ReactElement => {
       totalRowCount={totalDataCount ?? 0}
       sort={sort}
       onSort={handleSort}
+      onDefaultFilter={handleDefaultFilter}
       detailsPanel={DLSVisitDetailsPanel}
       columns={columns}
     />

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.tsx
@@ -181,6 +181,7 @@ const DLSMyDataTable = (): React.ReactElement => {
       sort={sort}
       onSort={handleSort}
       onDefaultFilter={handleDefaultFilter}
+      filters={filters}
       detailsPanel={DLSVisitDetailsPanel}
       columns={columns}
     />


### PR DESCRIPTION
## Description
The default filter only partially worked right - because the datepickers have internal state, updating the filter as we did applied the filter i.e. to the search params in the URL & thus to react-query - but the date picker itself showed blank.

Thus I made the code similar to how `defaultSort` works - it's specified at the column definition level, and it gets passed to the filter components to ensure they initialise with the default value if provided.

Also removed the filtering query from the default JSON file as this was not dynamic and set the date to some point in 2022.

https://github.com/user-attachments/assets/0f52e4c5-d1e4-4252-89ce-4c7d42ef7b03

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Check default filtering in my data DLS table works correctly
