### PR TITLE
Add Is PI button switch for My DOIs table

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -295,6 +295,14 @@ jobs:
       - name: Removing authenticator prefix for simple auth
         run: |
           sed -i 's/mechanism = simple/!mechanism = simple/' /home/runner/install/authn.simple/run.properties
+      - name: Adding Amy14 user
+        run: |
+          sed -i '/user\.list/ s/$/ Amy14/' /home/runner/install/authn.simple/run.properties
+      - name: Adding Amy14 user password
+        run: |
+          echo "user.Amy14.password = pw" >> /home/runner/install/authn.simple/run.properties
+        run: |
+          sed -i 's/mechanism = simple/!mechanism = simple/' /home/runner/install/authn.simple/run.properties
       - name: Adding Chris481 user
         run: |
           sed -i '/user\.list/ s/$/ Chris481/' /home/runner/install/authn.simple/run.properties

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -132,6 +132,12 @@ jobs:
       - name: Removing authenticator prefix for simple auth
         run: |
           sed -i 's/mechanism = simple/!mechanism = simple/' /home/runner/install/authn.simple/run.properties
+      - name: Adding Amy14 user
+        run: |
+          sed -i '/user\.list/ s/$/ Amy14/' /home/runner/install/authn.simple/run.properties
+      - name: Adding Amy14 user password
+        run: |
+          echo "user.Amy14.password = pw" >> /home/runner/install/authn.simple/run.properties
       - name: Adding Chris481 user
         run: |
           sed -i '/user\.list/ s/$/ Chris481/' /home/runner/install/authn.simple/run.properties
@@ -301,8 +307,6 @@ jobs:
       - name: Adding Amy14 user password
         run: |
           echo "user.Amy14.password = pw" >> /home/runner/install/authn.simple/run.properties
-        run: |
-          sed -i 's/mechanism = simple/!mechanism = simple/' /home/runner/install/authn.simple/run.properties
       - name: Adding Chris481 user
         run: |
           sed -i '/user\.list/ s/$/ Chris481/' /home/runner/install/authn.simple/run.properties

