### PR TITLE
Allow list elements to be translatable and left align data policy text

### DIFF
--- a/packages/datagateway-common/src/views/publishButton.component.tsx
+++ b/packages/datagateway-common/src/views/publishButton.component.tsx
@@ -114,7 +114,7 @@ const PublishButton: React.FC<PublishButtonProps> = (props) => {
             {!showRequestResult ? (
               <Grid container flexDirection="column">
                 <Grid item>
-                  <Typography variant="body2">
+                  <Typography variant="body2" align="left">
                     <Trans
                       i18nKey="DOIPublishConfirmDialog.data_policy"
                       components={{

--- a/packages/datagateway-dataview/src/i18n.ts
+++ b/packages/datagateway-dataview/src/i18n.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
-import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
 const loadPath = import.meta.env.VITE_DATAVIEW_BUILD_DIRECTORY
@@ -19,6 +19,10 @@ i18n
     },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
+    },
+    react: {
+      transSupportBasicHtmlNodes: true,
+      transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p', 'ul', 'ol', 'li'],
     },
   });
 

--- a/packages/datagateway-download/src/DOIGenerationForm/acceptDataPolicy.component.tsx
+++ b/packages/datagateway-download/src/DOIGenerationForm/acceptDataPolicy.component.tsx
@@ -26,7 +26,7 @@ const AcceptDataPolicy: React.FC<AcceptDataPolicyProps> = (props) => {
       >
         <Grid container flexDirection="column">
           <Grid item>
-            <Typography variant="body2">
+            <Typography variant="body2" align="left">
               <Trans
                 i18nKey="acceptDataPolicy.data_policy"
                 components={{

--- a/packages/datagateway-download/src/i18n.ts
+++ b/packages/datagateway-download/src/i18n.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
-import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
 const loadPath = import.meta.env.VITE_DOWNLOAD_BUILD_DIRECTORY
@@ -19,6 +19,10 @@ i18n
     },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
+    },
+    react: {
+      transSupportBasicHtmlNodes: true,
+      transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p', 'ul', 'ol', 'li'],
     },
   });
 

--- a/packages/datagateway-search/src/i18n.ts
+++ b/packages/datagateway-search/src/i18n.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
-import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
 const loadPath = import.meta.env.VITE_SEARCH_BUILD_DIRECTORY
@@ -19,6 +19,10 @@ i18n
     },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
+    },
+    react: {
+      transSupportBasicHtmlNodes: true,
+      transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p', 'ul', 'ol', 'li'],
     },
   });
 


### PR DESCRIPTION
## Description
See title. The data policy text I got from Silvia had a bullet-point list, so configuring i18next so we can render html lists properly, and then the data policy looked weird when it was middle aligned, so left aligned the data policies.

To test this, replace the `data_policy` string in `public/res/default.json` in datagateway-download to something like:

```
"data_policy": "Accept data policy: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<ul><li>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</li><li>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum lore eu fugiat nulla pariatur.</li><li>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li></ul>This is a <Link href=\"https://example.com/\">link to example.com</Link>."
```

and then go to the cart and pretend to mint a user-defined DOI and check that the data policy is rendering the list correctly and that it is left aligned.

There's also the data policy in the publish button, but the code is identical so probably don't need to double check both

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

