### PR TITLE
Fix 500 errors in text filters when single quote is typed

### DIFF
--- a/packages/datagateway-common/src/api/index.test.tsx
+++ b/packages/datagateway-common/src/api/index.test.tsx
@@ -265,9 +265,9 @@ describe('generic api functions', () => {
     it('parses all filter types to api params successfully', () => {
       const sortAndFilters: { sort: SortType; filters: FiltersType } = {
         filters: {
-          name: { value: 'test', type: 'include' },
-          title: { value: 'test', type: 'exclude' },
-          doi: { value: 'test', type: 'exact' },
+          name: { value: "test'", type: 'include' },
+          title: { value: "test'", type: 'exclude' },
+          doi: { value: "test'", type: 'exact' },
           startDate: {
             startDate: '2021-08-05',
             endDate: '2021-08-06',
@@ -280,9 +280,9 @@ describe('generic api functions', () => {
       const params = new URLSearchParams();
       params.append('order', JSON.stringify('name asc'));
       params.append('order', JSON.stringify('id asc'));
-      params.append('where', JSON.stringify({ name: { ilike: 'test' } }));
-      params.append('where', JSON.stringify({ title: { nilike: 'test' } }));
-      params.append('where', JSON.stringify({ doi: { eq: 'test' } }));
+      params.append('where', JSON.stringify({ name: { ilike: "test''" } }));
+      params.append('where', JSON.stringify({ title: { nilike: "test''" } }));
+      params.append('where', JSON.stringify({ doi: { eq: "test''" } }));
       params.append(
         'where',
         JSON.stringify({ startDate: { gte: '2021-08-05 00:00:00' } })

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -250,23 +250,45 @@ export const getApiParams = (
         }
         if ('type' in filter && filter.type) {
           // use switch statement to ensure TS can detect we cover all cases
+          // also need to escape single quotes
           switch (filter.type) {
             case 'include':
               searchParams.append(
                 'where',
-                JSON.stringify({ [column]: { ilike: filter.value } })
+                JSON.stringify({
+                  [column]: {
+                    ilike:
+                      typeof filter.value === 'string'
+                        ? filter.value.replaceAll("'", "''")
+                        : filter.value,
+                  },
+                })
               );
               break;
             case 'exclude':
               searchParams.append(
                 'where',
-                JSON.stringify({ [column]: { nilike: filter.value } })
+                JSON.stringify({
+                  [column]: {
+                    nilike:
+                      typeof filter.value === 'string'
+                        ? filter.value.replaceAll("'", "''")
+                        : filter.value,
+                  },
+                })
               );
               break;
             case 'exact':
               searchParams.append(
                 'where',
-                JSON.stringify({ [column]: { eq: filter.value } })
+                JSON.stringify({
+                  [column]: {
+                    eq:
+                      typeof filter.value === 'string'
+                        ? filter.value.replaceAll("'", "''")
+                        : filter.value,
+                  },
+                })
               );
               break;
             default:

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.test.tsx
@@ -246,7 +246,7 @@ describe('Admin Download Status Table', () => {
         'Filter by downloadStatus.username'
       );
 
-      await user.type(usernameFilterInput, 'test user');
+      await user.type(usernameFilterInput, "test user'");
 
       // test exact filter
       await user.click(
@@ -265,7 +265,7 @@ describe('Admin Download Status Table', () => {
           downloadApiUrl: mockedSettings.downloadApiUrl,
           facilityName: mockedSettings.facilityName,
         },
-        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND download.userName = 'test user' ORDER BY download.id ASC LIMIT 0, 50`
+        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND download.userName = 'test user''' ORDER BY download.id ASC LIMIT 0, 50`
       );
 
       await user.clear(usernameFilterInput);
@@ -296,7 +296,7 @@ describe('Admin Download Status Table', () => {
         'Filter by downloadStatus.status'
       );
 
-      await user.type(availabilityFilterInput, 'downloadStatus.complete');
+      await user.type(availabilityFilterInput, "downloadStatus.complete'");
       await flushPromises();
 
       // test include filter
@@ -305,7 +305,7 @@ describe('Admin Download Status Table', () => {
           downloadApiUrl: mockedSettings.downloadApiUrl,
           facilityName: mockedSettings.facilityName,
         },
-        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND UPPER(download.status) LIKE CONCAT('%', 'COMPLETE', '%') ORDER BY download.id ASC LIMIT 0, 50`
+        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND UPPER(download.status) LIKE CONCAT('%', 'COMPLETE''', '%') ORDER BY download.id ASC LIMIT 0, 50`
       );
 
       // We simulate a change in the select from 'include' to 'exclude'.
@@ -326,7 +326,7 @@ describe('Admin Download Status Table', () => {
           downloadApiUrl: mockedSettings.downloadApiUrl,
           facilityName: mockedSettings.facilityName,
         },
-        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND UPPER(download.status) NOT LIKE CONCAT('%', 'COMPLETE', '%') ORDER BY download.id ASC LIMIT 0, 50`
+        `WHERE download.facilityName = '${mockedSettings.facilityName}' AND UPPER(download.status) NOT LIKE CONCAT('%', 'COMPLETE''', '%') ORDER BY download.id ASC LIMIT 0, 50`
       );
 
       await user.clear(availabilityFilterInput);

--- a/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
+++ b/packages/datagateway-download/src/downloadStatus/adminDownloadStatusTable.component.tsx
@@ -91,9 +91,12 @@ const AdminDownloadStatusTable: React.FC = () => {
 
           if ('type' in filter && filter.type) {
             // As UPPER is used need to pass text filters in upper case to avoid case sensitivity
+            // also need to escape single quotes
             const filterValue =
-              typeof filter.value === 'string' && filter.type !== 'exact'
-                ? (filter.value as string).toUpperCase()
+              typeof filter.value === 'string'
+                ? filter.type !== 'exact'
+                  ? (filter.value as string).toUpperCase().replaceAll("'", "''")
+                  : filter.value.replaceAll("'", "''")
                 : filter.value;
 
             // use switch statement to ensure TS can detect we cover all cases


### PR DESCRIPTION
## Description
Replace all single quotes with 2 single quotes (which is how you escape them in SQL) when filtering via the backend.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Single quotes on current preprod/datagateway-dseg throw a 500 error when there's a single quote in a text fitler, on this PR typing in a single quote should result in 200s instead
