### PR TITLE
Improve UX of user generated DOIs

### DIFF
--- a/packages/datagateway-common/__mocks__/react-i18next.jsx
+++ b/packages/datagateway-common/__mocks__/react-i18next.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-// eslint-disable-next-line no-use-before-define
 import React from 'react';
 import * as reactI18next from 'react-i18next';
 
@@ -9,7 +7,11 @@ const hasChildren = (node) =>
 const getChildren = (node) =>
   node && node.children ? node.children : node.props && node.props.children;
 
-const renderNodes = (reactNodes) => {
+const renderNodes = (i18nKey, reactNodes) => {
+  if (typeof reactNodes === 'undefined') {
+    return i18nKey;
+  }
+
   if (typeof reactNodes === 'string') {
     return reactNodes;
   }
@@ -53,10 +55,11 @@ const applyTranslation = (Component) => {
   return applyProps;
 };
 
+// eslint-disable-next-line no-undef
 module.exports = {
   // this mock makes sure any components using the translate HoC receive the t function as a prop
   withTranslation: () => (Component) => applyTranslation(Component),
-  Trans: ({ children }) => renderNodes(children),
+  Trans: ({ i18nKey, children }) => renderNodes(i18nKey, children),
   Translation: ({ children }) => children((k) => k, { i18n: {} }),
   useTranslation: () => useMock,
 

--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -125,6 +125,8 @@ export interface User {
   id: number;
   name: string;
   fullName?: string;
+  givenName?: string;
+  familyName?: string;
   email?: string;
   affiliation?: string;
   orcidId?: string;

--- a/packages/datagateway-common/src/dois/DOIMetadataConfirmation.component.tsx
+++ b/packages/datagateway-common/src/dois/DOIMetadataConfirmation.component.tsx
@@ -65,7 +65,10 @@ const CreatorsAndContributorsMetadata: React.FC<{
                     <Typography>
                       {nameIdentifier.nameIdentifierScheme}:{' '}
                       {nameIdentifier.nameIdentifier.startsWith('http') ? (
-                        <Link href={nameIdentifier.nameIdentifier}>
+                        <Link
+                          href={nameIdentifier.nameIdentifier}
+                          target="_blank"
+                        >
                           {nameIdentifier.nameIdentifier}
                         </Link>
                       ) : (
@@ -143,7 +146,9 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
                   <Grid item>
                     <Typography>
                       {t('DOIGenerationForm.subject_schemeUri')}:{' '}
-                      <Link href={subject.schemeUri}>{subject.schemeUri}</Link>
+                      <Link href={subject.schemeUri} target="_blank">
+                        {subject.schemeUri}
+                      </Link>
                     </Typography>
                   </Grid>
                 )}
@@ -151,7 +156,9 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
                   <Grid item>
                     <Typography>
                       {t('DOIGenerationForm.subject_valueUri')}:{' '}
-                      <Link href={subject.valueUri}>{subject.valueUri}</Link>
+                      <Link href={subject.valueUri} target="_blank">
+                        {subject.valueUri}
+                      </Link>
                     </Typography>
                   </Grid>
                 )}
@@ -184,11 +191,14 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
                     <Typography>
                       {t('DOIGenerationForm.related_identifier_identifier')}:{' '}
                       {relatedIdentifierType === DOIIdentifierType.DOI ? (
-                        <Link href={`${doiHandleUrl}/${relatedIdentifier}`}>
+                        <Link
+                          href={`${doiHandleUrl}/${relatedIdentifier}`}
+                          target="_blank"
+                        >
                           {relatedIdentifier}
                         </Link>
                       ) : relatedIdentifierType === DOIIdentifierType.URL ? (
-                        <Link href={relatedIdentifier}>
+                        <Link href={relatedIdentifier} target="_blank">
                           {relatedIdentifier}
                         </Link>
                       ) : (
@@ -263,7 +273,7 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
               <Grid item>
                 <Typography>
                   {t('DOIGenerationForm.publisherSchemeURI')}:{' '}
-                  <Link href={metadata.publisher.schemeUri}>
+                  <Link href={metadata.publisher.schemeUri} target="_blank">
                     {metadata.publisher.schemeUri}
                   </Link>
                 </Typography>
@@ -351,7 +361,9 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
                     <Grid item>
                       <Typography>
                         {t('DOIGenerationForm.rightsURI')}:{' '}
-                        <Link href={rightsUri}>{rightsUri}</Link>
+                        <Link href={rightsUri} target="_blank">
+                          {rightsUri}
+                        </Link>
                       </Typography>
                     </Grid>
                   )}
@@ -375,7 +387,9 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
                     <Grid item>
                       <Typography>
                         {t('DOIGenerationForm.rightsSchemeURI')}:{' '}
-                        <Link href={schemeUri}>{schemeUri}</Link>
+                        <Link href={schemeUri} target="_blank">
+                          {schemeUri}
+                        </Link>
                       </Typography>
                     </Grid>
                   )}
@@ -445,7 +459,9 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
                   <Grid item>
                     <Typography>
                       {t('DOIGenerationForm.funderSchemeURI')}:{' '}
-                      <Link href={funder.schemeUri}>{funder.schemeUri}</Link>
+                      <Link href={funder.schemeUri} target="_blank">
+                        {funder.schemeUri}
+                      </Link>
                     </Typography>
                   </Grid>
                 )}
@@ -453,7 +469,9 @@ const DOIMetadataConfirmation: React.FC<DOIMetadataConfirmationProps> = (
                   <Grid item>
                     <Typography>
                       {t('DOIGenerationForm.awardURI')}:{' '}
-                      <Link href={funder.awardUri}>{funder.awardUri}</Link>
+                      <Link href={funder.awardUri} target="_blank">
+                        {funder.awardUri}
+                      </Link>
                     </Typography>
                   </Grid>
                 )}

--- a/packages/datagateway-common/src/dois/DOIMetadataForm.component.test.tsx
+++ b/packages/datagateway-common/src/dois/DOIMetadataForm.component.test.tsx
@@ -91,20 +91,63 @@ describe('DOI generation form component', () => {
     expect(props.setDescription).toHaveBeenCalledWith('description2');
   });
 
