### PR TITLE
Fix initial download table timestamp showing as UNIX epoch

### DIFF
--- a/packages/datagateway-download/src/downloadTab/downloadTab.component.test.tsx
+++ b/packages/datagateway-download/src/downloadTab/downloadTab.component.test.tsx
@@ -1,5 +1,5 @@
 import { RenderResult } from '@testing-library/react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { fetchDownloadCart } from 'datagateway-common';
 import { createMemoryHistory, History } from 'history';
@@ -115,21 +115,44 @@ describe('DownloadTab', () => {
   });
 
   it('refreshes downloads when the refresh button is clicked', async () => {
+    const mockedDate = new Date(Date.UTC(2025, 4, 14, 14, 0, 0)).toUTCString();
+    global.Date.prototype.toLocaleString = jest.fn(() => mockedDate);
+
     renderComponent();
+
+    let resolve: (v: Awaited<ReturnType<typeof fetchDownloads>>) => void = (
+      _
+    ) => {
+      // no-op
+    };
 
     (
       fetchDownloads as jest.MockedFunction<typeof fetchDownloads>
     ).mockImplementation(
       () =>
-        new Promise((_) => {
+        new Promise((res) => {
           // do nothing, simulating pending promise
-          // to test refreshing state
+          // to test refreshing state that we can resolve
+          // whenever we want by calling resolve function
+          resolve = res;
         })
     );
 
     // go to downloads tab
 
     await user.click(await screen.findByText('downloadTab.downloads_tab'));
+
+    expect(
+      await screen.findByText('downloadTab.refreshing_downloads')
+    ).toBeInTheDocument();
+
+    act(() => {
+      resolve([]);
+    });
+
+    expect(
+      await screen.findByText(mockedDate.toLocaleString())
+    ).toBeInTheDocument();
 
     await user.click(
       screen.getByRole('button', {

--- a/packages/datagateway-download/src/downloadTab/downloadTab.component.tsx
+++ b/packages/datagateway-download/src/downloadTab/downloadTab.component.tsx
@@ -60,7 +60,9 @@ const DownloadTabs: React.FC = () => {
   // Set the initial tab.
   const [selectedTab, setSelectedTab] = React.useState(0);
   const [refreshDownloads, setRefreshDownloads] = React.useState(false);
-  const [lastCheckedTimestamp, setLastCheckedTimestamp] = React.useState(0);
+  const [lastCheckedTimestamp, setLastCheckedTimestamp] = React.useState<
+    number | undefined
+  >(undefined);
   const [t] = useTranslation();
 
   const handleChange = (
@@ -140,7 +142,8 @@ const DownloadTabs: React.FC = () => {
               )}
 
               <Typography variant="subtitle1" component="h3">
-                {!refreshDownloads ? (
+                {!refreshDownloads &&
+                typeof lastCheckedTimestamp !== 'undefined' ? (
                   <p style={{ paddingLeft: '10px ' }}>
                     <b>{t('downloadTab.last_checked')}: </b>{' '}
                     {new Date(lastCheckedTimestamp).toLocaleString()}


### PR DESCRIPTION
## Description
See title. Chris raised this as a minor issue when he views his own download table as he has a lot of downloads so it takes a while for the data to load and so he can clearly see the UNIX epoch timestamp

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
