### PR TITLE
Fix exact filters & add is deleted filter

### DIFF
--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -249,21 +249,29 @@ export const getApiParams = (
           );
         }
         if ('type' in filter && filter.type) {
-          if (filter.type === 'include') {
-            searchParams.append(
-              'where',
-              JSON.stringify({ [column]: { ilike: filter.value } })
-            );
-          } else if (filter.type === 'exclude') {
-            searchParams.append(
-              'where',
-              JSON.stringify({ [column]: { nilike: filter.value } })
-            );
-          } else {
-            searchParams.append(
-              'where',
-              JSON.stringify({ [column]: { eq: filter.value } })
-            );
+          // use switch statement to ensure TS can detect we cover all cases
+          switch (filter.type) {
+            case 'include':
+              searchParams.append(
+                'where',
+                JSON.stringify({ [column]: { ilike: filter.value } })
+              );
+              break;
+            case 'exclude':
+              searchParams.append(
+                'where',
+                JSON.stringify({ [column]: { nilike: filter.value } })
+              );
+              break;
+            case 'exact':
+              searchParams.append(
+                'where',
+                JSON.stringify({ [column]: { eq: filter.value } })
+              );
+              break;
+            default:
+              const exhaustiveCheck: never = filter.type;
+              throw new Error(`Unhandled text filter type: ${exhaustiveCheck}`);
           }
         }
       } else {

--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -31,8 +31,6 @@ export interface Investigation {
   investigationInstruments?: InvestigationInstrument[];
   dataCollectionInvestigations?: DataCollectionInvestigation[];
   investigationFacilityCycles?: InvestigationFacilityCycle[];
-  size?: number;
-  datasetCount?: number;
   investigationUsers?: InvestigationUser[];
   samples?: Sample[];
   parameters?: DatafileParameter[];
@@ -55,8 +53,6 @@ export interface Dataset {
   doi?: string;
   complete?: boolean;
   location?: string;
-  size?: number;
-  datafileCount?: number;
   investigation?: Investigation;
   type?: DatasetType;
 }

--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -380,7 +380,7 @@ export interface DateFilter {
 
 export interface TextFilter {
   value?: string | number;
-  type: string;
+  type: 'include' | 'exclude' | 'exact';
 }
 
 export interface RangeFilter {

--- a/packages/datagateway-common/src/detailsPanels/datasetDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/datasetDetailsPanel.component.test.tsx
@@ -11,7 +11,7 @@ describe('Dataset details panel component', () => {
     rowData = {
       id: 1,
       name: 'Test 1',
-      size: 1,
+      fileSize: 1,
       modTime: '2019-07-23',
       createTime: '2019-07-23',
     };

--- a/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/dls/visitDetailsPanel.component.test.tsx
@@ -48,7 +48,6 @@ describe('Visit details panel component', () => {
       summary: 'foo bar',
       visitId: '1',
       doi: 'doi 1',
-      size: 1,
       fileSize: 64,
       fileCount: 1,
       investigationInstruments: [

--- a/packages/datagateway-common/src/detailsPanels/investigationDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/investigationDetailsPanel.component.test.tsx
@@ -16,7 +16,7 @@ describe('Investigation details panel component', () => {
       summary: 'foo bar',
       visitId: '1',
       doi: 'doi 1',
-      size: 1,
+      fileSize: 1,
       investigationInstruments: [
         {
           id: 1,

--- a/packages/datagateway-common/src/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
+++ b/packages/datagateway-common/src/detailsPanels/isis/investigationDetailsPanel.component.test.tsx
@@ -50,7 +50,7 @@ describe('Investigation details panel component', () => {
       summary: 'foo bar',
       visitId: '1',
       doi: 'doi 1',
-      size: 1,
+      fileSize: 1,
       investigationInstruments: [
         {
           id: 1,
@@ -76,8 +76,6 @@ describe('Investigation details panel component', () => {
                 id: 12,
                 pid: 'Data Publication Pid',
                 description: 'Data Publication description',
-                modTime: '2019-06-10',
-                createTime: '2019-06-11',
                 title: 'Data Publication',
                 type: {
                   id: 15,
@@ -102,8 +100,6 @@ describe('Investigation details panel component', () => {
                 id: 14,
                 pid: 'Data Publication Study Pid',
                 description: 'Data Publication description',
-                modTime: '2019-06-10',
-                createTime: '2019-06-11',
                 title: 'Data Publication Study',
                 type: {
                   id: 16,

--- a/packages/datagateway-common/src/table/columnFilters/__snapshots__/textColumnFilter.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/columnFilters/__snapshots__/textColumnFilter.component.test.tsx.snap
@@ -5,17 +5,15 @@ exports[`Text filter component renders correctly 1`] = `
   <div>
     <div
       class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-      id="test-filter"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorSecondary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1o0voyd-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        id="test-filter"
+        for="test-filter"
       >
         Include
       </label>
       <div
-        aria-hidden="true"
         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
       >
         <input
@@ -78,17 +76,15 @@ exports[`Text filter component renders correctly with default value 1`] = `
   <div>
     <div
       class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-      id="test-filter"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorSecondary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1o0voyd-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        id="test-filter"
+        for="test-filter"
       >
         Include
       </label>
       <div
-        aria-hidden="true"
         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
       >
         <input
@@ -151,17 +147,15 @@ exports[`Text filter component usePrincipalExperimenterFilter hook returns a fun
   <div>
     <div
       class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-      id="Principal Investigator-filter"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        id="Principal Investigator-filter"
+        for="Principal Investigator-filter"
       >
         Include
       </label>
       <div
-        aria-hidden="true"
         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
       >
         <input
@@ -224,17 +218,15 @@ exports[`Text filter component useTextFilter hook returns a function which can g
   <div>
     <div
       class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-      id="Name-filter"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        id="Name-filter"
+        for="Name-filter"
       >
         Include
       </label>
       <div
-        aria-hidden="true"
         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
       >
         <input

--- a/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.test.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.test.tsx
@@ -57,7 +57,6 @@ describe('Text filter component', () => {
     // We simulate a change in the input from 'test' to 'test-again'.
     const textFilterInput = await screen.findByRole('textbox', {
       name: 'Filter by test',
-      hidden: true,
     });
 
     await user.clear(textFilterInput);
@@ -86,7 +85,6 @@ describe('Text filter component', () => {
     // We simulate a change in the input from 'test' to 'test-again'.
     const textFilterInput = await screen.findByRole('textbox', {
       name: 'Filter by test',
-      hidden: true,
     });
 
     await user.clear(textFilterInput);
@@ -115,7 +113,6 @@ describe('Text filter component', () => {
     // We simulate a change in the input from 'test' to 'test-again'.
     const textFilterInput = await screen.findByRole('textbox', {
       name: 'Filter by test',
-      hidden: true,
     });
 
     await user.clear(textFilterInput);
@@ -145,7 +142,6 @@ describe('Text filter component', () => {
     await user.click(
       await screen.findByRole('button', {
         name: 'include, exclude or exact',
-        hidden: true,
       })
     );
     await user.click(await screen.findByText('Include'));
@@ -172,7 +168,6 @@ describe('Text filter component', () => {
     await user.click(
       await screen.findByRole('button', {
         name: 'include, exclude or exact',
-        hidden: true,
       })
     );
     await user.click(await screen.findByText('Exclude'));
@@ -199,7 +194,6 @@ describe('Text filter component', () => {
     await user.click(
       await screen.findByRole('button', {
         name: 'include, exclude or exact',
-        hidden: true,
       })
     );
     await user.click(await screen.findByText('Exact'));
@@ -226,7 +220,6 @@ describe('Text filter component', () => {
     await user.clear(
       await screen.findByRole('textbox', {
         name: 'Filter by test',
-        hidden: true,
       })
     );
 
@@ -250,7 +243,6 @@ describe('Text filter component', () => {
     await user.click(
       await screen.findByRole('button', {
         name: 'include, exclude or exact',
-        hidden: true,
       })
     );
     await user.click(await screen.findByText('Include'));
@@ -296,7 +288,6 @@ describe('Text filter component', () => {
     // We simulate a change in the input to 'test'.
     const textFilterInput = await screen.findByRole('textbox', {
       name: 'Filter by Name',
-      hidden: true,
     });
 
     await user.clear(textFilterInput);
@@ -338,7 +329,6 @@ describe('Text filter component', () => {
     // We simulate a change in the input to 'test'.
     const textFilterInput = await screen.findByRole('textbox', {
       name: 'Filter by Principal Investigator',
-      hidden: true,
     });
 
     await user.clear(textFilterInput);

--- a/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
@@ -72,13 +72,12 @@ const TextColumnFilter = (props: {
   return (
     <div>
       <FormControl
-        id={`${label}-filter`}
         variant="standard"
         color="secondary"
         fullWidth={true}
         margin="dense"
       >
-        <InputLabel id={`${label}-filter`}>
+        <InputLabel htmlFor={`${label}-filter`}>
           {type.charAt(0).toUpperCase() + type.slice(1)}
         </InputLabel>
         <Input
@@ -86,7 +85,6 @@ const TextColumnFilter = (props: {
           value={inputValue}
           onChange={handleInputChange}
           inputProps={{ 'aria-label': `Filter by ${label}` }}
-          aria-hidden={true}
           endAdornment={
             <InputAdornment position="end">
               <Select

--- a/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
+++ b/packages/datagateway-common/src/table/columnFilters/textColumnFilter.component.tsx
@@ -14,8 +14,8 @@ import { usePushFilter, usePushFilters } from '../../api';
 
 const TextColumnFilter = (props: {
   label: string;
-  onChange: (value: { value?: string | number; type: string } | null) => void;
-  value: { value?: string | number; type: string } | undefined;
+  onChange: (value: TextFilter | null) => void;
+  value: TextFilter | undefined;
   defaultFilter?: TextFilter;
 }): React.ReactElement => {
   const { onChange, label, defaultFilter } = props;
@@ -36,7 +36,7 @@ const TextColumnFilter = (props: {
     [onChange, type]
   );
 
-  const updateType = (type: string): void => {
+  const updateType = (type: TextFilter['type']): void => {
     onChange({ value: inputValue, type: type });
   };
 
@@ -47,7 +47,7 @@ const TextColumnFilter = (props: {
     setInputValue(event.target.value);
   };
 
-  const handleSelectChange = (type: string): void => {
+  const handleSelectChange = (type: TextFilter['type']): void => {
     // Only trigger onChange if input is not empty
     if (inputValue !== '') {
       updateType(type);
@@ -95,7 +95,9 @@ const TextColumnFilter = (props: {
                 IconComponent={SettingsIcon}
                 // Do not render a value
                 renderValue={() => ''}
-                onChange={(e) => handleSelectChange(e.target.value as string)}
+                onChange={(e) =>
+                  handleSelectChange(e.target.value as TextFilter['type'])
+                }
                 SelectDisplayProps={{
                   'aria-label': `include, exclude or exact`,
                 }}
@@ -152,7 +154,7 @@ export const useTextFilter = (
       <TextColumnFilter
         label={label}
         value={filters[dataKey] as TextFilter}
-        onChange={(value: { value?: string | number; type: string } | null) =>
+        onChange={(value: TextFilter | null) =>
           pushFilter(dataKey, value ? value : null)
         }
         defaultFilter={defaultFilter as TextFilter}
@@ -172,7 +174,7 @@ export const usePrincipalExperimenterFilter = (
       <TextColumnFilter
         label={label}
         value={filters[dataKey] as TextFilter}
-        onChange={(value: { value?: string | number; type: string } | null) => {
+        onChange={(value: TextFilter | null) => {
           pushFilters([
             { filterKey: dataKey, filter: value ? value : null },
             {

--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Data column header component renders correctly with filter but no sort 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test"
     class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
   >
     <div
@@ -112,6 +113,7 @@ exports[`Data column header component renders correctly with filter but no sort 
 exports[`Data column header component renders correctly with sort and filter 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test"
     class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
   >
     <div
@@ -240,6 +242,7 @@ exports[`Data column header component renders correctly with sort and filter 1`]
 exports[`Data column header component renders correctly with sort but no filter 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test"
     class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
   >
     <div
@@ -300,6 +303,7 @@ exports[`Data column header component renders correctly with sort but no filter 
 exports[`Data column header component renders correctly without sort or filter 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test"
     class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
   >
     <div

--- a/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/packages/datagateway-common/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -32,17 +32,15 @@ exports[`Data column header component renders correctly with filter but no sort 
       <div>
         <div
           class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-          id="Test-filter"
         >
           <label
             class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="false"
-            id="Test-filter"
+            for="Test-filter"
           >
             Include
           </label>
           <div
-            aria-hidden="true"
             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
           >
             <input
@@ -161,17 +159,15 @@ exports[`Data column header component renders correctly with sort and filter 1`]
       <div>
         <div
           class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-          id="Test-filter"
         >
           <label
             class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="false"
-            id="Test-filter"
+            for="Test-filter"
           >
             Include
           </label>
           <div
-            aria-hidden="true"
             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
           >
             <input

--- a/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
+++ b/packages/datagateway-common/src/table/headerRenderers/dataHeader.component.tsx
@@ -142,6 +142,7 @@ const DataHeader = (
       sx={sx}
       variant="head"
       sortDirection={currSortDirection}
+      aria-label={labelString}
     >
       <div
         style={{

--- a/packages/datagateway-dataview/cypress/e2e/table/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/datasets.cy.ts
@@ -57,7 +57,7 @@ describe('Datasets Table', () => {
     cy.get('[aria-sort="descending"]').should('not.exist');
     cy.get('.MuiTableSortLabel-iconDirectionAsc').should('not.exist');
 
-    cy.get('[data-testid="SortIcon"]').should('have.length', 3);
+    cy.get('[data-testid="SortIcon"]').should('have.length', 4);
     cy.get('[data-testid="ArrowUpwardIcon"]').should('not.exist');
 
     cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 1');
@@ -78,7 +78,7 @@ describe('Datasets Table', () => {
   });
 
   it('should change icons when sorting on a column', () => {
-    cy.get('[data-testid="SortIcon"]').should('have.length', 3);
+    cy.get('[data-testid="SortIcon"]').should('have.length', 4);
 
     // check icon when clicking on a column
     cy.contains('[role="button"]', 'Create Time').click();
@@ -97,7 +97,7 @@ describe('Datasets Table', () => {
 
     // check icons when shift is held
     cy.get('.App').trigger('keydown', { key: 'Shift' });
-    cy.get('[data-testid="AddIcon"]').should('have.length', 1);
+    cy.get('[data-testid="AddIcon"]').should('have.length', 2);
   });
 
   it('should be able to filter with both text & date filters on multiple columns', () => {

--- a/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/investigations.cy.ts
@@ -67,7 +67,7 @@ describe('Investigations Table', () => {
     cy.get('[aria-sort="descending"]').should('not.exist');
     cy.get('.MuiTableSortLabel-iconDirectionAsc').should('not.exist');
 
-    cy.get('[data-testid="SortIcon"]').should('have.length', 6);
+    cy.get('[data-testid="SortIcon"]').should('have.length', 8);
     cy.get('[data-testid="ArrowUpwardIcon"]').should('not.exist');
 
     cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains(
@@ -88,7 +88,7 @@ describe('Investigations Table', () => {
   });
 
   it('should change icons when sorting on a column', () => {
-    cy.get('[data-testid="SortIcon"]').should('have.length', 6);
+    cy.get('[data-testid="SortIcon"]').should('have.length', 8);
 
     // check icon when clicking on a column
     cy.contains('[role="button"]', 'Visit').click();
@@ -107,7 +107,7 @@ describe('Investigations Table', () => {
 
     // check icons when shift is held
     cy.get('.App').trigger('keydown', { key: 'Shift' });
-    cy.get('[data-testid="AddIcon"]').should('have.length', 4);
+    cy.get('[data-testid="AddIcon"]').should('have.length', 6);
   });
 
   it('should be able to filter with both text & date filters on multiple columns', () => {

--- a/packages/datagateway-dataview/cypress/e2e/table/isis/datasets.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/isis/datasets.cy.ts
@@ -79,7 +79,7 @@ describe('ISIS - Datasets Table', () => {
     cy.get('[aria-sort="descending"]').should('not.exist');
     cy.get('.MuiTableSortLabel-iconDirectionAsc').should('not.exist');
 
-    cy.get('[data-testid="SortIcon"]').should('have.length', 3);
+    cy.get('[data-testid="SortIcon"]').should('have.length', 4);
     cy.get('[data-testid="ArrowUpwardIcon"]').should('not.exist');
 
     cy.get('[aria-rowindex="1"] [aria-colindex="3"]').contains('DATASET 19');
@@ -104,7 +104,7 @@ describe('ISIS - Datasets Table', () => {
     cy.contains('[role="button"]', 'Name').click();
     cy.contains('[role="button"]', 'Name').click();
 
-    cy.get('[data-testid="SortIcon"]').should('have.length', 3);
+    cy.get('[data-testid="SortIcon"]').should('have.length', 4);
 
     // check icon when clicking on a column
     cy.contains('[role="button"]', 'Create Time').click();
@@ -123,7 +123,7 @@ describe('ISIS - Datasets Table', () => {
 
     // check icons when shift is held
     cy.get('.App').trigger('keydown', { key: 'Shift' });
-    cy.get('[data-testid="AddIcon"]').should('have.length', 1);
+    cy.get('[data-testid="AddIcon"]').should('have.length', 2);
   });
 
   it('should be able to filter with both text & date filters on multiple columns', () => {

--- a/packages/datagateway-dataview/src/views/card/datasetCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/datasetCardView.component.test.tsx
@@ -62,10 +62,10 @@ describe('Dataset - Card View', () => {
         id: 1,
         name: 'Test 1',
         description: 'Test description',
-        size: 1,
+        fileSize: 1,
         modTime: '2019-07-23',
         createTime: '2019-07-23',
-        datafileCount: 1,
+        fileCount: 1,
       },
     ];
     history = createMemoryHistory();

--- a/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/datasetCardView.component.tsx
@@ -85,8 +85,7 @@ const DatasetCardView = (props: DatasetCardViewProps): React.ReactElement => {
       {
         icon: ConfirmationNumber,
         label: t('datasets.datafile_count'),
-        dataKey: 'datafileCount',
-        disableSort: true,
+        dataKey: 'fileCount',
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/investigationCardView.component.tsx
@@ -125,15 +125,13 @@ const InvestigationCardView = (): React.ReactElement => {
         label: t('investigations.details.name'),
         dataKey: 'name',
         filterComponent: textFilter,
-        disableSort: true,
       },
       {
         icon: Save,
         label: t('investigations.details.size'),
-        dataKey: 'size',
+        dataKey: 'fileSize',
         content: (investigation: Investigation): number | string =>
           formatBytes(investigation.fileSize),
-        disableSort: true,
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.test.tsx
@@ -57,7 +57,7 @@ describe('ISIS Datasets - Card View', () => {
       {
         id: 1,
         name: 'Test 1',
-        size: 1,
+        fileSize: 1,
         modTime: '2019-07-23',
         createTime: '2019-07-23',
       },

--- a/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisDatasetsCardView.component.tsx
@@ -113,13 +113,9 @@ const ISISDatasetsCardView = (
       {
         icon: Save,
         label: t('datasets.size'),
-        dataKey: 'size',
-        content: (dataset: Dataset): string => {
-          const index = data?.findIndex((item) => item.id === dataset.id);
-          if (typeof index === 'undefined') return 'Unknown';
-          return formatBytes(dataset.fileSize);
-        },
-        disableSort: true,
+        dataKey: 'fileSize',
+        content: (dataset: Dataset): number | string =>
+          formatBytes(dataset.fileSize),
       },
       {
         icon: CalendarToday,
@@ -134,7 +130,7 @@ const ISISDatasetsCardView = (
         filterComponent: dateFilter,
       },
     ],
-    [data, dateFilter, t]
+    [dateFilter, t]
   );
 
   const buttons = React.useMemo(

--- a/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
+++ b/packages/datagateway-dataview/src/views/card/isis/isisInvestigationsCardView.component.tsx
@@ -181,10 +181,9 @@ const ISISInvestigationsCardView = (
       {
         icon: Save,
         label: t('investigations.details.size'),
-        dataKey: 'size',
+        dataKey: 'fileSize',
         content: (investigation: Investigation): number | string =>
           formatBytes(investigation.fileSize),
-        disableSort: true,
       },
       {
         icon: Person,

--- a/packages/datagateway-dataview/src/views/datafilePreview/datafilePreviewer.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/datafilePreview/datafilePreviewer.component.test.tsx
@@ -190,7 +190,9 @@ describe('DatafilePreviewer', () => {
     // formatted size of the datafile
     expect(screen.getByText('100 B')).toBeInTheDocument();
     expect(screen.getByText(mockDatafile.datafileModTime)).toBeInTheDocument();
-    expect(screen.getByText(mockDatafile.datafileCreateTime)).toBeInTheDocument();
+    expect(
+      screen.getByText(mockDatafile.datafileCreateTime)
+    ).toBeInTheDocument();
   });
 
   it('should show the current progress of downloading datafile content', async () => {
@@ -230,7 +232,9 @@ describe('DatafilePreviewer', () => {
     // formatted size of the datafile
     expect(screen.getByText('100 B')).toBeInTheDocument();
     expect(screen.getByText(mockDatafile.datafileModTime)).toBeInTheDocument();
-    expect(screen.getByText(mockDatafile.datafileCreateTime)).toBeInTheDocument();
+    expect(
+      screen.getByText(mockDatafile.datafileCreateTime)
+    ).toBeInTheDocument();
   });
 
   it('should show a message saying the datafile cannot be previewed if the datafile extension is not supported', async () => {
@@ -262,7 +266,9 @@ describe('DatafilePreviewer', () => {
     expect(screen.getByText(unsupportedDatafile.location)).toBeInTheDocument();
     // formatted size of the datafile
     expect(screen.getByText('100 B')).toBeInTheDocument();
-    expect(screen.getByText(unsupportedDatafile.datafileModTime)).toBeInTheDocument();
+    expect(
+      screen.getByText(unsupportedDatafile.datafileModTime)
+    ).toBeInTheDocument();
     expect(
       screen.getByText(unsupportedDatafile.datafileCreateTime)
     ).toBeInTheDocument();
@@ -297,7 +303,9 @@ describe('DatafilePreviewer', () => {
     expect(screen.getByText(unsupportedDatafile.location)).toBeInTheDocument();
     // formatted size of the datafile
     expect(screen.getByText('100 B')).toBeInTheDocument();
-    expect(screen.getByText(unsupportedDatafile.datafileModTime)).toBeInTheDocument();
+    expect(
+      screen.getByText(unsupportedDatafile.datafileModTime)
+    ).toBeInTheDocument();
     expect(
       screen.getByText(unsupportedDatafile.datafileCreateTime)
     ).toBeInTheDocument();
@@ -330,8 +338,12 @@ describe('DatafilePreviewer', () => {
       expect(screen.getByText(mockDatafile.location)).toBeInTheDocument();
       // formatted size of the datafile
       expect(screen.getByText('100 B')).toBeInTheDocument();
-      expect(screen.getByText(mockDatafile.datafileModTime)).toBeInTheDocument();
-      expect(screen.getByText(mockDatafile.datafileCreateTime)).toBeInTheDocument();
+      expect(
+        screen.getByText(mockDatafile.datafileModTime)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(mockDatafile.datafileCreateTime)
+      ).toBeInTheDocument();
     });
 
     it('hides the details pane when it is switched off', async () => {
@@ -387,8 +399,12 @@ describe('DatafilePreviewer', () => {
       expect(screen.getByText(mockDatafile.location)).toBeInTheDocument();
       // formatted size of the datafile
       expect(screen.getByText('100 B')).toBeInTheDocument();
-      expect(screen.getByText(mockDatafile.datafileModTime)).toBeInTheDocument();
-      expect(screen.getByText(mockDatafile.datafileCreateTime)).toBeInTheDocument();
+      expect(
+        screen.getByText(mockDatafile.datafileModTime)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(mockDatafile.datafileCreateTime)
+      ).toBeInTheDocument();
     });
   });
 

--- a/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/isis/isisInvestigationLanding.component.test.tsx
@@ -172,7 +172,6 @@ describe('ISIS Investigation Landing page', () => {
         summary: 'foo bar',
         visitId: 'visit id 1',
         doi: 'doi 1',
-        size: 1,
         facility: {
           id: 17,
           name: 'LILS',

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.test.tsx
@@ -65,7 +65,6 @@ describe('Dataset table component', () => {
         name: 'Test 1',
         fileSize: 1,
         fileCount: 1,
-        size: 1,
         modTime: '2019-07-23',
         createTime: '2019-07-23',
       },

--- a/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/datasetTable.component.tsx
@@ -126,7 +126,6 @@ const DatasetTable = (props: DatasetTableProps): React.ReactElement => {
         icon: ConfirmationNumber,
         label: t('datasets.datafile_count'),
         dataKey: 'fileCount',
-        disableSort: true,
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatasetsTable.component.test.tsx
@@ -82,7 +82,6 @@ describe('DLS Dataset table component', () => {
         fileSize: 1,
         fileCount: 1,
         name: 'Test 1',
-        size: 1,
         modTime: '2019-07-23',
         createTime: '2019-07-23',
       },

--- a/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsMyDataTable.component.test.tsx
@@ -83,7 +83,6 @@ describe('DLS MyData table component', () => {
         summary: 'foo bar',
         visitId: '1',
         doi: 'doi 1',
-        size: 1,
         fileSize: 1,
         fileCount: 1,
         investigationInstruments: [

--- a/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsProposalsTable.component.test.tsx
@@ -70,7 +70,6 @@ describe('DLS Proposals table component', () => {
         summary: 'foo bar',
         visitId: '1',
         doi: 'doi 1',
-        size: 1,
         investigationInstruments: [
           {
             id: 1,

--- a/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsVisitsTable.component.test.tsx
@@ -72,7 +72,6 @@ describe('DLS Visits table component', () => {
         summary: 'foo bar',
         visitId: '1',
         doi: 'doi 1',
-        size: 1,
         fileSize: 1,
         fileCount: 1,
         investigationInstruments: [

--- a/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/investigationTable.component.tsx
@@ -128,7 +128,6 @@ const InvestigationTable = (): React.ReactElement => {
         label: t('investigations.name'),
         dataKey: 'name',
         filterComponent: textFilter,
-        disableSort: true,
       },
       {
         icon: Public,
@@ -148,10 +147,9 @@ const InvestigationTable = (): React.ReactElement => {
       {
         icon: Save,
         label: t('investigations.size'),
-        dataKey: 'size',
+        dataKey: 'fileSize',
         cellContentRenderer: (cellProps: TableCellProps): number | string =>
           formatBytes(cellProps.rowData.fileSize),
-        disableSort: true,
       },
       {
         icon: Assessment,

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.test.tsx
@@ -72,7 +72,6 @@ describe('ISIS Dataset table component', () => {
       {
         id: 1,
         name: 'Test 1',
-        size: 1,
         modTime: '2019-07-23',
         createTime: '2019-07-23',
       },

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatasetsTable.component.tsx
@@ -147,10 +147,9 @@ const ISISDatasetsTable = (
       {
         icon: SaveIcon,
         label: t('datasets.size'),
-        dataKey: 'size',
+        dataKey: 'fileSize',
         cellContentRenderer: (cellProps: TableCellProps): number | string =>
           formatBytes(cellProps.rowData.fileSize),
-        disableSort: true,
       },
       {
         icon: CalendarTodayIcon,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.test.tsx
@@ -69,7 +69,6 @@ describe('ISIS Investigations table component', () => {
         summary: 'foo bar',
         visitId: '1',
         doi: 'doi 1',
-        size: 1,
         investigationUsers: [
           {
             id: 2,

--- a/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisInvestigationsTable.component.tsx
@@ -222,10 +222,9 @@ const ISISInvestigationsTable = (
       {
         icon: Save,
         label: t('investigations.size'),
-        dataKey: 'size',
+        dataKey: 'fileSize',
         cellContentRenderer: (cellProps: TableCellProps): number | string =>
           formatBytes(cellProps.rowData.fileSize),
-        disableSort: true,
       },
       {
         icon: Person,

--- a/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisMyDataTable.component.tsx
@@ -246,10 +246,9 @@ const ISISMyDataTable = (): React.ReactElement => {
       {
         icon: Save,
         label: t('investigations.size'),
-        dataKey: 'size',
+        dataKey: 'fileSize',
         cellContentRenderer: (cellProps: TableCellProps): number | string =>
           formatBytes(cellProps.rowData.fileSize),
-        disableSort: true,
       },
       {
         icon: CalendarToday,

--- a/packages/datagateway-download/cypress/e2e/adminDownloadStatus.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/adminDownloadStatus.cy.ts
@@ -93,11 +93,11 @@ describe('Admin Download Status', () => {
     cy.contains('[role="button"]', 'Availability').click({ shiftKey: true });
     cy.get('[aria-sort="ascending"]').should('have.length', 2);
 
-    cy.get('[aria-rowindex="1"] [aria-colindex="6"]').should(
+    cy.get('[aria-rowindex="2"] [aria-colindex="6"]').should(
       'have.text',
       'Available'
     );
-    cy.get('[aria-rowindex="2"] [aria-colindex="6"]').should(
+    cy.get('[aria-rowindex="3"] [aria-colindex="6"]').should(
       'have.text',
       'Expired'
     );

--- a/packages/datagateway-download/cypress/e2e/downloadCart.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/downloadCart.cy.ts
@@ -84,22 +84,55 @@ describe('Download Cart', () => {
   });
 
   it('should be able to filter cart items by name and type', () => {
-    cy.get('[aria-label="Filter by Name"]').first().as('nameFilter');
+    // sort by name to have consistency
+    cy.contains('[role="button"]', 'Name').click();
 
+    cy.findByRole('textbox', { name: 'Filter by Name' }).as('nameFilter');
+
+    cy.get('@nameFilter')
+      .parent()
+      .findByRole('button', { name: 'include, exclude or exact' })
+      .as('nameFilterOptionsButton')
+      .click();
+
+    cy.findByRole('option', { name: 'Exact' }).click();
+
+    // test exact filter
+    cy.get('@nameFilter').type('DATASET 1', { delay: 0 });
+
+    cy.get('[aria-rowcount=1]').should('exist');
+    cy.findByRole('gridcell', { name: 'DATASET 1' }).should('exist');
+    cy.findByRole('gridcell', { name: 'DATASET 11' }).should('not.exist');
+
+    // test exclude filter
+    cy.get('@nameFilterOptionsButton').click();
+    cy.findByRole('option', { name: 'Exclude' }).click();
+
+    cy.findByRole('gridcell', { name: 'DATASET 1' }).should('not.exist');
+    cy.findByRole('gridcell', { name: 'DATASET 11' }).should('not.exist');
+    cy.findByRole('gridcell', { name: 'DATASET 21' }).should('exist');
+
+    // test include filter
+    cy.get('@nameFilterOptionsButton').click();
+    cy.findByRole('option', { name: 'Include' }).click();
+
+    cy.get('[aria-rowcount=6]').should('exist');
+    cy.findByRole('gridcell', { name: 'DATASET 1' }).should('exist');
+    cy.findByRole('gridcell', { name: 'DATASET 11' }).should('exist');
+
+    cy.get('@nameFilter').clear();
     cy.get('@nameFilter').type('1');
     cy.get('[aria-rowcount=15]').should('exist');
-    cy.contains('DATASET 1').should('be.visible');
 
-    cy.get('[aria-label="Filter by Type"]').first().as('typeFilter');
+    cy.findByRole('textbox', { name: 'Filter by Type' }).as('typeFilter');
 
     cy.get('@typeFilter').type('in');
     cy.get('[aria-rowcount=5]').should('exist');
-    cy.contains('INVESTIGATION 16').should('be.visible');
+    cy.findByRole('gridcell', { name: 'INVESTIGATION 16' }).should('exist');
 
-    cy.contains('[role="button"]', 'Name').click();
     cy.get('@nameFilter').type('{backspace}');
     cy.get('[aria-rowcount=29]').should('exist');
-    cy.contains('INVESTIGATION 2').should('be.visible');
+    cy.findByRole('gridcell', { name: 'INVESTIGATION 2' }).should('exist');
   });
 
   it('should be able to remove individual items from the cart', () => {

--- a/packages/datagateway-download/cypress/e2e/downloadStatus.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/downloadStatus.cy.ts
@@ -212,9 +212,33 @@ describe('Download Status', () => {
         }
       });
 
-    cy.get('[aria-label="Filter by Access Method"]').first().type('globus');
+    cy.get('[aria-label="Filter by Access Method"]').first().as('methodFilter');
+    // test include
+    cy.get('@methodFilter').type('http');
+    cy.get('[aria-rowcount="2"]').should('exist');
+    cy.findByRole('gridcell', { name: 'http' }).should('exist');
+    cy.findByRole('gridcell', { name: 'https' }).should('exist');
+    cy.findByRole('gridcell', { name: 'globus' }).should('not.exist');
+
+    cy.get('@methodFilter')
+      .parent()
+      .findByRole('button', { name: 'include, exclude or exact' })
+      .as('methodFilterOptionsButton')
+      .click();
+
+    cy.findByRole('option', { name: 'Exact' }).click();
+
+    cy.get('[aria-rowcount="1"]').should('exist');
+    cy.findByRole('gridcell', { name: 'http' }).should('exist');
+    cy.findByRole('gridcell', { name: 'https' }).should('not.exist');
+
+    cy.get('@methodFilterOptionsButton').click();
+    cy.findByRole('option', { name: 'Exclude' }).click();
 
     cy.get('[aria-rowcount="2"]').should('exist');
+    cy.findByRole('gridcell', { name: 'http' }).should('not.exist');
+    cy.findByRole('gridcell', { name: 'https' }).should('not.exist');
+    cy.findAllByRole('gridcell', { name: 'globus' }).should('exist');
 
     cy.get('[aria-label="Filter by Availability"]').first().type('restoring');
 

--- a/packages/datagateway-download/cypress/support/commands.js
+++ b/packages/datagateway-download/cypress/support/commands.js
@@ -25,6 +25,7 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 import jsrsasign from 'jsrsasign';
+import '@testing-library/cypress/add-commands';
 
 const downloadsInfo = [
   {

--- a/packages/datagateway-download/cypress/tsconfig.json
+++ b/packages/datagateway-download/cypress/tsconfig.json
@@ -8,7 +8,10 @@
       "dom.iterable",
       "esnext"
     ],
-    "types": ["cypress"]
+    "types": [
+      "cypress",
+      "@testing-library/cypress"
+    ]
   },
   "include": ["**/*"]
 }

--- a/packages/datagateway-download/package.json
+++ b/packages/datagateway-download/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.23.3",
+    "@testing-library/cypress": "8.0.7",
     "@testing-library/jest-dom": "6.4.1",
     "@testing-library/react": "12.1.3",
     "@testing-library/react-hooks": "8.0.1",

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -17,11 +17,11 @@ import {
   type DownloadCartItem,
   type DownloadCartTableItem,
   formatBytes,
-  type Order,
   Table,
   type TableActionProps,
   TextColumnFilter,
   type TextFilter,
+  type SortType,
 } from 'datagateway-common';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -60,9 +60,9 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
     dataCiteUrl,
   } = React.useContext(DownloadSettingsContext);
 
-  const [sort, setSort] = React.useState<{ [column: string]: Order }>({});
+  const [sort, setSort] = React.useState<SortType>({});
   const [filters, setFilters] = React.useState<{
-    [column: string]: { value?: string | number; type: string };
+    [column: string]: TextFilter;
   }>({});
 
   const [showConfirmation, setShowConfirmation] = React.useState(false);
@@ -108,7 +108,7 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
     (label: string, dataKey: string): React.ReactElement => (
       <TextColumnFilter
         label={label}
-        onChange={(value: { value?: string | number; type: string } | null) => {
+        onChange={(value: TextFilter | null) => {
           if (value) {
             setFilters({ ...filters, [dataKey]: value });
           } else {
@@ -134,15 +134,23 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
     const filteredData = sizeAndCountAddedData?.filter((item) => {
       for (const [key, value] of Object.entries(filters)) {
         const tableValue = item[key];
-        if (
-          tableValue === undefined ||
-          (typeof tableValue === 'string' &&
-            typeof value.value === 'string' &&
-            (value.type === 'include'
-              ? !tableValue.includes(value.value)
-              : tableValue.includes(value.value)))
-        ) {
-          return false;
+        if (tableValue === undefined) return false;
+        if (typeof tableValue === 'string' && typeof value.value === 'string') {
+          // use switch statement to ensure TS can detect we cover all cases
+          switch (value.type) {
+            case 'include':
+              if (!tableValue.includes(value.value)) return false;
+              break;
+            case 'exclude':
+              if (tableValue.includes(value.value)) return false;
+              break;
+            case 'exact':
+              if (tableValue !== value.value) return false;
+              break;
+            default:
+              const exhaustiveCheck: never = value.type;
+              throw new Error(`Unhandled text filter type: ${exhaustiveCheck}`);
+          }
         }
       }
       return true;

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/adminDownloadStatusTable.component.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.id"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -129,17 +130,15 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                           <div>
                             <div
                               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                              id="downloadStatus.id-filter"
                             >
                               <label
                                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                                 data-shrink="false"
-                                id="downloadStatus.id-filter"
+                                for="downloadStatus.id-filter"
                               >
                                 Include
                               </label>
                               <div
-                                aria-hidden="true"
                                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                               >
                                 <input
@@ -211,6 +210,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.fullname"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -254,17 +254,15 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                           <div>
                             <div
                               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                              id="downloadStatus.fullname-filter"
                             >
                               <label
                                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                                 data-shrink="false"
-                                id="downloadStatus.fullname-filter"
+                                for="downloadStatus.fullname-filter"
                               >
                                 Include
                               </label>
                               <div
-                                aria-hidden="true"
                                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                               >
                                 <input
@@ -336,6 +334,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.username"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -379,17 +378,15 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                           <div>
                             <div
                               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                              id="downloadStatus.username-filter"
                             >
                               <label
                                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                                 data-shrink="false"
-                                id="downloadStatus.username-filter"
+                                for="downloadStatus.username-filter"
                               >
                                 Include
                               </label>
                               <div
-                                aria-hidden="true"
                                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                               >
                                 <input
@@ -461,6 +458,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.preparedId"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -504,17 +502,15 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                           <div>
                             <div
                               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                              id="downloadStatus.preparedId-filter"
                             >
                               <label
                                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                                 data-shrink="false"
-                                id="downloadStatus.preparedId-filter"
+                                for="downloadStatus.preparedId-filter"
                               >
                                 Include
                               </label>
                               <div
-                                aria-hidden="true"
                                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                               >
                                 <input
@@ -586,6 +582,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.transport"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -629,17 +626,15 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                           <div>
                             <div
                               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                              id="downloadStatus.transport-filter"
                             >
                               <label
                                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                                 data-shrink="false"
-                                id="downloadStatus.transport-filter"
+                                for="downloadStatus.transport-filter"
                               >
                                 Include
                               </label>
                               <div
-                                aria-hidden="true"
                                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                               >
                                 <input
@@ -711,6 +706,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.status"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -754,17 +750,15 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                           <div>
                             <div
                               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                              id="downloadStatus.status-filter"
                             >
                               <label
                                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                                 data-shrink="false"
-                                id="downloadStatus.status-filter"
+                                for="downloadStatus.status-filter"
                               >
                                 Include
                               </label>
                               <div
-                                aria-hidden="true"
                                 class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                               >
                                 <input
@@ -836,6 +830,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.size"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -850,11 +845,30 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                             <div
                               class="MuiBox-root css-0"
                             >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
+                              <span
+                                aria-label="downloadStatus.size"
+                                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active tour-dataview-sort css-f4w4o6-MuiButtonBase-root-MuiTableSortLabel-root"
+                                data-mui-internal-clone-element="true"
+                                role="button"
+                                tabindex="0"
                               >
-                                downloadStatus.size
-                              </p>
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
+                                >
+                                  downloadStatus.size
+                                </p>
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                  data-testid="SortIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
+                                  />
+                                </svg>
+                              </span>
                             </div>
                           </div>
                         </div>
@@ -874,6 +888,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.createdAt"
                         aria-sort="descending"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
@@ -1022,6 +1037,7 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                       style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 113.77777777777777px; min-width: 84px;"
                     >
                       <div
+                        aria-label="downloadStatus.deleted"
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                       >
                         <div
@@ -1060,6 +1076,55 @@ exports[`Admin Download Status Table should render correctly 1`] = `
                                   />
                                 </svg>
                               </span>
+                            </div>
+                          </div>
+                          <div
+                            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                          >
+                            <label
+                              aria-label="Filter by downloadStatus.deleted"
+                              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
+                              data-shrink="false"
+                              for="isDeleted-filter"
+                              id="isDeleted-filter-label"
+                            >
+                              downloadStatus.deleted?
+                            </label>
+                            <div
+                              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-fullWidth MuiInputBase-formControl css-1o7q6ah-MuiInputBase-root-MuiInput-root"
+                            >
+                              <div
+                                aria-expanded="false"
+                                aria-haspopup="listbox"
+                                aria-labelledby="isDeleted-filter-label isDeleted-filter"
+                                class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                                id="isDeleted-filter"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <span
+                                  class="notranslate"
+                                >
+                                  ​
+                                </span>
+                              </div>
+                              <input
+                                aria-hidden="true"
+                                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                                tabindex="-1"
+                                value=""
+                              />
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                                data-testid="ArrowDropDownIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M7 10l5 5 5-5z"
+                                />
+                              </svg>
                             </div>
                           </div>
                         </div>

--- a/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
+++ b/packages/datagateway-download/src/downloadStatus/__snapshots__/downloadStatusTable.component.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`Download Status Table should render correctly 1`] = `
                 style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 256px; min-width: 84px;"
               >
                 <div
+                  aria-label="downloadStatus.filename"
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                 >
                   <div
@@ -89,17 +90,15 @@ exports[`Download Status Table should render correctly 1`] = `
                     <div>
                       <div
                         class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                        id="downloadStatus.filename-filter"
                       >
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                           data-shrink="false"
-                          id="downloadStatus.filename-filter"
+                          for="downloadStatus.filename-filter"
                         >
                           Include
                         </label>
                         <div
-                          aria-hidden="true"
                           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                         >
                           <input
@@ -171,6 +170,7 @@ exports[`Download Status Table should render correctly 1`] = `
                 style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 256px; min-width: 84px;"
               >
                 <div
+                  aria-label="downloadStatus.transport"
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                 >
                   <div
@@ -214,17 +214,15 @@ exports[`Download Status Table should render correctly 1`] = `
                     <div>
                       <div
                         class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                        id="downloadStatus.transport-filter"
                       >
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                           data-shrink="false"
-                          id="downloadStatus.transport-filter"
+                          for="downloadStatus.transport-filter"
                         >
                           Include
                         </label>
                         <div
-                          aria-hidden="true"
                           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                         >
                           <input
@@ -296,6 +294,7 @@ exports[`Download Status Table should render correctly 1`] = `
                 style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 256px; min-width: 84px;"
               >
                 <div
+                  aria-label="downloadStatus.status"
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                 >
                   <div
@@ -339,17 +338,15 @@ exports[`Download Status Table should render correctly 1`] = `
                     <div>
                       <div
                         class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth css-zevgu-MuiFormControl-root"
-                        id="downloadStatus.status-filter"
                       >
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorSecondary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-t7bnno-MuiFormLabel-root-MuiInputLabel-root"
                           data-shrink="false"
-                          id="downloadStatus.status-filter"
+                          for="downloadStatus.status-filter"
                         >
                           Include
                         </label>
                         <div
-                          aria-hidden="true"
                           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorSecondary MuiInputBase-formControl MuiInputBase-adornedEnd css-89bi5l-MuiInputBase-root-MuiInput-root"
                         >
                           <input
@@ -421,6 +418,7 @@ exports[`Download Status Table should render correctly 1`] = `
                 style="display: flex; flex-direction: row; box-sizing: border-box; overflow: hidden; flex: 1 1 256px; min-width: 84px;"
               >
                 <div
+                  aria-label="downloadStatus.createdAt"
                   aria-sort="descending"
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1wleh9m-MuiTableCell-root"
                 >

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -405,6 +405,62 @@ describe('Admin Download Status Table', () => {
     cleanupDatePickerWorkaround();
   });
 
+  it('should filter deleted properly', async () => {
+    renderComponent();
+
+    // Table is sorted by createdAt desc by default
+    // To keep working test, we will remove all sorts on the table beforehand
+    await user.click(await screen.findByText('downloadStatus.createdAt'));
+    await flushPromises();
+
+    // Get the is deleted filter
+    const isDeletedFilter = await screen.findByRole('button', {
+      name: /Filter by downloadStatus\.deleted/,
+    });
+
+    await user.click(isDeletedFilter);
+
+    await user.click(await screen.findByRole('option', { name: 'No' }));
+
+    await flushPromises();
+
+    expect(fetchAdminDownloads).toHaveBeenCalledWith(
+      {
+        downloadApiUrl: mockedSettings.downloadApiUrl,
+        facilityName: mockedSettings.facilityName,
+      },
+      `WHERE download.facilityName = '${mockedSettings.facilityName}' AND download.isDeleted = 'false' ORDER BY download.id ASC LIMIT 0, 50`
+    );
+
+    await user.click(isDeletedFilter);
+
+    await user.click(await screen.findByRole('option', { name: 'Yes' }));
+
+    await flushPromises();
+
+    expect(fetchAdminDownloads).toHaveBeenCalledWith(
+      {
+        downloadApiUrl: mockedSettings.downloadApiUrl,
+        facilityName: mockedSettings.facilityName,
+      },
+      `WHERE download.facilityName = '${mockedSettings.facilityName}' AND download.isDeleted = 'true' ORDER BY download.id ASC LIMIT 0, 50`
+    );
+
+    await user.click(isDeletedFilter);
+
+    await user.click(await screen.findByRole('option', { name: 'Either' }));
+
+    await flushPromises();
+
+    expect(fetchAdminDownloads).toHaveBeenCalledWith(
+      {
+        downloadApiUrl: mockedSettings.downloadApiUrl,
+        facilityName: mockedSettings.facilityName,
+      },
+      `WHERE download.facilityName = '${mockedSettings.facilityName}' ORDER BY download.id ASC LIMIT 0, 50`
+    );
+  });
+
   it('should send restore item and item status requests when restore button is clicked', async () => {
     renderComponent();
 

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -247,6 +247,17 @@ describe('Admin Download Status Table', () => {
       );
 
       await user.type(usernameFilterInput, 'test user');
+
+      // test exact filter
+      await user.click(
+        within(
+          screen.getByRole('columnheader', { name: /downloadStatus.username/ })
+        ).getByLabelText('include, exclude or exact')
+      );
+      // click on exclude option
+      await user.click(
+        within(await screen.findByRole('listbox')).getByText('Exact')
+      );
       await flushPromises();
 
       expect(fetchAdminDownloads).toHaveBeenCalledWith(
@@ -254,7 +265,7 @@ describe('Admin Download Status Table', () => {
           downloadApiUrl: mockedSettings.downloadApiUrl,
           facilityName: mockedSettings.facilityName,
         },
-        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND UPPER(download.userName) LIKE CONCAT('%', 'TEST USER', '%') ORDER BY download.id ASC LIMIT 0, 50`
+        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND download.userName = 'test user' ORDER BY download.id ASC LIMIT 0, 50`
       );
 
       await user.clear(usernameFilterInput);
@@ -288,6 +299,7 @@ describe('Admin Download Status Table', () => {
       await user.type(availabilityFilterInput, 'downloadStatus.complete');
       await flushPromises();
 
+      // test include filter
       expect(fetchAdminDownloads).toHaveBeenCalledWith(
         {
           downloadApiUrl: mockedSettings.downloadApiUrl,
@@ -299,7 +311,9 @@ describe('Admin Download Status Table', () => {
       // We simulate a change in the select from 'include' to 'exclude'.
       // click on the select box
       await user.click(
-        screen.getAllByLabelText('include, exclude or exact')[5]
+        within(
+          screen.getByRole('columnheader', { name: /downloadStatus.status/ })
+        ).getByLabelText('include, exclude or exact')
       );
       // click on exclude option
       await user.click(

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -4,8 +4,10 @@ import {
   Grid,
   IconButton,
   LinearProgress,
+  MenuItem,
   Paper,
   styled,
+  TextField,
   Typography,
 } from '@mui/material';
 
@@ -210,6 +212,39 @@ const AdminDownloadStatusTable: React.FC = () => {
     />
   );
 
+  const downloadFilter = (
+    label: string,
+    dataKey: string
+  ): React.ReactElement => (
+    <TextField
+      fullWidth
+      variant="standard"
+      color="secondary"
+      select
+      id={`${dataKey}-filter`}
+      label={`${label}?`}
+      InputLabelProps={{ 'aria-label': `Filter by ${label}` }}
+      value={(filters[dataKey] as TextFilter | null)?.value ?? ''}
+      onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+        if (event.target.value.length > 0) {
+          setFilters({
+            ...filters,
+            [dataKey]: { type: 'exact', value: event.target.value },
+          });
+        } else {
+          const { [dataKey]: value, ...restOfFilters } = filters;
+          setFilters(restOfFilters);
+        }
+      }}
+    >
+      <MenuItem value="">
+        <em>Either</em>
+      </MenuItem>
+      <MenuItem value="true">Yes</MenuItem>
+      <MenuItem value="false">No</MenuItem>
+    </TextField>
+  );
+
   const dateFilter = (label: string, dataKey: string): React.ReactElement => (
     <DateColumnFilter
       label={label}
@@ -357,7 +392,6 @@ const AdminDownloadStatusTable: React.FC = () => {
                       cellContentRenderer: (cellProps) => {
                         return formatBytes(cellProps.cellData);
                       },
-                      disableSort: true,
                     },
                     {
                       label: t('downloadStatus.createdAt'),
@@ -375,7 +409,7 @@ const AdminDownloadStatusTable: React.FC = () => {
                     {
                       label: t('downloadStatus.deleted'),
                       dataKey: 'isDeleted',
-                      filterComponent: textFilter,
+                      filterComponent: downloadFilter,
                       cellContentRenderer: ({ rowData }) =>
                         (rowData as FormattedDownload).formattedIsDeleted,
                     },

--- a/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/downloadStatusTable.component.tsx
@@ -48,9 +48,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
     createdAt: 'desc',
   });
   const [filters, setFilters] = React.useState<{
-    [column: string]:
-      | { value?: string | number; type: string }
-      | { startDate?: string; endDate?: string };
+    [column: string]: TextFilter | DateFilter;
   }>({});
   const {
     data: downloads,
@@ -94,7 +92,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
   const textFilter = (label: string, dataKey: string): React.ReactElement => (
     <TextColumnFilter
       label={label}
-      onChange={(value: { value?: string | number; type: string } | null) => {
+      onChange={(value: TextFilter | null) => {
         if (value) {
           setFilters({ ...filters, [dataKey]: value });
         } else {
@@ -112,7 +110,7 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
   ): React.ReactElement => (
     <TextColumnFilter
       label={label}
-      onChange={(value: { value?: string | number; type: string } | null) => {
+      onChange={(value: TextFilter | null) => {
         if (value && typeof value.value === 'string') {
           setFilters({
             ...filters,
@@ -168,13 +166,25 @@ const DownloadStatusTable: React.FC<DownloadStatusTableProps> = (
         if (isTextFilter) {
           const filterKeyword = (filter.value as string).toLowerCase();
 
-          satisfiedFilters.push(
-            filter.type === 'exact'
-              ? tableValue.toLowerCase() === filterKeyword
-              : filter.type === 'exclude'
-              ? !tableValue.toLowerCase().includes(filterKeyword)
-              : tableValue.toLowerCase().includes(filterKeyword)
-          );
+          // use switch statement to ensure TS can detect we cover all cases
+          switch (filter.type) {
+            case 'include':
+              satisfiedFilters.push(
+                tableValue.toLowerCase().includes(filterKeyword)
+              );
+              break;
+            case 'exclude':
+              satisfiedFilters.push(
+                !tableValue.toLowerCase().includes(filterKeyword)
+              );
+              break;
+            case 'exact':
+              satisfiedFilters.push(tableValue.toLowerCase() === filterKeyword);
+              break;
+            default:
+              const exhaustiveCheck: never = filter.type;
+              throw new Error(`Unhandled text filter type: ${exhaustiveCheck}`);
+          }
 
           continue;
         }

--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -11,8 +11,8 @@
   "searchBox": {
     "search_text": "Search for investigations, datasets and datafiles",
     "examples_label": "For example <1>\"instrument calibration\"</1> or <4>neutron AND scattering</4>.",
-    "examples_label_link1": "?searchText=\"instrument+calibration\"",
-    "examples_label_link2": "?searchText=neutron+AND+scattering",
+    "examples_label_link1": "\"instrument calibration\"",
+    "examples_label_link2": "neutron AND scattering",
     "start_date": "Start date",
     "end_date": "End date",
     "checkboxes": {

--- a/packages/datagateway-search/src/facet/components/selectedFilterChips.component.test.tsx
+++ b/packages/datagateway-search/src/facet/components/selectedFilterChips.component.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 const testFilters: FiltersType = {
   'unrelated.dimension': {
-    type: 'type',
+    type: 'include',
     value: 'asd',
   },
   'unrelated.dimension.2': [{ label: 'asd', key: 'key', filter: [] }],

--- a/packages/datagateway-search/src/searchBoxContainer.component.test.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.test.tsx
@@ -87,15 +87,15 @@ describe('SearchBoxContainer - Tests', () => {
       screen.getByRole('button', { name: 'searchBox.search_button_arialabel' })
     ).toBeInTheDocument();
 
-    // link to example instrument calibration should be visible
+    // link to example searchBox.examples_label_link1 should be visible
     expect(
       screen.getByRole('link', { name: '"instrument calibration"' })
-    ).toHaveAttribute('href', '/?searchText=%22instrument+calibration%22');
+    ).toHaveAttribute('href', '/?searchText=searchBox.examples_label_link1');
 
-    // link to example neutron and scattering should be visible
+    // link to example searchBox.examples_label_link2 should be visible
     expect(
       screen.getByRole('link', { name: 'neutron AND scattering' })
-    ).toHaveAttribute('href', '/?searchText=neutron+AND+scattering');
+    ).toHaveAttribute('href', '/?searchText=searchBox.examples_label_link2');
   });
 
   it('shows my data checkbox if user is logged in', () => {

--- a/packages/datagateway-search/src/searchBoxContainer.component.tsx
+++ b/packages/datagateway-search/src/searchBoxContainer.component.tsx
@@ -120,7 +120,7 @@ const SearchBoxContainer = (
             <Link
               component={RouterLink}
               sx={{ fontWeight: 'bold' }}
-              to={searchTextExampleLink('"instrument calibration"')}
+              to={searchTextExampleLink(t('searchBox.examples_label_link1'))}
             >
               &quot;instrument calibration&quot;
             </Link>
@@ -128,7 +128,7 @@ const SearchBoxContainer = (
             <Link
               component={RouterLink}
               sx={{ fontWeight: 'bold' }}
-              to={searchTextExampleLink('neutron AND scattering')}
+              to={searchTextExampleLink(t('searchBox.examples_label_link2'))}
             >
               neutron AND scattering
             </Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6418,6 +6418,7 @@ __metadata:
     "@emotion/styled": 11.11.0
     "@mui/icons-material": 5.11.0
     "@mui/material": 5.11.0
+    "@testing-library/cypress": 8.0.7
     "@testing-library/jest-dom": 6.4.1
     "@testing-library/react": 12.1.3
     "@testing-library/react-hooks": 8.0.1


### PR DESCRIPTION
## Description
Exact filters were not working in the admin download table &  the download cart, so fixed that and refactored all the places we check for the type of the filter to ensure we are handling all use cases.

Also added a is deleted filter to the Deleted column on the admin download table - requested by Sabah. Implemented as a simple yes/no dropdown.

Also I noticed some tables/card views had `disableSort` still true for sizes/count columns which is no longer necessary

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] In dg-download, test exact filters & the new download filter