-  it('should disable mint button at correct times', () => {
+  it('should call onMintClick when mint button pressed with no errors', async () => {
+    renderComponent();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
+    );
+
+    expect(props.onMintClick).toHaveBeenCalled();
+  });
+
+  it('should show errors and disable mint button at correct times', async () => {
     const { rerender } = renderComponent();
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).not.toBeDisabled();
 
+    // selectedUsers is empty
+    const prevSelectedUsers = props.selectedUsers;
+    props.selectedUsers = [];
+    rerender(<DOIMetadataForm {...props} />);
+
+    // should be disabled without having to click the button to prompt errors
+    // as no users indicates the list of users is loading
+    expect(
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
+    ).toBeDisabled();
+
     // title is empty
+    props.selectedUsers = prevSelectedUsers;
     props.title = '';
     rerender(<DOIMetadataForm {...props} />);
 
+    // click on button to show errors
+    await user.click(
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
+    );
+
+    // button should be disabled after initial click to trigger errors to show
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
+    expect(
+      screen.getByRole('textbox', {
+        name: 'DOIGenerationForm.title',
+      })
+    ).toHaveAttribute('aria-invalid', 'true');
 
     // description is empty
     props.title = 'test';
@@ -112,24 +155,24 @@ describe('DOI generation form component', () => {
     rerender(<DOIMetadataForm {...props} />);
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
-
-    // selectedUsers is empty
-    props.description = 'test';
-    props.selectedUsers = [];
-    rerender(<DOIMetadataForm {...props} />);
-
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
-    ).toBeDisabled();
+      screen.getByRole('textbox', {
+        name: 'DOIGenerationForm.description',
+      })
+    ).toHaveAttribute('aria-invalid', 'true');
 
     // selectedUsers has empty contributor type
     props.selectedUsers = [{ id: 1, name: 'test', contributor_type: '' }];
     rerender(<DOIMetadataForm {...props} />);
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     // relatedIdentifiers has empty relationtypes or relatedItemtypes
@@ -154,7 +197,9 @@ describe('DOI generation form component', () => {
     rerender(<DOIMetadataForm {...props} />);
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     // disableMintButton is set to true
@@ -171,7 +216,9 @@ describe('DOI generation form component', () => {
     rerender(<DOIMetadataForm {...props} />);
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     // empty subjects
@@ -180,7 +227,9 @@ describe('DOI generation form component', () => {
     rerender(<DOIMetadataForm {...props} />);
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     // empty techniques
@@ -189,7 +238,9 @@ describe('DOI generation form component', () => {
     rerender(<DOIMetadataForm {...props} />);
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
   });
 
@@ -198,7 +249,9 @@ describe('DOI generation form component', () => {
     renderComponent();
 
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
 

--- a/packages/datagateway-common/src/dois/DOIMetadataForm.component.tsx
+++ b/packages/datagateway-common/src/dois/DOIMetadataForm.component.tsx
@@ -62,6 +62,28 @@ const DOIMetadataForm: React.FC<DOIMetadataFormProps> = (props) => {
 
   const [t] = useTranslation();
 
+  const [showErrors, setShowErrors] = React.useState(false);
+
+  const titleError = title.length === 0;
+  const descriptionError = description.length === 0;
+  const usersError = selectedUsers.some((user) => user.contributor_type === '');
+  const relatedIdentifiersError = relatedIdentifiers.some(
+    (relatedIdentifier) =>
+      relatedIdentifier.relationType === '' ||
+      relatedIdentifier.relatedItemType === undefined ||
+      relatedIdentifier.relatedIdentifierType === undefined // should never happen
+  );
+  const subjectError = subjects.length === 0;
+  const techniqueError = techniques.length === 0;
+
+  const validationError =
+    titleError ||
+    usersError ||
+    descriptionError ||
+    relatedIdentifiersError ||
+    subjectError ||
+    techniqueError;
+
   return (
     <Grid
       container
@@ -83,6 +105,7 @@ const DOIMetadataForm: React.FC<DOIMetadataFormProps> = (props) => {
           required
           fullWidth
           color="secondary"
+          error={showErrors && titleError}
           value={title}
           onChange={(event) => setTitle(event.target.value)}
           disabled={mintLoading}
@@ -96,6 +119,7 @@ const DOIMetadataForm: React.FC<DOIMetadataFormProps> = (props) => {
           rows={4}
           fullWidth
           color="secondary"
+          error={showErrors && descriptionError}
           value={description}
           onChange={(event) => setDescription(event.target.value)}
           disabled={mintLoading}
@@ -105,8 +129,10 @@ const DOIMetadataForm: React.FC<DOIMetadataFormProps> = (props) => {
         <TechniquesAndSubjects
           techniques={techniques}
           setTechniques={setTechniques}
+          techniqueError={showErrors && techniqueError}
           subjects={subjects}
           setSubjects={setSubjects}
+          subjectError={showErrors && subjectError}
           disabled={mintLoading}
           bioportalUrl={bioportalUrl}
         />
@@ -118,6 +144,7 @@ const DOIMetadataForm: React.FC<DOIMetadataFormProps> = (props) => {
           dataCiteUrl={dataCiteUrl}
           doiHandleUrl={doiHandleUrl}
           disabled={mintLoading}
+          showErrors={showErrors}
         />
       </Grid>
       <Grid item>
@@ -127,6 +154,7 @@ const DOIMetadataForm: React.FC<DOIMetadataFormProps> = (props) => {
           doiMinterUrl={doiMinterUrl}
           localContactRole={localContactRole}
           disabled={mintLoading}
+          showErrors={showErrors}
         />
       </Grid>
       <Grid item alignSelf="flex-end">
@@ -137,22 +165,18 @@ const DOIMetadataForm: React.FC<DOIMetadataFormProps> = (props) => {
           loading={mintLoading}
           disabled={
             disableMintButton ||
-            title.length === 0 ||
-            description.length === 0 ||
-            selectedUsers.length === 0 ||
-            selectedUsers.some((user) => user.contributor_type === '') ||
-            relatedIdentifiers.some(
-              (relatedIdentifier) =>
-                relatedIdentifier.relationType === '' ||
-                relatedIdentifier.relatedItemType === undefined ||
-                relatedIdentifier.relatedIdentifierType === undefined // should never happen
-            ) ||
-            subjects.length === 0 ||
-            techniques.length === 0
+            selectedUsers.length === 0 || // disable whilst users are loading
+            (validationError && showErrors)
           }
-          onClick={onMintClick}
+          onClick={() => {
+            if (validationError) {
+              setShowErrors(true);
+            } else {
+              onMintClick();
+            }
+          }}
         >
-          {t('DOIGenerationForm.generate_DOI')}
+          {t('DOIGenerationForm.review_metadata_button')}
         </LoadingButton>
       </Grid>
     </Grid>

--- a/packages/datagateway-common/src/dois/__snapshots__/DOIMetadataConfirmation.component.test.tsx.snap
+++ b/packages/datagateway-common/src/dois/__snapshots__/DOIMetadataConfirmation.component.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/technique"
+              target="_blank"
             >
               https://example.com/technique
             </a>
@@ -112,6 +113,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/technique/1"
+              target="_blank"
             >
               https://example.com/technique/1
             </a>
@@ -149,6 +151,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/technique"
+              target="_blank"
             >
               https://example.com/technique
             </a>
@@ -164,6 +167,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/technique/2"
+              target="_blank"
             >
               https://example.com/technique/2
             </a>
@@ -196,6 +200,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://doi.org/related.doi"
+              target="_blank"
             >
               related.doi
             </a>
@@ -242,6 +247,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/related-url"
+              target="_blank"
             >
               https://example.com/related-url
             </a>
@@ -426,6 +432,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
               <a
                 class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
                 href="https://orcid.org/123"
+                target="_blank"
               >
                 https://orcid.org/123
               </a>
@@ -486,6 +493,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/publisher"
+              target="_blank"
             >
               https://example.com/publisher
             </a>
@@ -638,6 +646,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/rights"
+              target="_blank"
             >
               https://example.com/rights
             </a>
@@ -671,6 +680,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/rights-scheme"
+              target="_blank"
             >
               https://example.com/rights-scheme
             </a>
@@ -781,6 +791,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/funder"
+              target="_blank"
             >
               https://example.com/funder
             </a>
@@ -796,6 +807,7 @@ exports[`DOI metadata confirmation component > should display the provided draft
             <a
               class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
               href="https://example.com/award"
+              target="_blank"
             >
               https://example.com/award
             </a>

--- a/packages/datagateway-common/src/dois/creatorsAndContributors.component.test.tsx
+++ b/packages/datagateway-common/src/dois/creatorsAndContributors.component.test.tsx
@@ -24,7 +24,7 @@ const createTestQueryClient = (): QueryClient =>
     },
   });
 
-describe('DOI generation form component', () => {
+describe('Creators and contributors component', () => {
   let user: ReturnType<typeof userEvent.setup>;
 
   let props: React.ComponentProps<typeof CreatorsAndContributors>;
@@ -70,7 +70,8 @@ describe('DOI generation form component', () => {
         {
           id: 2,
           name: '2',
-          fullName: 'User 2',
+          givenName: 'User',
+          familyName: '2',
           email: 'user2@example.com',
           affiliation: 'Example 2 Uni',
           contributor_type: ContributorType.Creator,
@@ -80,12 +81,12 @@ describe('DOI generation form component', () => {
       doiMinterUrl: 'example.com',
       disabled: false,
       localContactRole: 'local_contact|DataCollector',
+      showErrors: false,
     };
 
     mockUser = {
       id: 3,
       name: '3',
-      fullName: 'User 3',
       email: 'user3@example.com',
       affiliation: 'Example 3 Uni',
     };
@@ -175,7 +176,7 @@ describe('DOI generation form component', () => {
         .getAllByRole('row')
         .slice(1) // ignores the header row
     ).toHaveLength(3);
-    expect(screen.getByRole('cell', { name: 'User 3' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '3' })).toBeInTheDocument();
     expect(screen.getAllByRole('cell', { name: 'Creator' }).length).toBe(3);
 
     // test errors on duplicate user
@@ -268,6 +269,7 @@ describe('DOI generation form component', () => {
   });
 
   it('should let the user add contributors & select their contributor type', async () => {
+    props.showErrors = true;
     renderComponent();
 
     expect(
@@ -298,13 +300,20 @@ describe('DOI generation form component', () => {
         .getAllByRole('row')
         .slice(1) // ignores the header row
     ).toHaveLength(3);
-    expect(screen.getByRole('cell', { name: 'User 3' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '3' })).toBeInTheDocument();
 
     expect(
       screen.getByRole('combobox', {
         name: 'DOIGenerationForm.creator_type',
       })
     ).toBeInTheDocument();
+
+    // should be in an error state as no role is selected
+    expect(
+      screen.getByRole('combobox', {
+        name: 'DOIGenerationForm.creator_type',
+      })
+    ).toHaveClass('Mui-error');
 
     await user.click(
       screen.getByRole('combobox', {
@@ -321,6 +330,11 @@ describe('DOI generation form component', () => {
     await user.click(selectedRole);
 
     expect(screen.queryByRole('option')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', {
+        name: 'DOIGenerationForm.creator_type',
+      })
+    ).not.toHaveClass('Mui-error');
     // check that the option is actually selected in the table even after the menu closes
     expect(screen.getByText('Editor')).toBeInTheDocument();
   });

--- a/packages/datagateway-common/src/dois/creatorsAndContributors.component.tsx
+++ b/packages/datagateway-common/src/dois/creatorsAndContributors.component.tsx
@@ -1,9 +1,11 @@
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import {
   Button,
   CircularProgress,
   FormControl,
   Grid,
   InputLabel,
+  Link,
   MenuItem,
   Paper,
   Select,
@@ -13,11 +15,12 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { AxiosError } from 'axios';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useCheckUser } from '../api/dois';
 import { ContributorType, User } from '../app.types';
 import { readSciGatewayToken } from '../parseTokens';
@@ -57,6 +60,7 @@ type CreatorsAndContributorsProps = {
   doiMinterUrl: string | undefined;
   localContactRole: string;
   disabled: boolean;
+  showErrors: boolean;
 };
 
 const CreatorsAndContributors: React.FC<CreatorsAndContributorsProps> = (
@@ -68,6 +72,7 @@ const CreatorsAndContributors: React.FC<CreatorsAndContributorsProps> = (
     doiMinterUrl,
     localContactRole,
     disabled,
+    showErrors,
   } = props;
   const [t] = useTranslation();
   const [username, setUsername] = React.useState('');
@@ -133,10 +138,26 @@ const CreatorsAndContributors: React.FC<CreatorsAndContributorsProps> = (
       variant="outlined"
     >
       <Grid container direction="row" spacing={1}>
-        <Grid item>
-          <Typography variant="h6" component="h4" id="creators-label">
-            {t('DOIGenerationForm.creators_and_contributors')}
-          </Typography>
+        <Grid container item alignItems="end" spacing={0.5}>
+          <Grid item>
+            <Typography variant="h6" component="h4" id="creators-label">
+              {t('DOIGenerationForm.creators_and_contributors')}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Tooltip
+              title={
+                <Trans
+                  i18nKey="DOIGenerationForm.creators_contributors_help_tooltip"
+                  components={{
+                    Link: <Link />,
+                  }}
+                />
+              }
+            >
+              <HelpOutlineIcon fontSize="small" />
+            </Tooltip>
+          </Grid>
         </Grid>
         <Grid
           container
@@ -227,7 +248,12 @@ const CreatorsAndContributors: React.FC<CreatorsAndContributorsProps> = (
                 .toSorted(compareCreatorsAndContributors)
                 .map((user) => (
                   <TableRow key={user.id}>
-                    <TableCell>{user.fullName}</TableCell>
+                    <TableCell>
+                      {user.fullName ??
+                        (user.givenName && user.familyName
+                          ? `${user.givenName} ${user.familyName}`
+                          : user.name)}
+                    </TableCell>
                     <TableCell>{user?.affiliation}</TableCell>
                     <TableCell>{user?.email}</TableCell>
                     <TableCell>
@@ -240,6 +266,7 @@ const CreatorsAndContributors: React.FC<CreatorsAndContributorsProps> = (
                           required
                           sx={{ minWidth: 180 }}
                           disabled={disabled}
+                          error={showErrors && user.contributor_type === ''}
                         >
                           <InputLabel
                             id={`${user.id}-contributor-type-select-label`}

--- a/packages/datagateway-common/src/dois/relatedIdentifiers.component.test.tsx
+++ b/packages/datagateway-common/src/dois/relatedIdentifiers.component.test.tsx
@@ -66,6 +66,7 @@ describe('Related identifiers form component', () => {
       dataCiteUrl: 'example.com',
       doiHandleUrl: 'https://doi.org',
       disabled: false,
+      showErrors: false,
     };
 
     mockDOIResponse = {
@@ -224,6 +225,7 @@ describe('Related identifiers form component', () => {
   });
 
   it('should let the user add related non-dois + lets you change the relation type + resource type + identifier type', async () => {
+    props.showErrors = true;
     props.relatedIdentifiers = [];
     renderComponent();
 
@@ -256,6 +258,12 @@ describe('Related identifiers form component', () => {
     expect(screen.getByText('URL')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'non.doi' })).toBeInTheDocument();
 
+    expect(
+      screen.getByRole('combobox', {
+        name: 'DOIGenerationForm.related_identifier_relationship',
+      })
+    ).toHaveClass('Mui-error');
+
     await user.click(
       screen.getByRole('combobox', {
         name: 'DOIGenerationForm.related_identifier_relationship',
@@ -269,6 +277,11 @@ describe('Related identifiers form component', () => {
     // check that the option is actually selected in the table even after the menu closes
     expect(screen.getByText('IsSupplementedBy')).toBeInTheDocument();
 
+    expect(
+      screen.getByRole('combobox', {
+        name: 'DOIGenerationForm.related_identifier_resource_type',
+      })
+    ).toHaveClass('Mui-error');
     await user.click(
       screen.getByRole('combobox', {
         name: 'DOIGenerationForm.related_identifier_resource_type',

--- a/packages/datagateway-common/src/dois/relatedIdentifiers.component.tsx
+++ b/packages/datagateway-common/src/dois/relatedIdentifiers.component.tsx
@@ -1,3 +1,4 @@
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import {
   Button,
   FormControl,
@@ -13,11 +14,12 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { AxiosError } from 'axios';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useCheckDOI } from '../api/dois';
 import {
   DOIIdentifierType,
@@ -35,6 +37,7 @@ type RelatedIdentifiersProps = {
   dataCiteUrl: string | undefined;
   doiHandleUrl: string;
   disabled: boolean;
+  showErrors: boolean;
 };
 
 const RelatedIdentifiers: React.FC<RelatedIdentifiersProps> = (props) => {
@@ -44,6 +47,7 @@ const RelatedIdentifiers: React.FC<RelatedIdentifiersProps> = (props) => {
     dataCiteUrl,
     doiHandleUrl,
     disabled,
+    showErrors,
   } = props;
   const [t] = useTranslation();
   const [relatedIdentiferInputText, setRelatedIdentifierInputText] =
@@ -68,14 +72,30 @@ const RelatedIdentifiers: React.FC<RelatedIdentifiersProps> = (props) => {
       variant="outlined"
     >
       <Grid container direction="row" spacing={1}>
-        <Grid item>
-          <Typography
-            variant="h6"
-            component="h4"
-            id="related-identifiers-label"
-          >
-            {t('DOIGenerationForm.related_identifiers')}
-          </Typography>
+        <Grid container item alignItems="end" spacing={0.5}>
+          <Grid item>
+            <Typography
+              variant="h6"
+              component="h4"
+              id="related-identifiers-label"
+            >
+              {t('DOIGenerationForm.related_identifiers')}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Tooltip
+              title={
+                <Trans
+                  i18nKey="DOIGenerationForm.related_identifiers_help_tooltip"
+                  components={{
+                    Link: <Link />,
+                  }}
+                />
+              }
+            >
+              <HelpOutlineIcon fontSize="small" />
+            </Tooltip>
+          </Grid>
         </Grid>
         <Grid
           container
@@ -214,13 +234,17 @@ const RelatedIdentifiers: React.FC<RelatedIdentifiersProps> = (props) => {
                         >
                           <Link
                             href={`${doiHandleUrl}/${relatedIdentifier.identifier}`}
+                            target="_blank"
                           >
                             {relatedIdentifier.identifier}
                           </Link>
                         </StyledTooltip>
                       ) : relatedIdentifier.relatedIdentifierType ===
                         DOIIdentifierType.URL ? (
-                        <Link href={relatedIdentifier.identifier}>
+                        <Link
+                          href={relatedIdentifier.identifier}
+                          target="_blank"
+                        >
                           {relatedIdentifier.identifier}
                         </Link>
                       ) : (
@@ -303,6 +327,9 @@ const RelatedIdentifiers: React.FC<RelatedIdentifiersProps> = (props) => {
                         required
                         sx={{ minWidth: 150 }}
                         disabled={disabled}
+                        error={
+                          showErrors && relatedIdentifier.relationType === ''
+                        }
                       >
                         <InputLabel
                           id={`${relatedIdentifier.identifier.replaceAll(
@@ -366,6 +393,10 @@ const RelatedIdentifiers: React.FC<RelatedIdentifiersProps> = (props) => {
                         required
                         sx={{ minWidth: 150 }}
                         disabled={disabled}
+                        error={
+                          showErrors &&
+                          relatedIdentifier.relatedItemType === undefined
+                        }
                       >
                         <InputLabel
                           id={`${relatedIdentifier.identifier.replaceAll(

--- a/packages/datagateway-common/src/dois/techniquesAndSubjects.component.test.tsx
+++ b/packages/datagateway-common/src/dois/techniquesAndSubjects.component.test.tsx
@@ -75,6 +75,8 @@ describe('Techniques & Subjects selector component', () => {
       setTechniques: vi.fn(),
       bioportalUrl: 'https://example.com/bioportal',
       disabled: false,
+      subjectError: false,
+      techniqueError: false,
     };
 
     mockSearchResponse = Promise.resolve({
@@ -154,6 +156,20 @@ describe('Techniques & Subjects selector component', () => {
     expect(
       screen.getByRole('button', { name: 'DOIGenerationForm.add_technique' })
     ).toBeDisabled();
+  });
+
+  it('renders inputs as errored when passed the error props', () => {
+    props.techniqueError = true;
+    props.subjectError = true;
+
+    renderComponent();
+    expect(
+      screen.getByRole('combobox', { name: 'DOIGenerationForm.subjects' })
+    ).toHaveAttribute('aria-invalid', 'true');
+
+    expect(
+      screen.getByRole('combobox', { name: 'DOIGenerationForm.techniques' })
+    ).toHaveAttribute('aria-invalid', 'true');
   });
 
   it('lets you edit subjects', async () => {

--- a/packages/datagateway-common/src/dois/techniquesAndSubjects.component.tsx
+++ b/packages/datagateway-common/src/dois/techniquesAndSubjects.component.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mui/material';
 import debounce from 'lodash.debounce';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   useGetDescendantTechniques,
   useSearchPANETTechniques,
@@ -101,8 +101,8 @@ const TechniqueSelector: React.FC<{
               ? // don't bother translating as this should be a developer focused message i.e. that they haven't configured DGW correctly
                 "Can't fetch techniques as BioPortal API URL not specified"
               : isError
-              ? t('DOIGenerationForm.bioportal_search_error')
-              : undefined
+                ? t('DOIGenerationForm.bioportal_search_error')
+                : undefined
           }
         />
       )}
@@ -163,7 +163,12 @@ const TechniqueDialog: React.FC<{
         <Grid container direction="column" spacing={1}>
           <Grid item>
             <Typography>
-              {t('DOIGenerationForm.technique_dialog_initial_help')}
+              <Trans
+                i18nKey="DOIGenerationForm.technique_dialog_initial_help"
+                components={{
+                  Link: <Link />,
+                }}
+              />
             </Typography>
           </Grid>
           <Grid item>
@@ -177,9 +182,12 @@ const TechniqueDialog: React.FC<{
             <>
               <Grid item>
                 <Typography>
-                  {t(
-                    'DOIGenerationForm.technique_dialog_select_technique_help'
-                  )}
+                  <Trans
+                    i18nKey="DOIGenerationForm.technique_dialog_select_technique_help"
+                    components={{
+                      Link: <Link />,
+                    }}
+                  />
                 </Typography>
               </Grid>
               {isError && (
@@ -217,7 +225,10 @@ const TechniqueDialog: React.FC<{
                         </TableCell>
                         <TableCell>
                           {
-                            <Link href={initiallySelectedTechnique['@id']}>
+                            <Link
+                              href={initiallySelectedTechnique['@id']}
+                              target="_blank"
+                            >
                               {initiallySelectedTechnique['@id']}
                             </Link>
                           }
@@ -231,7 +242,11 @@ const TechniqueDialog: React.FC<{
                         >
                           <TableCell>{getTechniqueDisplayName(t)}</TableCell>
                           <TableCell>
-                            {<Link href={t['@id']}>{t['@id']}</Link>}
+                            {
+                              <Link href={t['@id']} target="_blank">
+                                {t['@id']}
+                              </Link>
+                            }
                           </TableCell>
                         </TableRow>
                       ))}
@@ -265,8 +280,10 @@ const TechniqueDialog: React.FC<{
 const TechniquesAndSubjects: React.FC<{
   techniques: BioPortalTerm[];
   setTechniques: React.Dispatch<React.SetStateAction<BioPortalTerm[]>>;
+  techniqueError: boolean;
   subjects: string[];
   setSubjects: React.Dispatch<React.SetStateAction<string[]>>;
+  subjectError: boolean;
   disabled: boolean;
   bioportalUrl: string | undefined;
 }> = (props) => {
@@ -274,8 +291,10 @@ const TechniquesAndSubjects: React.FC<{
   const {
     techniques,
     setTechniques,
+    techniqueError,
     subjects,
     setSubjects,
+    subjectError,
     disabled,
     bioportalUrl,
   } = props;
@@ -308,7 +327,14 @@ const TechniquesAndSubjects: React.FC<{
           </Grid>
           <Grid item>
             <Tooltip
-              title={t('DOIGenerationForm.techniques_subjects_help_tooltip')}
+              title={
+                <Trans
+                  i18nKey="DOIGenerationForm.techniques_subjects_help_tooltip"
+                  components={{
+                    Link: <Link />,
+                  }}
+                />
+              }
             >
               <HelpOutlineIcon fontSize="small" />
             </Tooltip>
@@ -340,6 +366,7 @@ const TechniquesAndSubjects: React.FC<{
                       sx: { caretColor: 'transparent', cursor: 'default' },
                     }}
                     required={true}
+                    error={techniqueError}
                   />
                 )}
                 getOptionLabel={getTechniqueDisplayName}
@@ -374,6 +401,7 @@ const TechniquesAndSubjects: React.FC<{
               multiple
               options={[]}
               freeSolo
+              autoSelect
               renderTags={(value: readonly string[], getTagProps) =>
                 value.map((option: string, index: number) => {
                   const { key, ...tagProps } = getTagProps({ index });
@@ -401,6 +429,7 @@ const TechniquesAndSubjects: React.FC<{
                       backgroundColor: 'background.default',
                     },
                   }}
+                  error={subjectError}
                 />
               )}
               disabled={disabled}

--- a/packages/datagateway-common/src/views/publishButton.component.tsx
+++ b/packages/datagateway-common/src/views/publishButton.component.tsx
@@ -5,11 +5,12 @@ import {
   Dialog,
   Grid,
   IconButton,
+  Link,
   Typography,
 } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useOpenDataPublication } from '../api';
 import { DataPublication } from '../app.types';
 import { StyledTooltip } from '../arrowtooltip.component';
@@ -113,9 +114,13 @@ const PublishButton: React.FC<PublishButtonProps> = (props) => {
             {!showRequestResult ? (
               <Grid container flexDirection="column">
                 <Grid item>
-                  {/* TODO: write data policy text */}
                   <Typography variant="body2">
-                    {t('DOIPublishConfirmDialog.data_policy')}
+                    <Trans
+                      i18nKey="DOIPublishConfirmDialog.data_policy"
+                      components={{
+                        Link: <Link />,
+                      }}
+                    />
                   </Typography>
                 </Grid>
                 <Grid item alignSelf="end">

--- a/packages/datagateway-dataview/__mocks__/react-i18next.jsx
+++ b/packages/datagateway-dataview/__mocks__/react-i18next.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-// eslint-disable-next-line no-use-before-define
 import React from 'react';
 import * as reactI18next from 'react-i18next';
 
@@ -9,7 +7,11 @@ const hasChildren = (node) =>
 const getChildren = (node) =>
   node && node.children ? node.children : node.props && node.props.children;
 
-const renderNodes = (reactNodes) => {
+const renderNodes = (i18nKey, reactNodes) => {
+  if (typeof reactNodes === 'undefined') {
+    return i18nKey;
+  }
+
   if (typeof reactNodes === 'string') {
     return reactNodes;
   }
@@ -50,10 +52,11 @@ const applyTranslation = (Component) => {
   return applyProps;
 };
 
+// eslint-disable-next-line no-undef
 module.exports = {
   // this mock makes sure any components using the translate HoC receive the t function as a prop
   withTranslation: () => (Component) => applyTranslation(Component),
-  Trans: ({ children }) => renderNodes(children),
+  Trans: ({ i18nKey, children }) => renderNodes(i18nKey, children),
   Translation: ({ children }) => children((k) => k, { i18n: {} }),
   useTranslation: () => useMock,
 

--- a/packages/datagateway-dataview/cypress/e2e/landing/dls/dataPublication.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/landing/dls/dataPublication.cy.ts
@@ -196,7 +196,7 @@ describe('DLS - User Generated Data Publication Landing', () => {
 
     cy.contains('Done').click();
 
-    cy.contains('button', 'Generate DOI').click();
+    cy.contains('button', 'Review DOI metadata').click();
 
     cy.contains('Please review the metadata', { timeout: 10000 }).should(
       'exist'

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -425,6 +425,7 @@
     "technique_pid": "PID",
     "add_technique": "Add technique",
     "creators_and_contributors": "Creators & Contributors",
+    "creators_contributors_help_tooltip": "Please ensure the people associated with this DOI are correct. You can add users via their Fed ID or via their ORCiD. Please select the Add Creator button if the person was a main researcher, otherwise select Add Contributor and specify their contributor type",
     "creators": "Creators",
     "contributors": "Contributors",
     "username": "Username",
@@ -437,6 +438,7 @@
     "creator_action": "Action",
     "delete_creator": "Delete",
     "related_identifiers": "Related Identifiers",
+    "related_identifiers_help_tooltip": "Please add any related resources that should be associated with this DOI. Please select the Add DOI button if you are adding a DOI, otherwise select the Add Other to add a different resource type (e.g. URL). Once you have added a resource, you will need to select the type of the resource, and how it is related to this DOI.",
     "related_identifier": "Identifier (e.g. DOI, URL)",
     "add_related_doi": "Add DOI",
     "add_related_other": "Add Other",
@@ -446,6 +448,7 @@
     "related_identifier_identifier_type": "Identifier Type",
     "related_identifier_action": "Action",
     "delete_related_identifier": "Delete",
+    "review_metadata_button": "Review DOI metadata",
     "generate_DOI": "Generate DOI",
     "cart_tabs_aria_label": "cart tabs",
     "cart_tab_investigations": "Investigations",
@@ -496,14 +499,13 @@
     "concept_doi_label": "Concept DOI",
     "version_doi_label": "Version DOI",
     "error_label": "Error",
-    "view_data_publication": "View Data Publication",
-    "close_aria_label": "Close mint confirm dialogue"
+    "view_data_publication": "View Data Publication"
   },
   "DOIPublishConfirmDialog": {
     "dialog_title": "Publish Data Publication",
     "close_aria_label": "Close publish data publication dialogue",
     "accept": "Accept & publish data publication",
-    "data_policy": "Accept data policy: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum lore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "data_policy": "Accept data policy: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum lore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. This is a <Link href=\"https://example.com/\">link to example.com</Link>.",
     "publish_success": "Publish was successful",
     "publish_error": "Publish was unsuccessful",
     "publish_loading": "Loading..."

--- a/packages/datagateway-dataview/src/views/landing/dls/dlsDataPublicationEditForm.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/landing/dls/dlsDataPublicationEditForm.component.test.tsx
@@ -577,7 +577,9 @@ describe('DOI edit form component', () => {
     // submit edited data publication
 
     await user.click(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     );
 
     expect(axios.post).toHaveBeenCalledWith(
@@ -669,7 +671,9 @@ describe('DOI edit form component', () => {
     );
 
     await user.click(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     );
 
     // expect confirmation page to appear, confirm submission
@@ -854,7 +858,9 @@ describe('DOI edit form component', () => {
     // submit edited data publication
 
     await user.click(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     );
 
     expect(axios.post).toHaveBeenCalledWith(

--- a/packages/datagateway-download/__mocks__/react-i18next.jsx
+++ b/packages/datagateway-download/__mocks__/react-i18next.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-// eslint-disable-next-line no-use-before-define
 import React from 'react';
 import * as reactI18next from 'react-i18next';
 
@@ -9,7 +7,11 @@ const hasChildren = (node) =>
 const getChildren = (node) =>
   node && node.children ? node.children : node.props && node.props.children;
 
-const renderNodes = (reactNodes) => {
+const renderNodes = (i18nKey, reactNodes) => {
+  if (typeof reactNodes === 'undefined') {
+    return i18nKey;
+  }
+
   if (typeof reactNodes === 'string') {
     return reactNodes;
   }
@@ -53,15 +55,12 @@ const applyTranslation = (Component) => {
   return applyProps;
 };
 
+// eslint-disable-next-line no-undef
 module.exports = {
   // this mock makes sure any components using the translate HoC receive the t function as a prop
   withTranslation: () => (Component) => applyTranslation(Component),
-  Trans: ({ children }) => renderNodes(children),
-  Translation: ({ children }) =>
-    children(
-      (k, o) => (o ? `${k} ${JSON.stringify(o).replace(/"/g, '')}` : k),
-      { i18n: {} }
-    ),
+  Trans: ({ i18nKey, children }) => renderNodes(i18nKey, children),
+  Translation: ({ children }) => children((k) => k, { i18n: {} }),
   useTranslation: () => useMock,
 
   // mock if needed

--- a/packages/datagateway-download/cypress.config.ts
+++ b/packages/datagateway-download/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   video: false,
   retries: {
     runMode: 3,
-    openMode: 1,
+    openMode: 0,
   },
   e2e: {
     setupNodeEvents(on, config) {

--- a/packages/datagateway-download/cypress/e2e/DOIGenerationForm.cy.ts
+++ b/packages/datagateway-download/cypress/e2e/DOIGenerationForm.cy.ts
@@ -69,7 +69,28 @@ describe('DOI Generation form', () => {
     });
 
     it('should not let user generate DOI when fields are still unfilled', () => {
-      cy.contains('button', 'Generate DOI').should('be.disabled');
+      cy.contains('button', 'Review DOI metadata').click();
+      cy.contains('button', 'Review DOI metadata').should('be.disabled');
+      cy.findByRole('textbox', { name: 'DOI Title' }).should(
+        'have.attr',
+        'aria-invalid',
+        'true'
+      );
+      cy.findByRole('textbox', { name: 'DOI Description' }).should(
+        'have.attr',
+        'aria-invalid',
+        'true'
+      );
+      cy.findByRole('combobox', { name: 'Techniques' }).should(
+        'have.attr',
+        'aria-invalid',
+        'true'
+      );
+      cy.findByRole('combobox', { name: 'Subjects' }).should(
+        'have.attr',
+        'aria-invalid',
+        'true'
+      );
     });
 
     it('should let user generate DOI when fields are filled', () => {
@@ -97,7 +118,7 @@ describe('DOI Generation form', () => {
       }).click();
       cy.findByRole('button', { name: 'Confirm' }).click();
 
-      cy.contains('button', 'Generate DOI').click();
+      cy.contains('button', 'Review DOI metadata').click();
 
       // expect confirmation page
 
@@ -149,7 +170,7 @@ describe('DOI Generation form', () => {
       }).click();
       cy.findByRole('button', { name: 'Confirm' }).click();
 
-      cy.contains('button', 'Generate DOI').click();
+      cy.contains('button', 'Review DOI metadata').click();
 
       // expect confirmation page
 
@@ -190,7 +211,8 @@ describe('DOI Generation form', () => {
       // add a subject
       cy.findByRole('combobox', { name: 'Subjects' }).type('subject1{enter}');
       cy.findByRole('combobox', { name: 'Subjects' }).type('subject2{enter}');
-      cy.findByRole('combobox', { name: 'Subjects' }).type('subject3{enter}');
+      cy.findByRole('combobox', { name: 'Subjects' }).type('subject3'); // test that subject can be added by blurring
+      cy.findByRole('combobox', { name: 'Subjects' }).blur();
 
       cy.findByRole('button', { name: 'subject1' }).should('be.visible');
       cy.findByRole('button', { name: 'subject2' }).should('be.visible');
@@ -204,7 +226,7 @@ describe('DOI Generation form', () => {
       cy.findByRole('button', { name: 'subject2' }).should('not.exist');
 
       // check that subject info displays correctly in confirmation page
-      cy.contains('button', 'Generate DOI').click();
+      cy.contains('button', 'Review DOI metadata').click();
 
       cy.contains('Subject: subject1').should('be.visible');
       cy.contains('Subject: subject3').should('be.visible');
@@ -279,7 +301,7 @@ describe('DOI Generation form', () => {
       cy.findByRole('button', { name: 'borrmann effect' }).should('not.exist');
 
       // check that technique info displays correctly in confirmation page
-      cy.contains('button', 'Generate DOI').click();
+      cy.contains('button', 'Review DOI metadata').click();
 
       cy.contains('Subject: x-ray standing wave').should('be.visible');
       cy.contains(
@@ -322,7 +344,7 @@ describe('DOI Generation form', () => {
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       // wait for users to load
-      cy.contains('button', 'Generate DOI').should('not.be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('not.be.disabled');
 
       cy.contains('Username').parent().find('input').type('Michael222');
       cy.contains('button', 'Add Creator').click();
@@ -337,10 +359,12 @@ describe('DOI Generation form', () => {
       cy.contains('Randy').parent().contains('button', 'Delete').click();
       cy.contains('Randy').should('not.exist');
 
-      cy.contains('button', 'Generate DOI').should('not.be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('not.be.disabled');
     });
 
     it('should let user add contributors and select their contributor type', () => {
+      // click button to trigger errors
+      cy.contains('button', 'Review DOI metadata').click();
       cy.contains('DOI Title').parent().find('input').type('Test title');
       cy.contains('DOI Description')
         .parent()
@@ -364,20 +388,24 @@ describe('DOI Generation form', () => {
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       // wait for users to load
-      cy.contains('button', 'Generate DOI').should('not.be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('not.be.disabled');
 
       cy.contains('Username').parent().find('input').type('Michael222');
       cy.contains('button', 'Add Contributor').click();
 
       // shouldn't let users submit DOIs without selecting a contributor type
-      cy.contains('button', 'Generate DOI').should('be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('be.disabled');
 
+      cy.contains('label', 'Contributor Type')
+        .parent()
+        .find('input')
+        .should('have.attr', 'aria-invalid', 'true');
       cy.contains('label', 'Contributor Type').parent().click();
 
       cy.contains('Researcher').click();
 
       // check that contributor info doesn't break the API
-      cy.contains('button', 'Generate DOI').click();
+      cy.contains('button', 'Review DOI metadata').click();
       cy.contains('Contributor Type: Researcher', { timeout: 10000 }).should(
         'be.visible'
       );
@@ -413,7 +441,7 @@ describe('DOI Generation form', () => {
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       // wait for users to load
-      cy.contains('button', 'Generate DOI').should('not.be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('not.be.disabled');
 
       cy.get('table[aria-labelledby="creators-label"] tbody tr').should(
         'have.length',
@@ -439,10 +467,12 @@ describe('DOI Generation form', () => {
         'No record found: No ICAT User found with name invalid'
       ).should('be.visible');
 
-      cy.contains('button', 'Generate DOI').should('not.be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('not.be.disabled');
     });
 
     it('should let user add a related DOI and select their relation & resource type', () => {
+      // click button to trigger errors
+      cy.contains('button', 'Review DOI metadata').click();
       cy.contains('DOI Title').parent().find('input').type('Test title');
       cy.contains('DOI Description')
         .parent()
@@ -466,7 +496,7 @@ describe('DOI Generation form', () => {
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       // wait for users to load
-      cy.contains('button', 'Generate DOI').should('not.be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('not.be.disabled');
 
       // DOI from https://support.datacite.org/docs/testing-guide
       cy.contains('Identifier (e.g. DOI, URL)')
@@ -476,21 +506,31 @@ describe('DOI Generation form', () => {
       cy.contains('button', 'Add DOI').click();
 
       // shouldn't let users submit DOIs without selecting a relation or resource type
-      cy.contains('button', 'Generate DOI').should('be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('be.disabled');
+
+      cy.contains('label', 'Resource Type')
+        .parent()
+        .find('input')
+        .should('have.attr', 'aria-invalid', 'true');
 
       cy.contains('label', 'Resource Type').parent().click();
 
       cy.contains('Journal').click();
 
       // shouldn't let users submit DOIs without selecting a relation type
-      cy.contains('button', 'Generate DOI').should('be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('be.disabled');
+
+      cy.contains('label', 'Relationship')
+        .parent()
+        .find('input')
+        .should('have.attr', 'aria-invalid', 'true');
 
       cy.contains('label', 'Relationship').parent().click();
 
       cy.contains('IsCitedBy').click();
 
       // check that related DOIs info doesn't break the API
-      cy.contains('button', 'Generate DOI').click();
+      cy.contains('button', 'Review DOI metadata').click();
 
       cy.contains('div', 'Identifier: 10.17596/w76y-4s92', { timeout: 10000 })
         .as('relatedDOI')
@@ -513,6 +553,8 @@ describe('DOI Generation form', () => {
     });
 
     it('should let user add a non-DOI related identifier and select their relation, identifier & resource type', () => {
+      // click button to trigger errors
+      cy.contains('button', 'Review DOI metadata').click();
       cy.contains('DOI Title').parent().find('input').type('Test title');
       cy.contains('DOI Description')
         .parent()
@@ -536,7 +578,7 @@ describe('DOI Generation form', () => {
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       // wait for users to load
-      cy.contains('button', 'Generate DOI').should('not.be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('not.be.disabled');
 
       // DOI from https://support.datacite.org/docs/testing-guide
       cy.contains('Identifier (e.g. DOI, URL)')
@@ -546,7 +588,7 @@ describe('DOI Generation form', () => {
       cy.contains('button', 'Add Other').click();
 
       // shouldn't let users submit DOIs without selecting a relation or resource type
-      cy.contains('button', 'Generate DOI').should('be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('be.disabled');
 
       // expect it defaults to a URL
       cy.contains('a', 'my.identifier');
@@ -559,14 +601,14 @@ describe('DOI Generation form', () => {
       cy.contains('ComputationalNotebook').click();
 
       // shouldn't let users submit DOIs without selecting a relation type
-      cy.contains('button', 'Generate DOI').should('be.disabled');
+      cy.contains('button', 'Review DOI metadata').should('be.disabled');
 
       cy.contains('label', 'Relationship').parent().click();
 
       cy.contains('IsSupplementedBy').click();
 
       // check that related DOIs info doesn't break the API
-      cy.contains('button', 'Generate DOI').click();
+      cy.contains('button', 'Review DOI metadata').click();
 
       cy.contains('div', 'Identifier: my.identifier', { timeout: 10000 })
         .as('relatedItem')

--- a/packages/datagateway-download/public/res/default.json
+++ b/packages/datagateway-download/public/res/default.json
@@ -102,7 +102,7 @@
   },
   "acceptDataPolicy": {
     "accept": "Accept",
-    "data_policy": "Accept data policy: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum lore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    "data_policy": "Accept data policy: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum lore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. This is a <Link href=\"https://example.com/\">link to example.com</Link>."
   },
   "DOIGenerationForm": {
     "page_header": "Generate DOI",
@@ -125,6 +125,7 @@
     "technique_pid": "PID",
     "add_technique": "Add technique",
     "creators_and_contributors": "Creators & Contributors",
+    "creators_contributors_help_tooltip": "Please ensure the people associated with this DOI are correct. You can add users via their Fed ID or via their ORCiD. Please select the Add Creator button if the person was a main researcher, otherwise select Add Contributor and specify their contributor type",
     "creators": "Creators",
     "contributors": "Contributors",
     "username": "Username",
@@ -137,6 +138,7 @@
     "creator_action": "Action",
     "delete_creator": "Delete",
     "related_identifiers": "Related Identifiers",
+    "related_identifiers_help_tooltip": "Please add any related resources that should be associated with this DOI. Please select the Add DOI button if you are adding a DOI, otherwise select the Add Other to add a different resource type (e.g. URL). Once you have added a resource, you will need to select the type of the resource, and how it is related to this DOI.",
     "related_identifier": "Identifier (e.g. DOI, URL)",
     "add_related_doi": "Add DOI",
     "add_related_other": "Add Other",
@@ -147,6 +149,7 @@
     "related_identifier_action": "Action",
     "delete_related_identifier": "Delete",
     "generate_DOI": "Generate DOI",
+    "review_metadata_button": "Review DOI metadata",
     "cart_tabs_aria_label": "cart tabs",
     "cart_tab_investigations": "Investigations",
     "cart_tab_datasets": "Datasets",

--- a/packages/datagateway-download/src/DOIGenerationForm/DOIGenerationForm.component.test.tsx
+++ b/packages/datagateway-download/src/DOIGenerationForm/DOIGenerationForm.component.test.tsx
@@ -337,7 +337,7 @@ describe('DOI generation form component', () => {
 
     await user.click(
       await screen.findByRole('button', {
-        name: 'DOIGenerationForm.generate_DOI',
+        name: 'DOIGenerationForm.review_metadata_button',
       })
     );
 
@@ -376,9 +376,18 @@ describe('DOI generation form component', () => {
       screen.getByRole('button', { name: 'acceptDataPolicy.accept' })
     );
 
+    // click button to trigger errors
+    await user.click(
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
+    );
+
     // missing title
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     await user.type(
@@ -388,7 +397,9 @@ describe('DOI generation form component', () => {
 
     // missing description
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     await user.type(
@@ -411,7 +422,9 @@ describe('DOI generation form component', () => {
 
     // missing contributor type
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     await user.click(
@@ -436,7 +449,9 @@ describe('DOI generation form component', () => {
 
     // missing relationship type
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     await user.click(
@@ -450,7 +465,9 @@ describe('DOI generation form component', () => {
 
     // missing resource type
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     await user.click(
@@ -464,7 +481,9 @@ describe('DOI generation form component', () => {
 
     // missing technique
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     await user.click(
@@ -500,7 +519,7 @@ describe('DOI generation form component', () => {
     expect(
       // use findBy here as we need to wait for technique dialog to disappear
       await screen.findByRole('button', {
-        name: 'DOIGenerationForm.generate_DOI',
+        name: 'DOIGenerationForm.review_metadata_button',
       })
     ).toBeDisabled();
 
@@ -510,7 +529,9 @@ describe('DOI generation form component', () => {
     );
 
     await user.click(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     );
 
     // expect confirmation page to appear, confirm submission
@@ -624,7 +645,7 @@ describe('DOI generation form component', () => {
     await user.click(
       // use findBy to wait for technique dialog to disappear
       await screen.findByRole('button', {
-        name: 'DOIGenerationForm.generate_DOI',
+        name: 'DOIGenerationForm.review_metadata_button',
       })
     );
 
@@ -711,7 +732,9 @@ describe('DOI generation form component', () => {
 
     // missing cart
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
   }, 60_000);
 
@@ -778,7 +801,9 @@ describe('DOI generation form component', () => {
 
     // empty cart
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
   }, 60_000);
 
@@ -845,7 +870,9 @@ describe('DOI generation form component', () => {
 
     // no users
     expect(
-      screen.getByRole('button', { name: 'DOIGenerationForm.generate_DOI' })
+      screen.getByRole('button', {
+        name: 'DOIGenerationForm.review_metadata_button',
+      })
     ).toBeDisabled();
 
     // expect add user + add contributor buttons to also be disabled

--- a/packages/datagateway-download/src/DOIGenerationForm/acceptDataPolicy.component.tsx
+++ b/packages/datagateway-download/src/DOIGenerationForm/acceptDataPolicy.component.tsx
@@ -1,6 +1,6 @@
-import { Button, Grid, Paper, Typography } from '@mui/material';
+import { Button, Grid, Link, Paper, Typography } from '@mui/material';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 type AcceptDataPolicyProps = {
   acceptDataPolicy: () => void;
@@ -26,9 +26,13 @@ const AcceptDataPolicy: React.FC<AcceptDataPolicyProps> = (props) => {
       >
         <Grid container flexDirection="column">
           <Grid item>
-            {/* TODO: write data policy text */}
             <Typography variant="body2">
-              {t('acceptDataPolicy.data_policy')}
+              <Trans
+                i18nKey="acceptDataPolicy.data_policy"
+                components={{
+                  Link: <Link />,
+                }}
+              />
             </Typography>
           </Grid>
           <Grid item alignSelf="end">

--- a/packages/datagateway-search/__mocks__/react-i18next.jsx
+++ b/packages/datagateway-search/__mocks__/react-i18next.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-// eslint-disable-next-line no-use-before-define
 import React from 'react';
 import * as reactI18next from 'react-i18next';
 
@@ -9,7 +7,11 @@ const hasChildren = (node) =>
 const getChildren = (node) =>
   node && node.children ? node.children : node.props && node.props.children;
 
-const renderNodes = (reactNodes) => {
+const renderNodes = (i18nKey, reactNodes) => {
+  if (typeof reactNodes === 'undefined') {
+    return i18nKey;
+  }
+
   if (typeof reactNodes === 'string') {
     return reactNodes;
   }
@@ -53,15 +55,12 @@ const applyTranslation = (Component) => {
   return applyProps;
 };
 
+// eslint-disable-next-line no-undef
 module.exports = {
   // this mock makes sure any components using the translate HoC receive the t function as a prop
   withTranslation: () => (Component) => applyTranslation(Component),
-  Trans: ({ children }) => renderNodes(children),
-  Translation: ({ children }) =>
-    children(
-      (k, o) => (o ? `${k} ${JSON.stringify(o).replace(/"/g, '')}` : k),
-      { i18n: {} }
-    ),
+  Trans: ({ i18nKey, children }) => renderNodes(i18nKey, children),
+  Translation: ({ children }) => children((k) => k, { i18n: {} }),
   useTranslation: () => useMock,
 
   // mock if needed


### PR DESCRIPTION
## Description
- improve translations to use Trans components to allow line breaks & links
- add help text to creators & related items
- change generate DOI button name to review DOI metadata
- Fallback to user givenName + familyName or name if fullName is null
- add autoSelect prop to subject picker to select value on blur
- change form error checking, so now show the button as clickable, but once clicked highlight any errors
- make links open in new tabs

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
