### PR TITLE
Improve styling, fix date picker locales & disable refetchOnWindowFocus for Lucene queries

### DIFF
--- a/packages/datagateway-common/src/api/lucene.tsx
+++ b/packages/datagateway-common/src/api/lucene.tsx
@@ -368,6 +368,7 @@ export const useLuceneSearchInfinite = (
       },
       retry: retryICATErrors,
       getNextPageParam: (lastPage, _) => lastPage.search_after,
+      refetchOnWindowFocus: false,
       ...(options ?? {}),
     }
   );

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -128,12 +128,10 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
   const theme = useTheme();
   const subTheme = createTheme(theme, {
     palette: {
-      primary: {
-        main:
-          theme.palette.mode === 'dark'
-            ? theme.palette.secondary.main
-            : theme.palette.primary.main,
-      },
+      primary:
+        theme.palette.mode === 'dark'
+          ? theme.palette.secondary
+          : theme.palette.primary,
     },
   });
 

--- a/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/dateColumnFilter.component.tsx
@@ -2,8 +2,15 @@ import React, { useState } from 'react';
 import { format, isValid, isEqual, isBefore } from 'date-fns';
 import { FiltersType, DateFilter } from '../../app.types';
 import { usePushFilter } from '../../api';
-import { TextField, TextFieldProps } from '@mui/material';
+import {
+  TextField,
+  TextFieldProps,
+  ThemeProvider,
+  createTheme,
+  useTheme,
+} from '@mui/material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { enGB } from 'date-fns/locale';
 import {
   DatePicker,
   DateTimePicker,
@@ -116,174 +123,193 @@ const DateColumnFilter = (props: DateColumnFilterProps): React.ReactElement => {
     DateTimeValidationError | DateValidationError | null
   >(null);
 
+  // can't set the main colour to secondary the "normal" MUI way, so have a sub-theme
+  // to override the primary colour for the date pickers
+  const theme = useTheme();
+  const subTheme = createTheme(theme, {
+    palette: {
+      primary: {
+        main:
+          theme.palette.mode === 'dark'
+            ? theme.palette.secondary.main
+            : theme.palette.primary.main,
+      },
+    },
+  });
+
   return (
     <form>
-      {props.filterByTime ? (
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <DateTimePicker
-            format="yyyy-MM-dd HH:mm:ss"
-            views={['year', 'month', 'day', 'hours', 'minutes', 'seconds']}
-            value={startDate}
-            maxDate={endDate || new Date('2100-01-01 00:00:00')}
-            onChange={(date) => {
-              setStartDate(date as Date);
-              updateFilter({
-                date: date as Date,
-                prevDate: startDate,
-                otherDate: endDate,
-                startDateOrEndDateChanged: 'startDate',
-                onChange: props.onChange,
-                filterByTime: true,
-              });
-            }}
-            // Catch error messages for helper text
-            onError={(newError) => setError(newError)}
-            slots={{
-              textField: CustomTextField,
-            }}
-            slotProps={{
-              actionBar: {
-                actions: ['clear'],
-              },
-              textField: {
-                inputProps: {
-                  invalidDateRange: invalidDateRange,
-                  errorText: errorText,
-                  filterByTime: props.filterByTime,
-                  id: props.label + ' filter from',
-                  placeholder: 'From...',
-                  'aria-label': `${props.label} filter from`,
-                },
-              },
-              openPickerButton: {
-                size: 'small',
-                'aria-label': `${props.label} filter from, date-time picker`,
-              },
-            }}
-          />
-          <DateTimePicker
-            format="yyyy-MM-dd HH:mm:ss"
-            views={['year', 'month', 'day', 'hours', 'minutes', 'seconds']}
-            value={endDate}
-            minDate={startDate || new Date('1984-01-01 00:00:00')}
-            onChange={(date) => {
-              setEndDate(date as Date);
-              updateFilter({
-                date: date as Date,
-                prevDate: endDate,
-                otherDate: startDate,
-                startDateOrEndDateChanged: 'endDate',
-                onChange: props.onChange,
-                filterByTime: true,
-              });
-            }}
-            onError={(newError) => setError(newError)}
-            slots={{
-              textField: CustomTextField,
-            }}
-            slotProps={{
-              actionBar: {
-                actions: ['clear'],
-              },
-              textField: {
-                inputProps: {
-                  invalidDateRange,
-                  errorText,
-                  filterByTime: props.filterByTime,
-                  id: props.label + ' filter to',
-                  placeholder: 'To...',
-                  'aria-label': `${props.label} filter to`,
-                },
-              },
-              openPickerButton: {
-                size: 'small',
-                'aria-label': `${props.label} filter to, date-time picker`,
-              },
-            }}
-          />
+      <ThemeProvider theme={subTheme}>
+        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={enGB}>
+          {props.filterByTime ? (
+            <>
+              <DateTimePicker
+                format="yyyy-MM-dd HH:mm:ss"
+                views={['year', 'month', 'day', 'hours', 'minutes', 'seconds']}
+                value={startDate}
+                maxDate={endDate || new Date('2100-01-01 00:00:00')}
+                onChange={(date) => {
+                  setStartDate(date as Date);
+                  updateFilter({
+                    date: date as Date,
+                    prevDate: startDate,
+                    otherDate: endDate,
+                    startDateOrEndDateChanged: 'startDate',
+                    onChange: props.onChange,
+                    filterByTime: true,
+                  });
+                }}
+                // Catch error messages for helper text
+                onError={(newError) => setError(newError)}
+                slots={{
+                  textField: CustomTextField,
+                }}
+                slotProps={{
+                  actionBar: {
+                    actions: ['clear'],
+                  },
+                  textField: {
+                    inputProps: {
+                      invalidDateRange: invalidDateRange,
+                      errorText: errorText,
+                      filterByTime: props.filterByTime,
+                      id: props.label + ' filter from',
+                      placeholder: 'From...',
+                      'aria-label': `${props.label} filter from`,
+                    },
+                    color: 'secondary',
+                  },
+                  openPickerButton: {
+                    size: 'small',
+                    'aria-label': `${props.label} filter from, date-time picker`,
+                  },
+                }}
+              />
+              <DateTimePicker
+                format="yyyy-MM-dd HH:mm:ss"
+                views={['year', 'month', 'day', 'hours', 'minutes', 'seconds']}
+                value={endDate}
+                minDate={startDate || new Date('1984-01-01 00:00:00')}
+                onChange={(date) => {
+                  setEndDate(date as Date);
+                  updateFilter({
+                    date: date as Date,
+                    prevDate: endDate,
+                    otherDate: startDate,
+                    startDateOrEndDateChanged: 'endDate',
+                    onChange: props.onChange,
+                    filterByTime: true,
+                  });
+                }}
+                onError={(newError) => setError(newError)}
+                slots={{
+                  textField: CustomTextField,
+                }}
+                slotProps={{
+                  actionBar: {
+                    actions: ['clear'],
+                  },
+                  textField: {
+                    inputProps: {
+                      invalidDateRange,
+                      errorText,
+                      filterByTime: props.filterByTime,
+                      id: props.label + ' filter to',
+                      placeholder: 'To...',
+                      'aria-label': `${props.label} filter to`,
+                    },
+                  },
+                  openPickerButton: {
+                    size: 'small',
+                    'aria-label': `${props.label} filter to, date-time picker`,
+                  },
+                }}
+              />
+            </>
+          ) : (
+            <>
+              <DatePicker
+                format="yyyy-MM-dd"
+                views={['year', 'month', 'day']}
+                value={startDate}
+                maxDate={endDate || new Date('2100-01-01 00:00:00')}
+                onChange={(date) => {
+                  setStartDate(date as Date);
+                  updateFilter({
+                    date: date as Date,
+                    prevDate: startDate,
+                    otherDate: endDate,
+                    startDateOrEndDateChanged: 'startDate',
+                    onChange: props.onChange,
+                  });
+                }}
+                onError={(newError) => setError(newError)}
+                slots={{
+                  textField: CustomTextField,
+                }}
+                slotProps={{
+                  actionBar: {
+                    actions: ['clear'],
+                  },
+                  textField: {
+                    inputProps: {
+                      invalidDateRange,
+                      errorText,
+                      filterByTime: props.filterByTime,
+                      id: props.label + ' filter from',
+                      placeholder: 'From...',
+                      'aria-label': `${props.label} filter from`,
+                    },
+                  },
+                  openPickerButton: {
+                    size: 'small',
+                    'aria-label': `${props.label} filter from, date picker`,
+                  },
+                }}
+              />
+              <DatePicker
+                format="yyyy-MM-dd"
+                views={['year', 'month', 'day']}
+                value={endDate}
+                minDate={startDate || new Date('1984-01-01 00:00:00')}
+                onChange={(date) => {
+                  setEndDate(date as Date);
+                  updateFilter({
+                    date: date as Date,
+                    prevDate: endDate,
+                    otherDate: startDate,
+                    startDateOrEndDateChanged: 'endDate',
+                    onChange: props.onChange,
+                  });
+                }}
+                onError={(newError) => setError(newError)}
+                slots={{
+                  textField: CustomTextField,
+                }}
+                slotProps={{
+                  actionBar: {
+                    actions: ['clear'],
+                  },
+                  textField: {
+                    inputProps: {
+                      invalidDateRange,
+                      errorText,
+                      filterByTime: props.filterByTime,
+                      id: props.label + ' filter to',
+                      placeholder: 'To...',
+                      'aria-label': `${props.label} filter to`,
+                    },
+                  },
+                  openPickerButton: {
+                    size: 'small',
+                    'aria-label': `${props.label} filter to, date picker`,
+                  },
+                }}
+              />
+            </>
+          )}
         </LocalizationProvider>
-      ) : (
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <DatePicker
-            format="yyyy-MM-dd"
-            views={['year', 'month', 'day']}
-            value={startDate}
-            maxDate={endDate || new Date('2100-01-01 00:00:00')}
-            onChange={(date) => {
-              setStartDate(date as Date);
-              updateFilter({
-                date: date as Date,
-                prevDate: startDate,
-                otherDate: endDate,
-                startDateOrEndDateChanged: 'startDate',
-                onChange: props.onChange,
-              });
-            }}
-            onError={(newError) => setError(newError)}
-            slots={{
-              textField: CustomTextField,
-            }}
-            slotProps={{
-              actionBar: {
-                actions: ['clear'],
-              },
-              textField: {
-                inputProps: {
-                  invalidDateRange,
-                  errorText,
-                  filterByTime: props.filterByTime,
-                  id: props.label + ' filter from',
-                  placeholder: 'From...',
-                  'aria-label': `${props.label} filter from`,
-                },
-              },
-              openPickerButton: {
-                size: 'small',
-                'aria-label': `${props.label} filter from, date picker`,
-              },
-            }}
-          />
-          <DatePicker
-            format="yyyy-MM-dd"
-            views={['year', 'month', 'day']}
-            value={endDate}
-            minDate={startDate || new Date('1984-01-01 00:00:00')}
-            onChange={(date) => {
-              setEndDate(date as Date);
-              updateFilter({
-                date: date as Date,
-                prevDate: endDate,
-                otherDate: startDate,
-                startDateOrEndDateChanged: 'endDate',
-                onChange: props.onChange,
-              });
-            }}
-            onError={(newError) => setError(newError)}
-            slots={{
-              textField: CustomTextField,
-            }}
-            slotProps={{
-              actionBar: {
-                actions: ['clear'],
-              },
-              textField: {
-                inputProps: {
-                  invalidDateRange,
-                  errorText,
-                  filterByTime: props.filterByTime,
-                  id: props.label + ' filter to',
-                  placeholder: 'To...',
-                  'aria-label': `${props.label} filter to`,
-                },
-              },
-              openPickerButton: {
-                size: 'small',
-                'aria-label': `${props.label} filter to, date picker`,
-              },
-            }}
-          />
-        </LocalizationProvider>
-      )}
+      </ThemeProvider>
     </form>
   );
 };

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -920,7 +920,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                               class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                             >
                               <div
-                                class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd css-1ptx2yq-MuiInputBase-root-MuiInput-root"
+                                class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                               >
                                 <input
                                   aria-invalid="false"

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
@@ -467,7 +467,7 @@ exports[`Download Status Table should render correctly 1`] = `
                         class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd css-1ptx2yq-MuiInputBase-root-MuiInput-root"
+                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                         >
                           <input
                             aria-invalid="false"

--- a/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/newParameterFilterCreator.component.tsx
+++ b/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/newParameterFilterCreator.component.tsx
@@ -155,6 +155,7 @@ function NewParameterFilterCreator({
           value={parameterName}
           onChange={(e) => changeParameterName(e.target.value)}
           label={t('parameterFilters.creator.labels.parameterNameSelect')}
+          color="secondary"
         >
           {parameterNames.map((param) => (
             <MenuItem key={param} value={param}>
@@ -169,6 +170,7 @@ function NewParameterFilterCreator({
           label={t('parameterFilters.creator.labels.parameterValueTypeSelect')}
           value={valueType}
           onChange={(e) => changeValueType(e.target.value)}
+          color="secondary"
         >
           {Object.values(PARAMETER_VALUE_TYPE).map((value) => (
             <MenuItem key={value} value={value}>

--- a/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/valueSelectors/parameterDateTimeSelector.component.tsx
+++ b/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/valueSelectors/parameterDateTimeSelector.component.tsx
@@ -120,6 +120,7 @@ function ParameterDateTimeSelector({
         label={t('parameterFilters.creator.labels.parameterDateTimeSelect')}
         data-testid="parameter-date-time-selector"
         value={selectedFacet?.label ?? ''}
+        color="secondary"
       >
         {facets.map((facet, index) => (
           <MenuItem

--- a/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/valueSelectors/parameterFacetList.component.tsx
+++ b/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/valueSelectors/parameterFacetList.component.tsx
@@ -79,6 +79,7 @@ function ParameterFacetList({
         label={t('parameterFilters.creator.labels.parameterStringSelect')}
         data-testid="parameter-facet-list"
         value={selectedFacet?.label ?? ''}
+        color="secondary"
       >
         {facets.map((facet, index) => (
           <MenuItem

--- a/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/valueSelectors/parameterNumericRange.component.tsx
+++ b/packages/datagateway-search/src/facet/components/facetPanel/parameterFilters/valueSelectors/parameterNumericRange.component.tsx
@@ -91,6 +91,7 @@ function ParameterNumericRange({
         }}
         aria-valuemax={Number(max)}
         onChange={onMinChange}
+        color="secondary"
       />
       <TextField
         fullWidth
@@ -105,6 +106,7 @@ function ParameterNumericRange({
           min: Number(min),
         }}
         onChange={onMaxChange}
+        color="secondary"
       />
       <TextField
         fullWidth
@@ -114,6 +116,7 @@ function ParameterNumericRange({
         id="parameter-numeric-range-unit"
         value={units}
         onChange={onUnitsChange}
+        color="secondary"
       />
     </Stack>
   );

--- a/packages/datagateway-search/src/search/checkBoxes.component.tsx
+++ b/packages/datagateway-search/src/search/checkBoxes.component.tsx
@@ -98,6 +98,7 @@ const CheckboxesGroup = (props: CheckBoxStoreProps): React.ReactElement => {
         className="tour-search-checkbox"
         sx={{ margin: 1, minWidth: '120px', maxWidth: '300px' }}
         variant="standard"
+        color="secondary"
       >
         {error && (
           <InputLabel

--- a/packages/datagateway-search/src/search/datePicker.component.tsx
+++ b/packages/datagateway-search/src/search/datePicker.component.tsx
@@ -9,9 +9,16 @@ import {
 } from 'datagateway-common';
 import { useLocation } from 'react-router-dom';
 import { isBefore, isValid } from 'date-fns';
-import { TextField, TextFieldProps } from '@mui/material';
+import {
+  TextField,
+  TextFieldProps,
+  ThemeProvider,
+  createTheme,
+  useTheme,
+} from '@mui/material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { enGB } from 'date-fns/locale';
 
 interface DatePickerProps {
   initiateSearch: () => void;
@@ -121,67 +128,92 @@ export function SelectDates(props: DatePickerCombinedProps): JSX.Element {
 
   const invalidDateRange = startDate && endDate && isBefore(endDate, startDate);
 
+  // can't set the main colour to secondary the "normal" MUI way, so have a sub-theme
+  // to override the primary colour for the date pickers
+  const theme = useTheme();
+  const subTheme = createTheme(theme, {
+    palette: {
+      primary: {
+        main:
+          theme.palette.mode === 'dark'
+            ? theme.palette.secondary.main
+            : theme.palette.primary.main,
+      },
+    },
+  });
+
   return (
     <div className="tour-search-dates">
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
-        <>
-          <DatePicker
-            format="yyyy-MM-dd"
-            views={['year', 'month', 'day']}
-            value={startDate}
-            maxDate={endDate || new Date()}
-            onChange={(date) => {
-              handleChange(date as Date, 'startDate');
-            }}
-            slots={{
-              textField: CustomTextField,
-            }}
-            slotProps={{
-              actionBar: {
-                actions: ['clear'],
-              },
-              textField: {
-                inputProps: {
-                  invalidDateRange,
-                  sideLayout,
-                  t: t,
-                  placeholder: t('searchBox.start_date'),
-                  'aria-label': t('searchBox.start_date_arialabel'),
+      <ThemeProvider theme={subTheme}>
+        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={enGB}>
+          <>
+            <DatePicker
+              format="yyyy-MM-dd"
+              views={['year', 'month', 'day']}
+              value={startDate}
+              maxDate={endDate || new Date()}
+              onChange={(date) => {
+                handleChange(date as Date, 'startDate');
+              }}
+              slots={{
+                textField: CustomTextField,
+              }}
+              slotProps={{
+                actionBar: {
+                  actions: ['clear'],
                 },
-                onKeyDown: handleKeyDown,
-              },
-            }}
-          />
-          {sideLayout ? <br></br> : null}
-          <DatePicker
-            format="yyyy-MM-dd"
-            views={['year', 'month', 'day']}
-            value={endDate}
-            minDate={startDate || new Date('1984-01-01T00:00:00Z')}
-            onChange={(date) => {
-              handleChange(date as Date, 'endDate');
-            }}
-            slots={{
-              textField: CustomTextField,
-            }}
-            slotProps={{
-              actionBar: {
-                actions: ['clear'],
-              },
-              textField: {
-                inputProps: {
-                  invalidDateRange,
-                  sideLayout,
-                  t: t,
-                  placeholder: t('searchBox.end_date'),
-                  'aria-label': t('searchBox.end_date_arialabel'),
+                textField: {
+                  inputProps: {
+                    invalidDateRange,
+                    sideLayout,
+                    t: t,
+                    placeholder: t('searchBox.start_date'),
+                    'aria-label': t('searchBox.start_date_arialabel'),
+                  },
+                  onKeyDown: handleKeyDown,
                 },
-                onKeyDown: handleKeyDown,
-              },
-            }}
-          />
-        </>
-      </LocalizationProvider>
+                layout: {
+                  sx: {
+                    '& .MuiPickersDay-root.Mui-selected': {
+                      '&:focus': {
+                        background: (theme) => theme.palette.primary.main,
+                      },
+                    },
+                  },
+                },
+              }}
+            />
+            {sideLayout ? <br></br> : null}
+            <DatePicker
+              format="yyyy-MM-dd"
+              views={['year', 'month', 'day']}
+              value={endDate}
+              minDate={startDate || new Date('1984-01-01T00:00:00Z')}
+              onChange={(date) => {
+                handleChange(date as Date, 'endDate');
+              }}
+              slots={{
+                textField: CustomTextField,
+              }}
+              slotProps={{
+                actionBar: {
+                  actions: ['clear'],
+                },
+                textField: {
+                  inputProps: {
+                    invalidDateRange,
+                    sideLayout,
+                    t: t,
+                    placeholder: t('searchBox.end_date'),
+                    'aria-label': t('searchBox.end_date_arialabel'),
+                  },
+                  onKeyDown: handleKeyDown,
+                },
+              }}
+            />
+          </>
+        </LocalizationProvider>
+      </ThemeProvider>
     </div>
   );
 }

--- a/packages/datagateway-search/src/search/datePicker.component.tsx
+++ b/packages/datagateway-search/src/search/datePicker.component.tsx
@@ -133,12 +133,10 @@ export function SelectDates(props: DatePickerCombinedProps): JSX.Element {
   const theme = useTheme();
   const subTheme = createTheme(theme, {
     palette: {
-      primary: {
-        main:
-          theme.palette.mode === 'dark'
-            ? theme.palette.secondary.main
-            : theme.palette.primary.main,
-      },
+      primary:
+        theme.palette.mode === 'dark'
+          ? theme.palette.secondary
+          : theme.palette.primary,
     },
   });
 
@@ -171,15 +169,6 @@ export function SelectDates(props: DatePickerCombinedProps): JSX.Element {
                     'aria-label': t('searchBox.start_date_arialabel'),
                   },
                   onKeyDown: handleKeyDown,
-                },
-                layout: {
-                  sx: {
-                    '& .MuiPickersDay-root.Mui-selected': {
-                      '&:focus': {
-                        background: (theme) => theme.palette.primary.main,
-                      },
-                    },
-                  },
                 },
               }}
             />

--- a/packages/datagateway-search/src/search/myDataCheckBox.component.tsx
+++ b/packages/datagateway-search/src/search/myDataCheckBox.component.tsx
@@ -35,6 +35,7 @@ const MyDataCheckBox = ({
           }}
           control={<Checkbox checked={checked} onChange={handleChange} />}
           label={t('check_boxes.my_data')}
+          color="secondary"
         />
       </div>
     </ArrowTooltip>

--- a/packages/datagateway-search/src/search/sortSelect.component.tsx
+++ b/packages/datagateway-search/src/search/sortSelect.component.tsx
@@ -44,6 +44,7 @@ const SortSelectComponent = (): React.ReactElement => {
           minWidth: 120,
           maxWidth: 300,
         }}
+        color="secondary"
       >
         <InputLabel variant="outlined" shrink={true} id="sort-select-label">
           {t('sort.label')}


### PR DESCRIPTION
## Description
See title, but basic issues were:

- Date pickers were defaulting to the US locale, which had days of the week Sun-Sat. Explicitly setting british locale means we get Mon-Sun
- Date pickers had some hard to see elements in darkmode
 - I also noticed some other parts of dg-search that had bad dark mode styling so also fixed those
- Search queries that timed out would retrigger once the user focused back on DG. This is an issue as long running queries can cause performance issues and if they time out the user should change their search not just resubmit. Just had to explicitly set `refetchOnWindowFocus` to false on Lucene queries.

I'll put up some screenshots showing the new styling in darkmode

![image](https://github.com/user-attachments/assets/9a1ad934-ef7e-40bb-ab78-447987717222)

![image](https://github.com/user-attachments/assets/e606b676-95bc-44a1-b93f-dcf54ef8e6a3)


![image](https://github.com/user-attachments/assets/f667ef79-ade6-490d-942d-d9fb50d2ed8a)


## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