--- a/packages/datagateway-common/src/api/index.tsx
+++ b/packages/datagateway-common/src/api/index.tsx
@@ -120,6 +120,7 @@ export const parseSearchToQuery = (queryParams: string): QueryParams => {
       if (typeof parsed.view === 'string') {
         parsedDOIType = { view: parsed.view };
         if (typeof parsed.open === 'boolean') parsedDOIType.open = parsed.open;
+        if (typeof parsed.pi === 'boolean') parsedDOIType.pi = parsed.pi;
       }
     } catch (_e) {
       console.error('doiType query param provided in an incorrect format.');

--- a/packages/datagateway-common/src/app.types.tsx
+++ b/packages/datagateway-common/src/app.types.tsx
@@ -494,7 +494,7 @@ export interface SortType {
 
 export type ViewsType = 'table' | 'card' | null;
 
-export type DOIViewType = 'minter' | 'user' | 'session' | 'all';
+export type DOIViewType = 'user' | 'session' | 'all';
 
 export interface QueryParams {
   sort: SortType;
@@ -511,7 +511,7 @@ export interface QueryParams {
   endDate: Date | null;
   currentTab: string;
   restrict: boolean;
-  doiType: { view: DOIViewType; open?: boolean } | null;
+  doiType: { view: DOIViewType; open?: boolean; pi?: boolean } | null;
 }
 
 export enum ContributorType {

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/allDois.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/allDois.cy.ts
@@ -186,7 +186,7 @@ describe('DLS - All DOIs Table', () => {
     cy.get('[aria-rowcount="1"]').should('exist');
     cy.contains('78: Across').should('exist');
 
-    cy.contains('User-created DOIs').click();
+    cy.contains('User-defined DOIs').click();
 
     cy.get('[aria-rowcount="2"]').should('exist');
     cy.contains('Test DOI Title 1').should('exist');

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/myDois.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/myDois.cy.ts
@@ -18,7 +18,9 @@ describe('DLS - MyDOIs Table', () => {
       before(() => {
         cy.login({ username: 'root', password: 'pw', mechanism: 'simple' });
         cy.seedSessionDataPublication().as('sessionDataPublication');
-
+        cy.seedSessionDataPublication({ id: 14 }).as(
+          'sessionDataPublication14'
+        );
         cy.login(
           {
             username: 'Chris481',
@@ -36,6 +38,23 @@ describe('DLS - MyDOIs Table', () => {
         cy.seedUserGeneratedDataPublication('Test DOI Title 2').as(
           'dataPublication2'
         );
+
+        cy.login(
+          {
+            username: 'Amy14',
+            password: 'pw',
+            mechanism: 'simple',
+          },
+          'Amy14'
+        );
+
+        // can seed the user defined DP in before rather than beforeEach as myDOI page is read-only
+        cy.seedUserGeneratedDataPublication(
+          'Test DOI Title 3',
+          [{ username: 'Chris481' }],
+          [14],
+          []
+        ).as('dataPublication3');
         cy.dumpAliases(store);
       });
 
@@ -60,17 +79,26 @@ describe('DLS - MyDOIs Table', () => {
         cy.login({ username: 'root', password: 'pw', mechanism: 'simple' });
         cy.get<UserDefinedMintResponse>('@dataPublication1').then((dp1) => {
           cy.get<UserDefinedMintResponse>('@dataPublication2').then((dp2) => {
-            cy.get<SessionMintResponse>('@sessionDataPublication').then(
-              (dp3) => {
-                cy.clearDataPublications([
-                  dp1.body.concept.data_publication_id,
-                  dp1.body.version.data_publication_id,
-                  dp2.body.concept.data_publication_id,
-                  dp2.body.version.data_publication_id,
-                  dp3.body.data_publication_id,
-                ]);
-              }
-            );
+            cy.get<UserDefinedMintResponse>('@dataPublication3').then((dp3) => {
+              cy.get<SessionMintResponse>('@sessionDataPublication').then(
+                (dp4) => {
+                  cy.get<SessionMintResponse>('@sessionDataPublication14').then(
+                    (dp5) => {
+                      cy.clearDataPublications([
+                        dp1.body.concept.data_publication_id,
+                        dp1.body.version.data_publication_id,
+                        dp2.body.concept.data_publication_id,
+                        dp2.body.version.data_publication_id,
+                        dp3.body.concept.data_publication_id,
+                        dp3.body.version.data_publication_id,
+                        dp4.body.data_publication_id,
+                        dp5.body.data_publication_id,
+                      ]);
+                    }
+                  );
+                }
+              );
+            });
           });
         });
       });
@@ -180,6 +208,13 @@ describe('DLS - MyDOIs Table', () => {
         );
 
         cy.get('[aria-rowcount="0"]').should('exist');
+      });
+
+      it('should be able filter the Principal Investigator toggle button to show only sessions which they are not the PI', () => {
+        cy.contains('Others').click();
+        cy.get('[aria-rowindex="1"] [aria-colindex="1"]').contains(
+          'Test DOI Title 3'
+        );
       });
     });
 

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/myDois.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/myDois.cy.ts
@@ -100,6 +100,7 @@ describe('DLS - MyDOIs Table', () => {
 
       it('should be able to sort by all sort directions on single and multiple columns', () => {
         cy.contains('Principal Investigator').click();
+        cy.contains('User-defined DOIs').click();
         //Revert the default sort
         cy.contains('[role="button"]', 'Publication Date')
           .as('dateSortButton')

--- a/packages/datagateway-dataview/cypress/e2e/table/dls/myDois.cy.ts
+++ b/packages/datagateway-dataview/cypress/e2e/table/dls/myDois.cy.ts
@@ -99,7 +99,7 @@ describe('DLS - MyDOIs Table', () => {
       });
 
       it('should be able to sort by all sort directions on single and multiple columns', () => {
-        cy.contains('Minted the user-created DOI').click();
+        cy.contains('Principal Investigator').click();
         //Revert the default sort
         cy.contains('[role="button"]', 'Publication Date')
           .as('dateSortButton')
@@ -218,7 +218,7 @@ describe('DLS - MyDOIs Table', () => {
         cy.title().should('equal', 'DataGateway DataView');
         cy.get('#datagateway-dataview').should('be.visible');
 
-        cy.contains('Am listed on the session DOI').click();
+        cy.contains('Session DOIs').click();
 
         //Default sort
         cy.get('[aria-sort="descending"]').should('exist');

--- a/packages/datagateway-dataview/cypress/support/commands.js
+++ b/packages/datagateway-dataview/cypress/support/commands.js
@@ -123,42 +123,45 @@ Cypress.Commands.add('isScrolledTo', { prevSubject: true }, (element) => {
   });
 });
 
-Cypress.Commands.add('seedUserGeneratedDataPublication', (title) => {
-  return cy.request('datagateway-dataview-settings.json').then((response) => {
-    const settings = response.body;
-    return cy
-      .request({
-        method: 'POST',
-        url: `${settings.doiMinterUrl}/draft`,
-        headers: {
-          Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
-        },
-        body: {
-          metadata: {
-            title: title ?? 'Test DOI title',
-            description: 'Test DOI description',
-            creators: [],
-            related_items: [],
-            subjects: [],
-            resource_type: 'Collection',
-          },
-          // these ids are specifically mintable by the Chris481 user
-          investigation_ids: [],
-          dataset_ids: [15],
-          datafile_ids: [74, 193],
-        },
-      })
-      .then((response) => {
-        return cy.request({
-          method: 'PUT',
-          url: `${settings.doiMinterUrl}/draft/${response.body.concept.data_publication_id}/publish`,
+Cypress.Commands.add(
+  'seedUserGeneratedDataPublication',
+  (title, creators, dataset_ids, datafile_ids) => {
+    return cy.request('datagateway-dataview-settings.json').then((response) => {
+      const settings = response.body;
+      return cy
+        .request({
+          method: 'POST',
+          url: `${settings.doiMinterUrl}/draft`,
           headers: {
             Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
           },
+          body: {
+            metadata: {
+              title: title ?? 'Test DOI title',
+              description: 'Test DOI description',
+              creators: creators ?? [],
+              related_items: [],
+              subjects: [],
+              resource_type: 'Collection',
+            },
+            // these ids are specifically mintable by the Chris481 user
+            investigation_ids: [],
+            dataset_ids: dataset_ids ?? [15],
+            datafile_ids: datafile_ids ?? [74, 193],
+          },
+        })
+        .then((response) => {
+          return cy.request({
+            method: 'PUT',
+            url: `${settings.doiMinterUrl}/draft/${response.body.concept.data_publication_id}/publish`,
+            headers: {
+              Authorization: `Bearer ${readSciGatewayToken().sessionId}`,
+            },
+          });
         });
-      });
-  });
-});
+    });
+  }
+);
 
 Cypress.Commands.add('clearDataPublications', (ids) => {
   return cy.request('datagateway-dataview-settings.json').then((response) => {

--- a/packages/datagateway-dataview/cypress/support/index.d.ts
+++ b/packages/datagateway-dataview/cypress/support/index.d.ts
@@ -11,7 +11,10 @@ declare namespace Cypress {
     clearDownloadCart(): Cypress.Chainable<Cypress.Response>;
     seedDownloadCart(cartItems: string[]): Cypress.Chainable<Cypress.Response>;
     seedUserGeneratedDataPublication(
-      title?: string
+      title?: string,
+      creators?: string[],
+      dataset_ids?: number[],
+      datafile_ids?: number[]
     ): Cypress.Chainable<Cypress.Response>;
     clearDataPublications(ids: string[]): Cypress.Chainable<Cypress.Response>;
     seedSessionDataPublication(params?: {

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -281,25 +281,32 @@
     "all_roles": "All"
   },
   "my_doi_table": {
-    "type_button_group_aria_label": "Select DOIs where I",
-    "minter": "Minted the user-created DOI",
-    "user": "Am listed on the user-created DOI",
-    "session": "Am listed on the session DOI",
-    "open_button_group_aria_label": "Select Session DOIs which are",
-    "open_or_closed": "Open or Closed",
-    "open": "Open",
-    "closed": "Closed",
-    "all": "All"
-  },
-  "all_doi_table": {
-    "type_button_group_aria_label": "Select DOI type",
-    "user": "User-created DOIs",
+    "type_button_group_aria_label": "Select DOIs type",
+    "user": "User-defined DOIs",
     "session": "Session DOIs",
     "open_button_group_aria_label": "Select Session DOIs which are",
     "open_or_closed": "Open or Closed",
     "open": "Open",
     "closed": "Closed",
-    "all": "All"
+    "all": "All",
+    "pi_button_group_aria_label": "Select DOIs which roles are",
+    "pi_or_any": "All",
+    "pi": "Principal Investigator",
+    "any": "Others"
+  },
+  "all_doi_table": {
+    "type_button_group_aria_label": "Select DOI type",
+    "user": "User-defined DOIs",
+    "session": "Session DOIs",
+    "open_button_group_aria_label": "Select Session DOIs which are",
+    "open_or_closed": "Open or Closed",
+    "open": "Open",
+    "closed": "Closed",
+    "all": "All",
+    "pi_button_group_aria_label": "Select DOIs which roles are",    
+    "pi_or_any": "All",
+    "pi": "Principal Investigator",
+    "any": "Others"
   },
   "loading": {
     "verifying": "Verifying URL",

--- a/packages/datagateway-dataview/public/res/default.json
+++ b/packages/datagateway-dataview/public/res/default.json
@@ -281,7 +281,7 @@
     "all_roles": "All"
   },
   "my_doi_table": {
-    "type_button_group_aria_label": "Select DOIs type",
+    "type_button_group_aria_label": "Select DOI type",
     "user": "User-defined DOIs",
     "session": "Session DOIs",
     "open_button_group_aria_label": "Select Session DOIs which are",
@@ -302,11 +302,7 @@
     "open_or_closed": "Open or Closed",
     "open": "Open",
     "closed": "Closed",
-    "all": "All",
-    "pi_button_group_aria_label": "Select DOIs which roles are",    
-    "pi_or_any": "All",
-    "pi": "Principal Investigator",
-    "any": "Others"
+    "all": "All"
   },
   "loading": {
     "verifying": "Verifying URL",

--- a/packages/datagateway-dataview/src/views/doiTypeSelector.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/doiTypeSelector.component.test.tsx
@@ -59,12 +59,6 @@ describe('DOI Type Selector', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: 'my_doi_table.minter',
-        pressed: false,
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
         name: 'my_doi_table.user',
         pressed: false,
       })
@@ -91,12 +85,6 @@ describe('DOI Type Selector', () => {
     expect(
       screen.getByRole('button', {
         name: 'my_doi_table.all',
-        pressed: false,
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'my_doi_table.minter',
         pressed: false,
       })
     ).toBeInTheDocument();
@@ -147,11 +135,6 @@ describe('DOI Type Selector', () => {
         name: 'all_doi_table.type_button_group_aria_label',
       })
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {
-        name: /minter/,
-      })
-    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', {
         name: 'all_doi_table.all',
@@ -242,23 +225,6 @@ describe('DOI Type Selector', () => {
     });
   });
 
-  it('updates filters when user or minter button is clicked after open or closed is selected', async () => {
-    vi.mocked(parseSearchToQuery, { partial: true }).mockReturnValue({
-      doiType: { view: 'all', open: false },
-    });
-    renderComponent('myDOIs');
-
-    await user.click(
-      screen.getByRole('button', {
-        name: 'my_doi_table.minter',
-      })
-    );
-
-    expect(mockPushQueryParams).toHaveBeenCalledWith({
-      doiType: { view: 'minter' },
-    });
-  });
-
   it('parses current doiType from query params correctly', async () => {
     vi.mocked(parseSearchToQuery, { partial: true }).mockReturnValue({
       doiType: { view: 'user' },
@@ -270,12 +236,6 @@ describe('DOI Type Selector', () => {
       screen.getByRole('button', {
         name: 'my_doi_table.user',
         pressed: true,
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'my_doi_table.minter',
-        pressed: false,
       })
     ).toBeInTheDocument();
     expect(

--- a/packages/datagateway-dataview/src/views/doiTypeSelector.component.tsx
+++ b/packages/datagateway-dataview/src/views/doiTypeSelector.component.tsx
@@ -148,45 +148,38 @@ const DOITypeSelector = (props: DOITypeSelectorProps): React.ReactElement => {
         </Grid>
       )}
 
-      {(doiType === null ||
-        doiType.view === 'all' ||
-        doiType.view === 'session' ||
-        doiType.view === 'user') && (
-        <Grid container item direction="column" xs="auto">
-          <Grid item>
-            <Typography component={'label'} id="doi-pi-selector-label">
-              {type === 'myDOIs'
-                ? t('my_doi_table.pi_button_group_aria_label')
-                : t('all_doi_table.pi_button_group_aria_label')}
-            </Typography>
+      {type === 'myDOIs' &&
+        (doiType === null ||
+          doiType.view === 'all' ||
+          doiType.view === 'session' ||
+          doiType.view === 'user') && (
+          <Grid container item direction="column" xs="auto">
+            <Grid item>
+              <Typography component={'label'} id="doi-pi-selector-label">
+                {t('my_doi_table.pi_button_group_aria_label')}
+              </Typography>
+            </Grid>
+            <Grid item>
+              <ToggleButtonGroup
+                value={doiType?.pi ?? 'undefined'}
+                exclusive
+                onChange={handlePIorAny}
+                aria-labelledby="doi-pi-selector-label"
+                size="small"
+              >
+                <ToggleButton value={'undefined'} sx={{ p: '3px 7px' }}>
+                  {t('my_doi_table.pi_or_any')}
+                </ToggleButton>
+                <ToggleButton value={true} sx={{ p: '3px 7px' }}>
+                  {t('my_doi_table.pi')}
+                </ToggleButton>
+                <ToggleButton value={false} sx={{ p: '3px 7px' }}>
+                  {t('my_doi_table.any')}
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Grid>
           </Grid>
-          <Grid item>
-            <ToggleButtonGroup
-              value={doiType?.pi ?? 'undefined'}
-              exclusive
-              onChange={handlePIorAny}
-              aria-labelledby="doi-pi-selector-label"
-              size="small"
-            >
-              <ToggleButton value={'undefined'} sx={{ p: '3px 7px' }}>
-                {type === 'myDOIs'
-                  ? t('my_doi_table.pi_or_any')
-                  : t('all_doi_table.pi_or_any')}
-              </ToggleButton>
-              <ToggleButton value={true} sx={{ p: '3px 7px' }}>
-                {type === 'myDOIs'
-                  ? t('my_doi_table.pi')
-                  : t('all_doi_table.pi')}
-              </ToggleButton>
-              <ToggleButton value={false} sx={{ p: '3px 7px' }}>
-                {type === 'myDOIs'
-                  ? t('my_doi_table.any')
-                  : t('all_doi_table.any')}
-              </ToggleButton>
-            </ToggleButtonGroup>
-          </Grid>
-        </Grid>
-      )}
+        )}
     </Grid>
   );
 };

--- a/packages/datagateway-dataview/src/views/doiTypeSelector.component.tsx
+++ b/packages/datagateway-dataview/src/views/doiTypeSelector.component.tsx
@@ -38,10 +38,8 @@ const DOITypeSelector = (props: DOITypeSelectorProps): React.ReactElement => {
       pushQueryParams({
         doiType: {
           view: newType,
-          open:
-            newType === 'minter' || newType === 'user'
-              ? undefined
-              : doiType?.open,
+          open: newType === 'user' ? undefined : doiType?.open,
+          pi: newType === 'all' ? undefined : doiType?.pi,
         },
       });
   };
@@ -55,10 +53,24 @@ const DOITypeSelector = (props: DOITypeSelectorProps): React.ReactElement => {
         doiType: {
           view: doiType?.view ?? 'all',
           open: newOpenOrClosed === 'undefined' ? undefined : newOpenOrClosed,
+          pi: doiType?.pi,
         },
       });
   };
 
+  const handlePIorAny = (
+    _event: React.MouseEvent<HTMLElement>,
+    newPIorAny: boolean | 'undefined' | null
+  ): void => {
+    if (newPIorAny !== null)
+      pushQueryParams({
+        doiType: {
+          view: doiType?.view ?? 'all',
+          open: doiType?.open,
+          pi: newPIorAny === 'undefined' ? undefined : newPIorAny,
+        },
+      });
+  };
   return (
     <Grid container item direction="row" xs="auto" spacing={1}>
       <Grid container item direction="column" ml={1} xs="auto">
@@ -83,11 +95,7 @@ const DOITypeSelector = (props: DOITypeSelectorProps): React.ReactElement => {
                 ? t('my_doi_table.all')
                 : t('all_doi_table.all')}
             </ToggleButton>
-            {type === 'myDOIs' && (
-              <ToggleButton value="minter" sx={{ p: '3px 7px' }}>
-                {t('my_doi_table.minter')}
-              </ToggleButton>
-            )}
+
             <ToggleButton value="user" sx={{ p: '3px 7px' }}>
               {type === 'myDOIs'
                 ? t('my_doi_table.user')
@@ -134,6 +142,46 @@ const DOITypeSelector = (props: DOITypeSelectorProps): React.ReactElement => {
                 {type === 'myDOIs'
                   ? t('my_doi_table.closed')
                   : t('all_doi_table.closed')}
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Grid>
+        </Grid>
+      )}
+
+      {(doiType === null ||
+        doiType.view === 'all' ||
+        doiType.view === 'session' ||
+        doiType.view === 'user') && (
+        <Grid container item direction="column" xs="auto">
+          <Grid item>
+            <Typography component={'label'} id="doi-pi-selector-label">
+              {type === 'myDOIs'
+                ? t('my_doi_table.pi_button_group_aria_label')
+                : t('all_doi_table.pi_button_group_aria_label')}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <ToggleButtonGroup
+              value={doiType?.pi ?? 'undefined'}
+              exclusive
+              onChange={handlePIorAny}
+              aria-labelledby="doi-pi-selector-label"
+              size="small"
+            >
+              <ToggleButton value={'undefined'} sx={{ p: '3px 7px' }}>
+                {type === 'myDOIs'
+                  ? t('my_doi_table.pi_or_any')
+                  : t('all_doi_table.pi_or_any')}
+              </ToggleButton>
+              <ToggleButton value={true} sx={{ p: '3px 7px' }}>
+                {type === 'myDOIs'
+                  ? t('my_doi_table.pi')
+                  : t('all_doi_table.pi')}
+              </ToggleButton>
+              <ToggleButton value={false} sx={{ p: '3px 7px' }}>
+                {type === 'myDOIs'
+                  ? t('my_doi_table.any')
+                  : t('all_doi_table.any')}
               </ToggleButton>
             </ToggleButtonGroup>
           </Grid>

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDOITables.component.test.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDOITables.component.test.tsx
@@ -217,36 +217,6 @@ describe('DLS DOI table components', () => {
       ).toBeInTheDocument();
     });
 
-    it('supplies the correct filter params for minter doiType', async () => {
-      history.replace('?doiType={"view":"minter"}');
-      renderComponent();
-
-      const filterParams = [
-        {
-          filterType: 'where',
-          filterValue: JSON.stringify({
-            'users.user.name': { eq: 'testUser' },
-          }),
-        },
-        {
-          filterType: 'where',
-          filterValue: JSON.stringify({
-            'users.orderKey': {
-              eq: '0',
-            },
-          }),
-        },
-        {
-          filterType: 'where',
-          filterValue: JSON.stringify({
-            'type.name': { eq: 'User-defined-concept' },
-          }),
-        },
-      ];
-      expect(useDataPublicationCount).toHaveBeenCalledWith(filterParams);
-      expect(useDataPublicationsInfinite).toHaveBeenCalledWith(filterParams);
-    });
-
     it('supplies the correct filter params for user doiType', async () => {
       history.replace('?doiType={"view":"user"}');
       renderComponent();

--- a/packages/datagateway-dataview/src/views/table/dls/dlsDOITables.component.tsx
+++ b/packages/datagateway-dataview/src/views/table/dls/dlsDOITables.component.tsx
@@ -176,23 +176,6 @@ export const DLSMyDOIsTable = (): React.ReactElement => {
         'type.name': { eq: 'User-defined-concept' },
       }),
     });
-  else if (doiType.view === 'minter')
-    params.push(
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'users.orderKey': {
-            eq: '0',
-          },
-        }),
-      },
-      {
-        filterType: 'where',
-        filterValue: JSON.stringify({
-          'type.name': { eq: 'User-defined-concept' },
-        }),
-      }
-    );
 
   if (doiType?.open === true)
     params.push({
@@ -209,11 +192,42 @@ export const DLSMyDOIsTable = (): React.ReactElement => {
       }),
     });
 
+  if (doiType?.pi === true)
+    params.push(
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.orderKey': { eq: '0' },
+        }),
+      },
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.user.name': { eq: username },
+        }),
+      }
+    );
+  else if (doiType?.pi === false)
+    params.push(
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.orderKey': { neq: '0' },
+        }),
+      },
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.user.name': { eq: username },
+        }),
+      }
+    );
   return <DLSBaseDOIsTable filterParams={params} />;
 };
 
 export const DLSAllDOIsTable = (): React.ReactElement => {
   const location = useLocation();
+  const username = readSciGatewayToken().username || '';
 
   const { doiType } = React.useMemo(
     () => parseSearchToQuery(location.search),
@@ -260,6 +274,37 @@ export const DLSAllDOIsTable = (): React.ReactElement => {
         publicationDate: { isnull: true },
       }),
     });
+
+  if (doiType?.pi === true)
+    params.push(
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.orderKey': { eq: '0' },
+        }),
+      },
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.user.name': { eq: username },
+        }),
+      }
+    );
+  else if (doiType?.pi === false)
+    params.push(
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.orderKey': { neq: '0' },
+        }),
+      },
+      {
+        filterType: 'where',
+        filterValue: JSON.stringify({
+          'users.user.name': { eq: username },
+        }),
+      }
+    );
 
   return <DLSBaseDOIsTable filterParams={params} />;
 };


### PR DESCRIPTION
## Description
Remove the existing option minter, and instead have a separate toggle for PI/Any which can be used to filter both user defined and session DOIs. Then we should probably reword/rename the remaining options in the my doi page to just be User-Defined/Session DOI and change the label wording to match what the All DOI table uses (this language will be simpler and more intuitive as well)

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes to #1956 
