### PR TITLE
Fix flaky unit tests

### DIFF
--- a/packages/datagateway-common/src/hooks/useSticky.test.ts
+++ b/packages/datagateway-common/src/hooks/useSticky.test.ts
@@ -1,69 +1,72 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { fireEvent, renderHook, waitFor } from '@testing-library/react';
+import { Mock } from 'vitest';
 import useSticky from './useSticky';
-import { fireEvent } from '@testing-library/react';
+
+// Mock lodash.debounce to return the function we want to call without delay
+vi.mock('lodash.debounce', () => ({
+  default: (fn: (args: unknown) => unknown) => fn,
+}));
 
 describe('useSticky', () => {
-  it('returns isSticky true if the bottom of the target element is scrolled past', () => {
-    const mockGetBoundingClientRect = vi.fn();
-    const target = document.createElement('div');
+  let mockGetBoundingClientRect: Mock<() => DOMRect>;
+  let target: HTMLDivElement;
+  const initScrollY = global.scrollY;
+
+  beforeEach(() => {
+    mockGetBoundingClientRect = vi.fn(() => new DOMRect(0, 0, 0, 100));
+    target = document.createElement('div');
     target.getBoundingClientRect = mockGetBoundingClientRect;
 
+    global.scrollY = 100;
+  });
+
+  afterEach(() => {
+    global.scrollY = initScrollY;
+  });
+
+  it('returns isSticky true if the bottom of the target element is scrolled past', async () => {
     // if window scrollY is greater than boundingClientRect bottom
     // that means the element is scrolled out of view
-    global.scrollY = 100;
-    mockGetBoundingClientRect.mockReturnValue({
-      bottom: 50,
-    });
+    mockGetBoundingClientRect.mockReturnValue(new DOMRect(0, 0, 0, 50));
 
     const { result } = renderHook(() => useSticky({ current: target }));
 
     // scroll the window
     fireEvent.scroll(window, {});
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(result.current.isSticky).toBe(true);
     });
   });
 
-  it('returns isSticky false if the bottom of the target element is still in view', () => {
-    const mockGetBoundingClientRect = vi.fn();
-    const target = document.createElement('div');
-    target.getBoundingClientRect = mockGetBoundingClientRect;
-
+  it('returns isSticky false if the bottom of the target element is still in view', async () => {
     // if window scrollY is greater than boundingClientRect bottom
     // that means the element is scrolled out of view
-    global.scrollY = 100;
-    mockGetBoundingClientRect.mockReturnValue({
-      bottom: 150,
-    });
+    mockGetBoundingClientRect.mockReturnValue(new DOMRect(0, 0, 0, 150));
 
     const { result } = renderHook(() => useSticky({ current: target }));
 
     // scroll the window
     fireEvent.scroll(window, {});
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(result.current.isSticky).toBe(false);
     });
   });
 
-  it('returns isSticky false upon window scroll if the given react ref points to null', () => {
+  it('returns isSticky false upon window scroll if the given react ref points to null', async () => {
     const { result } = renderHook(() => useSticky({ current: null }));
     // scroll the window
     fireEvent.scroll(window, {});
-    waitFor(() => {
+    await waitFor(() => {
       expect(result.current.isSticky).toBe(false);
     });
   });
 
-  it('returns isStick false upon window scroll if bottom coordinate of the target element is unavailable', () => {
-    const mockGetBoundingClientRect = vi.fn();
-    const target = document.createElement('div');
-    target.getBoundingClientRect = mockGetBoundingClientRect;
-
+  it('returns isStick false upon window scroll if bottom coordinate of the target element is unavailable', async () => {
     // if window scrollY is greater than boundingClientRect bottom
     // that means the element is scrolled out of view
-    global.scrollY = 100;
+    // @ts-expect-error purposefully providing an invalid value
     mockGetBoundingClientRect.mockReturnValue({
       top: 150,
     });
@@ -73,7 +76,7 @@ describe('useSticky', () => {
     // scroll the window
     fireEvent.scroll(window, {});
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(result.current.isSticky).toBe(false);
     });
   });

--- a/packages/datagateway-dataview/src/views/table/datafileTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/datafileTable.component.test.tsx
@@ -1,31 +1,31 @@
-import {
-  type Datafile,
-  type DownloadCartItem,
-  dGCommonInitialState,
-} from 'datagateway-common';
-import { Provider } from 'react-redux';
-import { Router } from 'react-router-dom';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-import type { StateType } from '../../state/app.types';
-import { initialState as dgDataViewInitialState } from '../../state/reducers/dgdataview.reducer';
-import DatafileTable from './datafileTable.component';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createMemoryHistory, type History } from 'history';
-import { findAllRows, findColumnHeaderByName } from '../../setupTests';
 import {
   render,
-  type RenderResult,
   screen,
   waitFor,
   within,
+  type RenderResult,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import axios, { type AxiosResponse } from 'axios';
+import {
+  dGCommonInitialState,
+  type Datafile,
+  type DownloadCartItem,
+} from 'datagateway-common';
 import {
   findCellInRow,
   findColumnIndexByName,
 } from 'datagateway-search/src/setupTests';
-import axios, { type AxiosResponse } from 'axios';
+import { createMemoryHistory, type History } from 'history';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { findAllRows, findColumnHeaderByName } from '../../setupTests';
+import type { StateType } from '../../state/app.types';
+import { initialState as dgDataViewInitialState } from '../../state/reducers/dgdataview.reducer';
+import DatafileTable from './datafileTable.component';
 
 describe('Datafile table component', () => {
   const mockStore = configureStore([thunk]);
@@ -151,11 +151,14 @@ describe('Datafile table component', () => {
     renderComponent();
 
     let rows: HTMLElement[] = [];
-    await waitFor(async () => {
-      rows = await findAllRows();
-      // should have 1 row in the table
-      expect(rows).toHaveLength(1);
-    });
+    await waitFor(
+      async () => {
+        rows = await findAllRows();
+        // should have 1 row in the table
+        expect(rows).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     const row = rows[0];
 
@@ -310,9 +313,12 @@ describe('Datafile table component', () => {
 
     renderComponent();
     // wait for rows to show up
-    await waitFor(async () => {
-      expect(await findAllRows()).toHaveLength(1);
-    });
+    await waitFor(
+      async () => {
+        expect(await findAllRows()).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     const selectAllCheckbox = await screen.findByRole('checkbox', {
       name: 'select all rows',
@@ -327,9 +333,12 @@ describe('Datafile table component', () => {
 
     renderComponent();
     // wait for rows to show up
-    await waitFor(async () => {
-      expect(await findAllRows()).toHaveLength(1);
-    });
+    await waitFor(
+      async () => {
+        expect(await findAllRows()).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     await waitFor(() => {
       expect(
@@ -343,10 +352,13 @@ describe('Datafile table component', () => {
 
     // wait for rows to show up
     let rows: HTMLElement[] = [];
-    await waitFor(async () => {
-      rows = await findAllRows();
-      expect(rows).toHaveLength(1);
-    });
+    await waitFor(
+      async () => {
+        rows = await findAllRows();
+        expect(rows).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     expect(
       within(rows[0]).getByRole('button', { name: 'buttons.download' })
@@ -358,10 +370,13 @@ describe('Datafile table component', () => {
 
     // wait for rows to show up
     let rows: HTMLElement[] = [];
-    await waitFor(async () => {
-      rows = await findAllRows();
-      expect(rows).toHaveLength(1);
-    });
+    await waitFor(
+      async () => {
+        rows = await findAllRows();
+        expect(rows).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     expect(screen.queryByTestId('datafile-details-panel')).toBeNull();
 

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDatafilesTable.component.test.tsx
@@ -1,3 +1,13 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  render,
+  screen,
+  waitFor,
+  within,
+  type RenderResult,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios, { AxiosResponse } from 'axios';
 import {
   Datafile,
   dGCommonInitialState,
@@ -8,15 +18,11 @@ import {
   useIds,
   useRemoveFromCart,
 } from 'datagateway-common';
+import { createMemoryHistory, type History } from 'history';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { StateType } from '../../../state/app.types';
-import { initialState as dgDataViewInitialState } from '../../../state/reducers/dgdataview.reducer';
-import DLSDatafilesTable from './dlsDatafilesTable.component';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createMemoryHistory, type History } from 'history';
 import {
   findAllRows,
   findCellInRow,
@@ -24,15 +30,9 @@ import {
   findColumnIndexByName,
   findRowAt,
 } from '../../../setupTests';
-import {
-  render,
-  type RenderResult,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import axios, { AxiosResponse } from 'axios';
+import { StateType } from '../../../state/app.types';
+import { initialState as dgDataViewInitialState } from '../../../state/reducers/dgdataview.reducer';
+import DLSDatafilesTable from './dlsDatafilesTable.component';
 
 vi.mock('datagateway-common', async () => {
   const originalModule = await vi.importActual('datagateway-common');
@@ -135,9 +135,15 @@ describe('DLS datafiles table component', () => {
   it('renders correctly', async () => {
     renderComponent();
 
-    const rows = await findAllRows();
-    // should have 1 row in the table
-    expect(rows).toHaveLength(1);
+    let rows: HTMLElement[] = [];
+    await waitFor(
+      async () => {
+        rows = await findAllRows();
+        // should have 1 row in the table
+        expect(rows).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     expect(await findColumnHeaderByName('datafiles.name')).toBeInTheDocument();
     expect(

--- a/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/isis/isisDatafilesTable.component.test.tsx
@@ -1,31 +1,31 @@
-import ISISDatafilesTable from './isisDatafilesTable.component';
-import { initialState as dgDataViewInitialState } from '../../../state/reducers/dgdataview.reducer';
-import configureStore from 'redux-mock-store';
-import type { StateType } from '../../../state/app.types';
-import {
-  type Datafile,
-  dGCommonInitialState,
-  DownloadCartItem,
-} from 'datagateway-common';
-import { Provider } from 'react-redux';
-import thunk from 'redux-thunk';
-import { Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createMemoryHistory, type History } from 'history';
-import { findAllRows, findColumnHeaderByName } from '../../../setupTests';
 import {
   render,
-  type RenderResult,
   screen,
   waitFor,
   within,
+  type RenderResult,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import axios, { AxiosResponse } from 'axios';
+import {
+  DownloadCartItem,
+  dGCommonInitialState,
+  type Datafile,
+} from 'datagateway-common';
 import {
   findCellInRow,
   findColumnIndexByName,
 } from 'datagateway-search/src/setupTests';
-import axios, { AxiosResponse } from 'axios';
+import { createMemoryHistory, type History } from 'history';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { findAllRows, findColumnHeaderByName } from '../../../setupTests';
+import type { StateType } from '../../../state/app.types';
+import { initialState as dgDataViewInitialState } from '../../../state/reducers/dgdataview.reducer';
+import ISISDatafilesTable from './isisDatafilesTable.component';
 
 describe('ISIS datafiles table component', () => {
   const mockStore = configureStore([thunk]);
@@ -151,11 +151,14 @@ describe('ISIS datafiles table component', () => {
     renderComponent();
 
     let rows: HTMLElement[] = [];
-    await waitFor(async () => {
-      rows = await findAllRows();
-      // should have 1 row in the table
-      expect(rows).toHaveLength(1);
-    });
+    await waitFor(
+      async () => {
+        rows = await findAllRows();
+        // should have 1 row in the table
+        expect(rows).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     // check that column headers are shown correctly
     expect(await findColumnHeaderByName('datafiles.name')).toBeInTheDocument();
@@ -285,9 +288,12 @@ describe('ISIS datafiles table component', () => {
     renderComponent();
 
     // wait for rows to show up
-    await waitFor(async () => {
-      expect(await findAllRows()).toHaveLength(1);
-    });
+    await waitFor(
+      async () => {
+        expect(await findAllRows()).toHaveLength(1);
+      },
+      { timeout: 5_000 }
+    );
 
     // row should not be selected initially as the cart is empty
     expect(


### PR DESCRIPTION
## Description
I noticed the unit tests are failing on CI semi-often, so looking at the logs I hopefully have stabilised the culplit tests.

- useSticky test was pretty badly implemented, this fixes e.g. missing async/awaits, missing debounce mocking etc. which will fix the issues
- datafile table tests are failing intermittently and I don;t know why - I've just increased the timeouts on the `waitFor`s that were failing for now

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
