### PR TITLE
Clear query caches when the user logs out

### DIFF
--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -304,7 +304,7 @@
   "loading": {
     "verifying": "Verifying URL",
     "oops": "Oops!",
-    "message": "We're sorry, it seems as though the URL you requested is attempting to fetch incorrect data. Please double check your URL, navigate back via the breadcrumbs or <2>go back to the top level</2>.",
+    "message": "We're sorry, it seems as though the URL you requested is attempting to fetch incorrect data or data you do not have permission to access. Please check you are logged in as the correct user, double check your URL, navigate back via the breadcrumbs or <LinkToTopLevel>go back to the top level</LinkToTopLevel>.",
     "filter_message": "No results found with current filters applied, please modify filter settings and try again."
   },
   "buttons": {

--- a/packages/datagateway-dataview/src/page/__snapshots__/withIdCheck.test.tsx.snap
+++ b/packages/datagateway-dataview/src/page/__snapshots__/withIdCheck.test.tsx.snap
@@ -39,14 +39,7 @@ exports[`WithIdCheck > renders error when checkingPromise does not resolve to be
       <p
         class="MuiTypography-root MuiTypography-body1 css-10k3s6n-MuiTypography-root"
       >
-        We're sorry, it seems as though the URL you requested is attempting to fetch incorrect data. Please double check your URL, navigate back via the breadcrumbs or 
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="/browse/investigation"
-        >
-          go back to the top level
-        </a>
-        .
+        loading.message
       </p>
     </div>
   </div>
@@ -84,14 +77,7 @@ exports[`WithIdCheck > renders error when checkingPromise is rejected 1`] = `
       <p
         class="MuiTypography-root MuiTypography-body1 css-10k3s6n-MuiTypography-root"
       >
-        We're sorry, it seems as though the URL you requested is attempting to fetch incorrect data. Please double check your URL, navigate back via the breadcrumbs or 
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="/browse/investigation"
-        >
-          go back to the top level
-        </a>
-        .
+        loading.message
       </p>
     </div>
   </div>

--- a/packages/datagateway-dataview/src/page/idCheckFunctions.test.ts
+++ b/packages/datagateway-dataview/src/page/idCheckFunctions.test.ts
@@ -1,15 +1,20 @@
+import axios from 'axios';
 import {
+  BroadcastSignOutType,
+  ConfigureURLsType,
+  MicroFrontendId,
+  handleICATError,
+} from 'datagateway-common';
+import configureStore from 'redux-mock-store';
+import {
+  checkDatasetId,
+  checkInstrumentAndFacilityCycleId,
+  checkInstrumentId,
   checkInvestigationId,
   checkProposalName,
-  checkInstrumentAndFacilityCycleId,
-  saveApiUrlMiddleware,
-  checkInstrumentId,
   checkStudyDataPublicationId,
-  checkDatasetId,
+  saveApiUrlMiddleware,
 } from './idCheckFunctions';
-import axios from 'axios';
-import { handleICATError, ConfigureURLsType } from 'datagateway-common';
-import configureStore from 'redux-mock-store';
 
 vi.mock('datagateway-common', async () => {
   const originalModule = await vi.importActual('datagateway-common');
@@ -21,14 +26,17 @@ vi.mock('datagateway-common', async () => {
   };
 });
 
-vi.mock('lodash.memoize', () => ({
-  default: (fn: (args: unknown) => unknown) => fn,
-}));
-
 describe('ID check functions', () => {
   afterEach(() => {
     vi.mocked(axios.get).mockClear();
     vi.mocked(handleICATError).mockClear();
+
+    checkDatasetId.cache.clear?.();
+    checkProposalName.cache.clear?.();
+    checkInstrumentId.cache.clear?.();
+    checkStudyDataPublicationId.cache.clear?.();
+    checkInstrumentAndFacilityCycleId.cache.clear?.();
+    checkInvestigationId.cache.clear?.();
   });
 
   it('saveApiUrlMiddleware sets apiUrl on ConfigureUrls action', async () => {
@@ -52,6 +60,7 @@ describe('ID check functions', () => {
       headers: { Authorization: 'Bearer null' },
     });
     vi.mocked(axios.get).mockClear();
+    checkInvestigationId.cache.clear?.();
 
     saveApiUrlMiddleware(store)(store.dispatch)({
       type: ConfigureURLsType,
@@ -69,6 +78,39 @@ describe('ID check functions', () => {
       type: ConfigureURLsType,
       payload: { urls: { apiUrl: '' } },
     });
+  });
+
+  it('clears caches on BroadcastSignOutType message', async () => {
+    const datasetCacheClearSpy = vi.spyOn(checkDatasetId.cache, 'clear');
+    const proposalCacheClearSpy = vi.spyOn(checkProposalName.cache, 'clear');
+    const instrumentCacheClearSpy = vi.spyOn(checkInstrumentId.cache, 'clear');
+    const dataPublicationCacheClearSpy = vi.spyOn(
+      checkStudyDataPublicationId.cache,
+      'clear'
+    );
+    const facilityCycleCacheClearSpy = vi.spyOn(
+      checkInstrumentAndFacilityCycleId.cache,
+      'clear'
+    );
+    const investigationCacheClearSpy = vi.spyOn(
+      checkInvestigationId.cache,
+      'clear'
+    );
+
+    document.dispatchEvent(
+      new CustomEvent(MicroFrontendId, {
+        detail: {
+          type: BroadcastSignOutType,
+        },
+      })
+    );
+
+    expect(datasetCacheClearSpy).toHaveBeenCalled();
+    expect(proposalCacheClearSpy).toHaveBeenCalled();
+    expect(instrumentCacheClearSpy).toHaveBeenCalled();
+    expect(dataPublicationCacheClearSpy).toHaveBeenCalled();
+    expect(facilityCycleCacheClearSpy).toHaveBeenCalled();
+    expect(investigationCacheClearSpy).toHaveBeenCalled();
   });
 
   describe('checkInvestigationId', () => {

--- a/packages/datagateway-dataview/src/page/idCheckFunctions.ts
+++ b/packages/datagateway-dataview/src/page/idCheckFunctions.ts
@@ -1,12 +1,14 @@
 import axios, { AxiosResponse } from 'axios';
 import {
-  handleICATError,
-  Investigation,
+  BroadcastSignOutType,
   ConfigureURLsType,
+  Investigation,
+  MicroFrontendId,
+  handleICATError,
   readSciGatewayToken,
 } from 'datagateway-common';
-import { Middleware, Dispatch, AnyAction } from 'redux';
 import memoize from 'lodash.memoize';
+import { AnyAction, Dispatch, Middleware } from 'redux';
 
 let apiUrl = '';
 
@@ -186,7 +188,7 @@ export const checkInstrumentId = memoize(
   (...args) => JSON.stringify(args)
 );
 
-export const unmemoizedCheckProposalName = (
+const unmemoizedCheckProposalName = (
   proposalName: string,
   investigationId: number
 ): Promise<boolean> => {
@@ -247,3 +249,16 @@ const unmemoizedCheckDatasetId = (
 export const checkDatasetId = memoize(unmemoizedCheckDatasetId, (...args) =>
   JSON.stringify(args)
 );
+
+// clear caches when the user signs out - prepares for if they sign in as a different user. E.g. anon -> authenticated
+document.addEventListener(MicroFrontendId, (e) => {
+  const action = (e as CustomEvent).detail;
+  if (action.type === BroadcastSignOutType) {
+    checkDatasetId.cache.clear?.();
+    checkProposalName.cache.clear?.();
+    checkInstrumentId.cache.clear?.();
+    checkStudyDataPublicationId.cache.clear?.();
+    checkInstrumentAndFacilityCycleId.cache.clear?.();
+    checkInvestigationId.cache.clear?.();
+  }
+});

--- a/packages/datagateway-dataview/src/page/withIdCheck.tsx
+++ b/packages/datagateway-dataview/src/page/withIdCheck.tsx
@@ -76,18 +76,19 @@ const WithIdCheck: React.FC<{
               variant="body1"
               sx={{ maxWidth: '600px', textAlign: 'center' }}
             >
-              <Trans t={t} i18nKey="loading.message">
-                We&#39;re sorry, it seems as though the URL you requested is
-                attempting to fetch incorrect data. Please double check your
-                URL, navigate back via the breadcrumbs or{' '}
-                <Link
-                  component={RouterLink}
-                  to={location.pathname.split('/').slice(0, 3).join('/')}
-                >
-                  go back to the top level
-                </Link>
-                .
-              </Trans>
+              <Trans
+                t={t}
+                i18nKey="loading.message"
+                components={{
+                  Link: <Link />,
+                  LinkToTopLevel: (
+                    <Link
+                      component={RouterLink}
+                      to={location.pathname.split('/').slice(0, 3).join('/')}
+                    />
+                  ),
+                }}
+              ></Trans>
             </Typography>
           </Grid>
         </Grid>

--- a/packages/datagateway-download/src/App.tsx
+++ b/packages/datagateway-download/src/App.tsx
@@ -1,20 +1,21 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import {
+  BroadcastSignOutType,
   DGThemeProvider,
   MicroFrontendId,
   Preloader,
   RequestPluginRerenderType,
 } from 'datagateway-common';
 import React, { Component } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { BrowserRouter as Router, Link, Route, Switch } from 'react-router-dom';
+import { Link, Route, BrowserRouter as Router, Switch } from 'react-router-dom';
 
 import ConfigProvider, { DownloadSettingsContext } from './ConfigProvider';
 import DOIGenerationForm from './DOIGenerationForm/DOIGenerationForm.component';
 import AdminDownloadStatusTable from './downloadStatus/adminDownloadStatusTable.component';
 
-import DownloadTabs from './downloadTab/downloadTab.component';
 import { QueryClientSettingsUpdater } from 'datagateway-common';
+import DownloadTabs from './downloadTab/downloadTab.component';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -23,6 +24,13 @@ const queryClient = new QueryClient({
       staleTime: 300000,
     },
   },
+});
+
+document.addEventListener(MicroFrontendId, (e) => {
+  const action = (e as CustomEvent).detail;
+  if (action.type === BroadcastSignOutType) {
+    queryClient.clear();
+  }
 });
 
 export const QueryClientSettingsUpdaterContext: React.FC<{


### PR DESCRIPTION
## Description
Chris reported an issue where he was seeing the `WithIdCheck` "oops" page, even when he switched users. After some digging in the logs, it was likely that he was initially looking at the URL anonymously, which meant he saw the oops page as the anon user didn't have permission, and then when he switched to his user account the error persisted as the caches aren't cleared in that case. So, two fixes:

- ensure all query caches are cleared on sign out
- adjust the WithIdCheck oops page to clarify that a reason you could be seeing that message is you don't have permissions, and to check which user you are logged in as

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

