### PR TITLE
Add examples section to advanced help dialogue

### DIFF
--- a/packages/datagateway-search/public/res/default.json
+++ b/packages/datagateway-search/public/res/default.json
@@ -303,6 +303,20 @@
     "close_button_arialabel": "Close",
     "title": "Advanced Search Tips",
     "description": "Searching the metadata catalogue using one or more words should be intuitive, with the most relevant matches appearing first. However, there is a powerful syntax that supports more advanced use cases, which are described below.",
+    "examples": {
+      "title": "Examples",
+      "description": "Below are a few examples of common searches and how they can be crafted to execute efficiently for those with access to large volumes of data:",
+      "examples": [
+        {
+          "name": "To search for a visit and partial location",
+          "value": "+visitId:\"nt20-8\" +location:\"jpegs/pg1/\""
+        },
+        {
+          "name": "To search for a visit, partial location and filename ext",
+          "value": "+visitId:\"nt20-8\" +location:\" jpegs/pg1/\" +(location:jpeg location:*.jpeg)"
+        }
+      ]
+    },
     "terms": {
       "title": "Terms",
       "description": "By default, all words in the search text are treated as separate <strong>terms</strong>. Results must contain at least one <strong>term</strong> to be returned, and they can occur in any order in the result. When using the default relevancy based sorting, results containing the most <strong>terms</strong> will appear first. For example, <10>neutron scattering</10> will return results containing both <strong>terms</strong> first, then results containing only one or the other.",

--- a/packages/datagateway-search/src/__mocks__/react-i18next.jsx
+++ b/packages/datagateway-search/src/__mocks__/react-i18next.jsx
@@ -62,7 +62,7 @@ module.exports = {
       (k, o) => (o ? `${k} ${JSON.stringify(o).replace(/"/g, '')}` : k),
       { i18n: {} }
     ),
-  useTranslation: () => useMock,
+  useTranslation: jest.fn(() => useMock),
 
   // mock if needed
   I18nextProvider: reactI18next.I18nextProvider,

--- a/packages/datagateway-search/src/__mocks__/react-i18next.jsx
+++ b/packages/datagateway-search/src/__mocks__/react-i18next.jsx
@@ -62,7 +62,7 @@ module.exports = {
       (k, o) => (o ? `${k} ${JSON.stringify(o).replace(/"/g, '')}` : k),
       { i18n: {} }
     ),
-  useTranslation: jest.fn(() => useMock),
+  useTranslation: () => useMock,
 
   // mock if needed
   I18nextProvider: reactI18next.I18nextProvider,

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.test.tsx
@@ -39,6 +39,7 @@ function renderComponent({
 describe('Advanced help dialogue', () => {
   let state: StateType;
   const tSpy = jest.fn((str) => str);
+  let originalUseTranslation: typeof reactI18Next.useTranslation;
 
   beforeEach(() => {
     state = JSON.parse(
@@ -48,7 +49,12 @@ describe('Advanced help dialogue', () => {
       })
     );
 
-    (reactI18Next.useTranslation as jest.Mock).mockReturnValue([tSpy]);
+    originalUseTranslation = reactI18Next.useTranslation;
+    reactI18Next.useTranslation = jest.fn().mockReturnValue([tSpy]);
+  });
+
+  afterEach(() => {
+    reactI18Next.useTranslation = originalUseTranslation;
   });
 
   it('is hidden initially', () => {

--- a/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
+++ b/packages/datagateway-search/src/search/advancedHelpDialogue.component.tsx
@@ -6,8 +6,14 @@ import {
   IconButton,
   Link,
   styled,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
   Theme,
   Typography,
+  TableContainer,
+  Paper,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { Trans, useTranslation } from 'react-i18next';
@@ -80,7 +86,7 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
         }}
       >
         <DialogTitle id="advanced-search-dialog-title">
-          Advanced Search Tips
+          {t('advanced_search_help.title')}
           <IconButton
             aria-label={t('advanced_search_help.close_button_arialabel')}
             sx={{
@@ -99,6 +105,58 @@ const AdvancedHelpDialogue = (): React.ReactElement => {
           <Typography gutterBottom>
             {t('advanced_search_help.description')}
           </Typography>
+          {Array.isArray(
+            t('advanced_search_help.examples.examples', {
+              returnObjects: true,
+            })
+          ) &&
+            (
+              t('advanced_search_help.examples.examples', {
+                returnObjects: true,
+              }) as { name: string; value: string }[]
+            ).length > 0 && (
+              <Section>
+                <SectionTitle>
+                  {t('advanced_search_help.examples.title')}
+                </SectionTitle>
+                <SectionText>
+                  <Trans
+                    t={t}
+                    i18nKey="advanced_search_help.examples.description"
+                  >
+                    Below are a few examples of common searches and how they can
+                    be crafted to execute efficiently for those with access to
+                    large volumes of data:
+                  </Trans>
+                </SectionText>
+
+                <TableContainer component={Paper}>
+                  <Table size="small">
+                    <TableBody>
+                      {(
+                        t('advanced_search_help.examples.examples', {
+                          returnObjects: true,
+                        }) as { name: string; value: string }[]
+                      ).map(({ name, value }, index) => (
+                        <TableRow key={index}>
+                          <TableCell>{name}</TableCell>
+                          <TableCell>
+                            <Link
+                              component={RouterLink}
+                              to={`?searchText=${value}`}
+                              onClick={handleClose}
+                            >
+                              {value}
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Section>
+            )}
+
           <Section>
             <SectionTitle>{t('advanced_search_help.terms.title')}</SectionTitle>
             <SectionText>


### PR DESCRIPTION
## Description
Adds an example section to the advanced help dialogue. This section appears as the first section, but only if the examples array both exists and has at least 1 example in it.

![image](https://github.com/user-attachments/assets/0490f341-5570-4615-9135-dfc7305dad56)

Also fixed that the dialogue title wasn't using the translation string

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage