### PR TITLE
Fix ismintable error handling to account for API changes

### DIFF
--- a/packages/datagateway-common/src/api/dois.test.tsx
+++ b/packages/datagateway-common/src/api/dois.test.tsx
@@ -3,7 +3,6 @@ import axios, { AxiosError, AxiosHeaders } from 'axios';
 import log from 'loglevel';
 import {
   handleDOIAPIError,
-  isMintabilityErrorExpected,
   useCheckUser,
   useDOI,
   useDeleteDraftVersion,
@@ -140,57 +139,6 @@ describe('handleDOIAPIError', () => {
         message: 'Network Error, please reload the page or try again later',
       },
     });
-  });
-});
-
-// Entities do not belong to an existing session DOI: [15]
-//
-describe('isMintabilityErrorExpected', () => {
-  it("returns true if 403 error if the user isn't the PI", () => {
-    const error = {
-      response: {
-        status: 403,
-        data: { detail: 'User is not PI for: [1]' },
-      },
-    };
-
-    expect(isMintabilityErrorExpected(error)).toBe(true);
-  });
-
-  it('returns true if 400 error mentioning session DOIs for no session DOI error', () => {
-    const error = {
-      response: {
-        status: 400,
-        data: {
-          detail: 'Entities do not belong to an existing session DOI: [1]',
-        },
-      },
-    };
-
-    expect(isMintabilityErrorExpected(error)).toBe(true);
-  });
-
-  it('returns false for other error codes', () => {
-    const error = {
-      response: {
-        status: 422,
-      },
-    };
-
-    expect(isMintabilityErrorExpected(error)).toBe(false);
-  });
-
-  it('returns false for other 400 errors', () => {
-    const error = {
-      response: {
-        status: 400,
-        data: {
-          details: 'other error',
-        },
-      },
-    };
-
-    expect(isMintabilityErrorExpected(error)).toBe(false);
   });
 });
 
@@ -652,6 +600,28 @@ describe('doi api functions', () => {
 
       expect(result.current.data).toEqual(false);
       expect(axios.post).not.toHaveBeenCalled();
+    });
+
+    it('should log and retry unexpected errors', async () => {
+      const error = {
+        message: 'Test error message',
+        response: {
+          status: 400,
+        },
+      };
+      axios.post = vi.fn().mockRejectedValue(error);
+
+      const { result } = renderHook(
+        () =>
+          useIsCartMintable(mockCartItems, 'https://example.com/doi-minter'),
+        {
+          wrapper: createReactQueryWrapper(),
+        }
+      );
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(log.error).toHaveBeenCalled();
+      expect(axios.post).toHaveBeenCalledTimes(4);
     });
 
     it('should not log expected errors or retry them', async () => {

--- a/packages/datagateway-common/src/api/dois.tsx
+++ b/packages/datagateway-common/src/api/dois.tsx
@@ -475,19 +475,9 @@ export const isCartMintable = async (
   return status === 200;
 };
 
-// these are "expected" errors i.e. user not a PI or no session DOI
-export const isMintabilityErrorExpected = (
-  error: AxiosError<{
-    detail: { msg: string }[] | string;
-  }>
-): boolean => {
-  return (
-    error.response?.status === 403 ||
-    (error.response?.status === 400 &&
-    typeof error.response?.data?.detail === 'string'
-      ? error.response.data.detail.includes('session DOI')
-      : false)
-  );
+// these are "expected" errors i.e. user not a PI, no session DOI or incorrect data type
+export const isMintabilityErrorExpected = (error: AxiosError): boolean => {
+  return error.response?.status === 403;
 };
 
 /**
@@ -499,9 +489,16 @@ export const useIsCartMintable = (
   doiMinterUrl: string | undefined
 ): UseQueryResult<
   boolean,
-  AxiosError<{
-    detail: { msg: string }[] | string;
-  }>
+  AxiosError<
+    | {
+        detail: { msg: string }[] | string;
+      }
+    | {
+        investigation_ids: Record<string, string>;
+        dataset_ids: Record<string, string>;
+        datafile_ids: Record<string, string>;
+      }
+  >
 > => {
   const queryClient = useQueryClient();
   const opts = queryClient.getDefaultOptions();
@@ -517,14 +514,14 @@ export const useIsCartMintable = (
     },
     {
       onError: (error) => {
-        handleDOIAPIError(
-          error,
-          undefined,
-          undefined,
-          // don't broadcast or log "expected" errors
-          !isMintabilityErrorExpected(error),
-          !isMintabilityErrorExpected(error)
-        );
+        if (!isMintabilityErrorExpected(error))
+          handleDOIAPIError(
+            error as AxiosError<{
+              detail: { msg: string }[] | string;
+            }>,
+            undefined,
+            undefined
+          );
       },
       retry: (failureCount, error) => {
         // don't bother retrying "expected" errors - all other errors use default retry behaviour

--- a/packages/datagateway-dataview/src/views/landing/dls/dlsDataPublicationEditForm.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/dls/dlsDataPublicationEditForm.component.test.tsx
@@ -705,12 +705,28 @@ describe('DOI edit form component', () => {
         name: 'unmintable cart investigation',
         parentEntities: [],
       },
+      {
+        entityId: 6,
+        entityType: 'dataset',
+        id: 3,
+        name: 'unmintable cart dataset',
+        parentEntities: [],
+      },
+      {
+        entityId: 7,
+        entityType: 'datafile',
+        id: 3,
+        name: 'unmintable cart datafile',
+        parentEntities: [],
+      },
     ];
     mintabilityResponse = Promise.reject({
       response: {
         status: 403,
         data: {
-          detail: '[5]',
+          investigation_ids: { '5': 'Unable to mint' },
+          dataset_ids: { '6': 'Unable to mint' },
+          datafile_ids: { '7': 'Unable to mint' },
         },
       },
     });
@@ -764,6 +780,24 @@ describe('DOI edit form component', () => {
         await user.click(
           await within(choices).findByRole('checkbox', {
             name: 'unmintable cart investigation',
+          })
+        )
+    ).rejects.toThrow();
+
+    await expect(
+      async () =>
+        await user.click(
+          await within(choices).findByRole('checkbox', {
+            name: 'unmintable cart dataset',
+          })
+        )
+    ).rejects.toThrow();
+
+    await expect(
+      async () =>
+        await user.click(
+          await within(choices).findByRole('checkbox', {
+            name: 'unmintable cart datafile',
           })
         )
     ).rejects.toThrow();

--- a/packages/datagateway-dataview/src/views/landing/dls/dlsDataPublicationEditForm.component.tsx
+++ b/packages/datagateway-dataview/src/views/landing/dls/dlsDataPublicationEditForm.component.tsx
@@ -232,17 +232,13 @@ const DLSDataPublicationEditForm: React.FC<DLSDataPublicationEditFormProps> = (
   const { isLoading: cartMintabilityLoading, error: mintableError } =
     useIsCartMintable(cart, doiMinterUrl);
 
-  const unmintableEntityIDs: number[] | undefined = React.useMemo(
+  const unmintableEntityIDs = React.useMemo(
     () =>
       mintableError !== null &&
       isMintabilityErrorExpected(mintableError) &&
-      typeof mintableError?.response?.data?.detail === 'string'
-        ? JSON.parse(
-            mintableError.response.data.detail.substring(
-              mintableError.response.data.detail.indexOf('['),
-              mintableError.response.data.detail.lastIndexOf(']') + 1
-            )
-          )
+      mintableError?.response?.data &&
+      'investigation_ids' in mintableError.response.data
+        ? mintableError.response.data
         : undefined,
     [mintableError]
   );
@@ -266,7 +262,18 @@ const DLSDataPublicationEditForm: React.FC<DLSDataPublicationEditFormProps> = (
             id: cartItem.entityId,
             label: cartItem.name,
             entityType: cartItem.entityType,
-            disabled: unmintableEntityIDs?.includes(cartItem.entityId),
+            disabled:
+              cartItem.entityType === 'datafile'
+                ? typeof unmintableEntityIDs?.datafile_ids?.[
+                    cartItem.entityId
+                  ] !== 'undefined'
+                : cartItem.entityType === 'dataset'
+                  ? typeof unmintableEntityIDs?.dataset_ids?.[
+                      cartItem.entityId
+                    ] !== 'undefined'
+                  : typeof unmintableEntityIDs?.investigation_ids?.[
+                      cartItem.entityId
+                    ] !== 'undefined',
           }))
       );
       setLoadedUnselectedContent(true);

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.test.tsx
@@ -620,7 +620,11 @@ describe('Download cart table component', () => {
   it('should disable Generate DOI button when cart is not mintable', async () => {
     mintabilityResponse = Promise.reject({
       response: {
-        data: { detail: 'Not allowed to mint the following items: [2,4]' },
+        data: {
+          investigation_ids: { '2': 'Unable to mint' },
+          dataset_ids: { '3': 'Unable to mint' },
+          datafile_ids: { '4': 'Unable to mint' },
+        },
         status: 403,
       },
     });
@@ -645,9 +649,9 @@ describe('Download cart table component', () => {
       .filter((e) => e.hasAttribute('aria-rowindex'));
     const muiErrorColor = createTheme().palette.error.main;
     expect(tableRows[1]).toHaveStyle(`background-color: ${muiErrorColor}`);
+    expect(tableRows[2]).toHaveStyle(`background-color: ${muiErrorColor}`);
     expect(tableRows[3]).toHaveStyle(`background-color: ${muiErrorColor}`);
     expect(tableRows[0]).not.toHaveStyle(`background-color: ${muiErrorColor}`);
-    expect(tableRows[2]).not.toHaveStyle(`background-color: ${muiErrorColor}`);
 
     await user.click(generateDOIButton);
 

--- a/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
+++ b/packages/datagateway-download/src/downloadCart/downloadCartTable.component.tsx
@@ -190,26 +190,41 @@ const DownloadCartTable: React.FC<DownloadCartTableProps> = (
     return filteredData?.sort(sortCartItems);
   }, [cartItems, fileSizesAndCounts, filters, sort]);
 
-  const unmintableEntityIDs: number[] | undefined = React.useMemo(
+  const unmintableEntityIDs = React.useMemo(
     () =>
       mintableError !== null &&
       isMintabilityErrorExpected(mintableError) &&
-      typeof mintableError?.response?.data?.detail === 'string'
-        ? JSON.parse(
-            mintableError.response.data.detail.substring(
-              mintableError.response.data.detail.indexOf('['),
-              mintableError.response.data.detail.lastIndexOf(']') + 1
-            )
-          )
+      mintableError?.response?.data &&
+      'investigation_ids' in mintableError.response.data
+        ? mintableError.response.data
         : undefined,
     [mintableError]
   );
 
   const unmintableRowIDs = React.useMemo(() => {
     if (unmintableEntityIDs && sortedAndFilteredData) {
-      return unmintableEntityIDs.map((id) =>
-        sortedAndFilteredData.findIndex((entity) => entity.entityId === id)
-      );
+      return Object.keys(unmintableEntityIDs.investigation_ids)
+        .map((id) =>
+          sortedAndFilteredData.findIndex(
+            (entity) =>
+              entity.entityType === 'investigation' &&
+              `${entity.entityId}` === id
+          )
+        )
+        .concat(
+          Object.keys(unmintableEntityIDs.dataset_ids).map((id) =>
+            sortedAndFilteredData.findIndex(
+              (entity) =>
+                entity.entityType === 'dataset' && `${entity.entityId}` === id
+            )
+          ),
+          Object.keys(unmintableEntityIDs.datafile_ids).map((id) =>
+            sortedAndFilteredData.findIndex(
+              (entity) =>
+                entity.entityType === 'datafile' && `${entity.entityId}` === id
+            )
+          )
+        );
     } else {
       return [];
     }


### PR DESCRIPTION
## Description
See https://github.com/ral-facilities/icat-doi-minter-api/pull/137 for corresponding API changes.

But now, all ismintable "expected errors", aka ones telling us "no this isn't mintable" are now 403, and they have a different format which splits up the 3 different entity types and gives individual reasons per ID. We don't need the reasons, but need to handle the changed format to extract out the IDs and entity types to highlight the correct things.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [ ] datagateway-dseg has updated api, check that adding unmintable data highlights rows (should be easy to find any data with no session DOI, or that you're not the PI for)
